### PR TITLE
Add state to details component

### DIFF
--- a/src/components/accordion/_macro.njk
+++ b/src/components/accordion/_macro.njk
@@ -31,7 +31,8 @@
                     "summaryAttributes": item.summaryAttributes,
                     "title": item.title,
                     "content": item.content,
-                    "group": params.id
+                    "group": params.id,
+                    "saveState": params.saveState
                 })
             }}
         {% endfor %}

--- a/src/components/details/_macro.njk
+++ b/src/components/details/_macro.njk
@@ -8,6 +8,7 @@
         {% if params.button and params.button.close %} data-btn-close="{{ params.button.close }}"{% endif %}
         {% if params.group %} data-group="{{ params.group }}"{% endif %}
         {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
+        {% if params.saveState %} data-save-state="true"{% endif %}
     >
         <summary 
             class="details__summary js-collapsible-summary"

--- a/src/components/details/collapsible.js
+++ b/src/components/details/collapsible.js
@@ -2,8 +2,9 @@ import CollapsibleGroup from './collapsible.group';
 
 export class Collapsible {
   constructor(detailsElement) {
+    this.saveState = detailsElement.getAttribute('data-save-state') === 'true';
+
     // State
-    this.isOpen = true;
     this.group = detailsElement.getAttribute('data-group');
     this.isAccordion = detailsElement.classList.contains('details--accordion');
 
@@ -32,8 +33,11 @@ export class Collapsible {
     if (!this.isAccordion) {
       this.summary.setAttribute('tabindex', 0);
     }
-
-    this.setOpen(false);
+    if (localStorage.getItem(detailsId)) {
+      this.setOpen(true);
+    } else {
+      this.setOpen(false);
+    }
 
     this.summary.addEventListener('click', this.toggle.bind(this));
 
@@ -78,6 +82,12 @@ export class Collapsible {
           this.onClose();
         }
       }
+    }
+
+    if (this.saveState === true && open === true) {
+      localStorage.setItem(this.details.getAttribute('id'), true);
+    } else {
+      localStorage.removeItem(this.details.getAttribute('id'));
     }
   }
 }

--- a/src/tests/spec/collapsible/collapsible.spec.js
+++ b/src/tests/spec/collapsible/collapsible.spec.js
@@ -189,8 +189,9 @@ describe('Component: Details', function() {
       onOpenTests();
 
       describe('and the component is closed', function() {
-        beforeEach(function() {
+        beforeEach(function(done) {
           this.summary.click();
+          setTimeout(done);
         });
 
         onCloseTests();
@@ -198,7 +199,7 @@ describe('Component: Details', function() {
         describe('and the component is opened', function() {
           beforeEach(function(done) {
             this.summary.click();
-            setTimeout(done, 200);
+            setTimeout(done);
           });
           it('then the local storage item should be added', function() {
             expect(localStorage.getItem(this.details.getAttribute('id'))).to.equal('true');

--- a/src/tests/spec/collapsible/collapsible.spec.js
+++ b/src/tests/spec/collapsible/collapsible.spec.js
@@ -9,28 +9,29 @@ const params = {
     '<p>A typical photovoltaic system employs solar panels, each comprising a number of solar cells, which generate electrical power. PV installations may be ground-mounted, rooftop mounted or wall mounted. The mount may be fixed, or use a solar tracker to follow the sun across the sky.</p>',
   button: {
     close: 'Hide this'
-  }
+  },
+  saveState: null
 };
 
 describe('Component: Details', function() {
   before(() => awaitPolyfills);
 
   describe('If the component has a button', function() {
-    beforeEach(function() {
-      const component = renderComponent(params);
-
-      Object.keys(component).forEach(key => {
-        this[key] = component[key];
-      });
-    });
-
-    afterEach(function() {
-      if (this.wrapper) {
-        this.wrapper.remove();
-      }
-    });
-
     describe('before the component initialises', function() {
+      beforeEach(function() {
+        const component = renderComponent(params);
+
+        Object.keys(component).forEach(key => {
+          this[key] = component[key];
+        });
+      });
+
+      afterEach(function() {
+        if (this.wrapper) {
+          this.wrapper.remove();
+        }
+      });
+
       it('then the details element should have a open attribute', function() {
         expect(this.details.hasAttribute('open')).to.be.true;
       });
@@ -68,9 +69,20 @@ describe('Component: Details', function() {
       });
     });
 
-    describe('When the component initialises', function() {
-      beforeEach(() => {
+    describe('when the component initialises and savestate is not set', function() {
+      beforeEach(function() {
+        const component = renderComponent(params);
+
+        Object.keys(component).forEach(key => {
+          this[key] = component[key];
+        });
         collapsible();
+      });
+
+      afterEach(function() {
+        if (this.wrapper) {
+          this.wrapper.remove();
+        }
       });
 
       it('then the open attribute should be removed from the details element', function() {
@@ -121,24 +133,12 @@ describe('Component: Details', function() {
             this.summary.click();
           });
 
-          it('then the open attribute on the summary element should be added', function() {
-            expect(this.summary.hasAttribute('aria-expanded')).to.be.true;
-          });
+          onOpenTests();
 
-          it('then a details--open class should be added to the details', function() {
-            expect(this.details.classList.contains('details--open')).to.be.true;
-          });
-
-          it('then the aria-expanded attribute on the summary element should be set to true', function() {
-            expect(this.summary.getAttribute('aria-expanded')).to.equal('true');
-          });
-
-          it('then the data-ga-action attribute on the summary element should be set to "Open panel', function() {
-            expect(this.summary.getAttribute('data-ga-action')).to.equal('Open panel');
-          });
-
-          it('then the aria-hidden attribute on the content element should be set to false', function() {
-            expect(this.content.getAttribute('aria-hidden')).to.equal('false');
+          describe('and saveState isnt set', function() {
+            it('then the local storage item should not be added', function() {
+              expect(localStorage.getItem(this.details.getAttribute('id'))).to.be.null;
+            });
           });
         });
       });
@@ -163,6 +163,45 @@ describe('Component: Details', function() {
           });
 
           onCloseTests();
+        });
+      });
+    });
+
+    describe('when the component initialises, savestate is set and the element has been set in local storage', function() {
+      beforeEach(function() {
+        params.saveState = true;
+        const component = renderComponent(params);
+
+        Object.keys(component).forEach(key => {
+          this[key] = component[key];
+        });
+        localStorage.setItem(this.details.getAttribute('id'), true);
+        collapsible();
+      });
+
+      afterEach(function() {
+        if (this.wrapper) {
+          this.wrapper.remove();
+        }
+        localStorage.removeItem(this.details.getAttribute('id'));
+      });
+
+      onOpenTests();
+
+      describe('and the component is closed', function() {
+        beforeEach(function() {
+          this.summary.click();
+        });
+
+        onCloseTests();
+
+        describe('and the component is opened', function() {
+          beforeEach(function() {
+            this.summary.click();
+          });
+          it('then the local storage item should be added', function() {
+            expect(localStorage.getItem(this.details.getAttribute('id'))).to.equal('true');
+          });
         });
       });
     });
@@ -238,5 +277,31 @@ function onCloseTests() {
 
   it('then the aria-hidden attribute on the content element should be set to true', function() {
     expect(this.content.getAttribute('aria-hidden')).to.equal('true');
+  });
+
+  it('then the local storage item should be removed or not set', function() {
+    expect(localStorage.getItem(this.details.getAttribute('id'))).to.be.null;
+  });
+}
+
+function onOpenTests() {
+  it('then the open attribute on the summary element should be added', function() {
+    expect(this.summary.hasAttribute('aria-expanded')).to.be.true;
+  });
+
+  it('then a details--open class should be added to the details', function() {
+    expect(this.details.classList.contains('details--open')).to.be.true;
+  });
+
+  it('then the aria-expanded attribute on the summary element should be set to true', function() {
+    expect(this.summary.getAttribute('aria-expanded')).to.equal('true');
+  });
+
+  it('then the data-ga-action attribute on the summary element should be set to "Open panel', function() {
+    expect(this.summary.getAttribute('data-ga-action')).to.equal('Open panel');
+  });
+
+  it('then the aria-hidden attribute on the content element should be set to false', function() {
+    expect(this.content.getAttribute('aria-hidden')).to.equal('false');
   });
 }

--- a/src/tests/spec/collapsible/collapsible.spec.js
+++ b/src/tests/spec/collapsible/collapsible.spec.js
@@ -196,8 +196,9 @@ describe('Component: Details', function() {
         onCloseTests();
 
         describe('and the component is opened', function() {
-          beforeEach(function() {
+          beforeEach(function(done) {
             this.summary.click();
+            setTimeout(done);
           });
           it('then the local storage item should be added', function() {
             expect(localStorage.getItem(this.details.getAttribute('id'))).to.equal('true');

--- a/src/tests/spec/collapsible/collapsible.spec.js
+++ b/src/tests/spec/collapsible/collapsible.spec.js
@@ -198,7 +198,7 @@ describe('Component: Details', function() {
         describe('and the component is opened', function() {
           beforeEach(function(done) {
             this.summary.click();
-            setTimeout(done);
+            setTimeout(done, 200);
           });
           it('then the local storage item should be added', function() {
             expect(localStorage.getItem(this.details.getAttribute('id'))).to.equal('true');


### PR DESCRIPTION
This PR is to save in localstorage the state of a details component. This will mean that when a details component is open and the user navigates back to the page in the same session it will still be open.

