### PR TITLE
Fix radios and checkboxes description spacing

### DIFF
--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -67,7 +67,8 @@ $checkbox-label-vertical-padding: 0.75rem;
   }
 
   &__description {
-    display: inline-block;
+    display: block;
+    margin-top: 0.25rem;
     margin-left: -($checkbox-input-width + $checkbox-padding);
   }
 

--- a/src/components/radios/examples/radios-descriptions/index.njk
+++ b/src/components/radios/examples/radios-descriptions/index.njk
@@ -1,0 +1,49 @@
+{% from "components/radios/_macro.njk" import onsRadios %}
+{{ 
+    onsRadios({
+        "legend": "What is your ethnic group or background?",
+        "name": "ethnicity",
+        "radios": [
+            {
+                "id": "white",
+                "label": {
+                    "text": "White",
+                    "description": "Includes British, Northern Irish, Irish, Gypsy, Irish Traveller, Roma or any other White background"
+                },
+                "name": "white"
+            },
+            {
+                "id": "mixed",
+                "label": {
+                    "text": "Mixed or Multiple ethnic groups",
+                    "description": "Includes White and Black Caribbean, White and Black African, White and Asian or any other Mixed or Multiple background"
+                },
+                "name": "mixed"
+            },
+            {
+                "id": "asian",
+                "label": {
+                    "text": "Asian or Asian British",
+                    "description": "Includes Indian, Pakistani, Bangladeshi, Chinese or any other Asian background"
+                },
+                "name": "asian"
+            },
+            {
+                "id": "black",
+                "label": {
+                    "text": "Black, Caribbean, African or Black British",
+                    "description": "Includes Black British, Caribbean, African or any other Black background"
+                },
+                "name": "black"
+            },
+            {
+                "id": "other",
+                "label": {
+                    "text": "Other ethnic group",
+                    "description": "Includes Arab or any other ethnic group"
+                },
+                "name": "other"
+            }
+        ]
+    }) 
+}}

--- a/src/components/radios/index.njk
+++ b/src/components/radios/index.njk
@@ -20,6 +20,13 @@ Radios are grouped within a `<fieldset>` which starts with a `<legend>` which le
 
 ## Variants
 
+## Descriptons
+This variant allows you to add more context to the options in the list. The description is populated by providing a `description` parameter within the radio's `label` parameter.
+
+{{
+    patternlibExample({"path": "components/radios/examples/radios-descriptions/index.njk"})
+}}
+
 ### Other
 This variant lets the user provide an answer other to the options in the list, or to provide supplemental information required to describe the nature of their answer.
 
@@ -31,6 +38,7 @@ CSS hides this div until the radio is ``:checked``.
 {{
     patternlibExample({"path": "components/radios/examples/radios-other/index.njk"})
 }}
+
 
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}


### PR DESCRIPTION
Will resolve #293 

Fix can be seen here by reducing the width of your browser window to cause a description to wrap https://deploy-preview-298--ons-design-system.netlify.com/components/radios/examples/radios-descriptions/ 