### PR TITLE
Ensure text in abbr for prefixed/suffixed inputs is vertically centred

### DIFF
--- a/src/components/input/_input-type.scss
+++ b/src/components/input/_input-type.scss
@@ -29,7 +29,7 @@
     font-size: 1rem;
     font-weight: 600;
 
-    line-height: 1.1;
+    line-height: normal;
     text-align: center;
 
     text-decoration: none;


### PR DESCRIPTION
Will resolve #548 