### PR TITLE
The h3 font size on cards is too large for long titles

### DIFF
--- a/src/components/card/_macro-options.md
+++ b/src/components/card/_macro-options.md
@@ -1,5 +1,6 @@
-| Name  | Type   | Required | Description                    |
-| ----- | ------ | -------- | ------------------------------ |
-| url   | string | false    | Will wrap the text in a link   |
-| title | string | true     | The title for the card element |
-| text  | string | true     | The text for the card element  |
+| Name         | Type   | Required | Description                        |
+| ------------ | ------ | -------- | ---------------------------------- |
+| url          | string | false    | Will wrap the text in a link       |
+| title        | string | true     | The title for the card element     |
+| text         | string | true     | The text for the card element      |
+| titleClasses | string | false    | Font size class for the card title |

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -1,6 +1,6 @@
 {%- macro onsCard(params) -%}
     <div class="card">
-        <h3 class="u-fs-l">
+        <h3 class="u-fs-m">
             {% if params.url -%}
                 <a href="{{ params.url }}">
                     {{ params.title }}

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -1,6 +1,6 @@
 {%- macro onsCard(params) -%}
     <div class="card">
-        <h3 class="u-fs-m">
+        <h3 class="{{ params.titleClasses | default('u-fs-m')}}">
             {% if params.url -%}
                 <a href="{{ params.url }}">
                     {{ params.title }}


### PR DESCRIPTION
Reduced the heading font size on cards component by changing the font size utility class to ```u-fs-m```

Fixes #365 