### PR TITLE
Add data attribute to footer for GTM

### DIFF
--- a/src/components/card/examples/card-lists/index.njk
+++ b/src/components/card/examples/card-lists/index.njk
@@ -18,10 +18,7 @@
                         "url": '#',
                         "text": 'Business index'
                     }
-                ],
-                "attributes": {
-                    "data-ga-element": 'card'
-                }
+                ]
             })
         }}
     </div>
@@ -43,10 +40,7 @@
                         "url": '#',
                         "text": 'Business index'
                     }
-                ],
-                "attributes": {
-                    "data-ga-element": 'card'
-                }
+                ]
             })
         }}
     </div>
@@ -68,10 +62,7 @@
                         "url": '#',
                         "text": 'Business index'
                     }
-                ],
-                "attributes": {
-                    "data-ga-element": 'card'
-                }
+                ]
             })
         }}
     </div>

--- a/src/components/card/examples/card-set/index.njk
+++ b/src/components/card/examples/card-set/index.njk
@@ -8,10 +8,7 @@
                 "textId": 'text1',
                 "title": 'Search for a business',
                 "url": '#',
-                "text": 'A list of UK businesses for statistical use across government.',
-                "attributes": {
-                    "data-ga-element": 'card'
-                }
+                "text": 'A list of UK businesses for statistical use across government.'
             })
         }}
     </div>
@@ -23,10 +20,7 @@
                 "textId": 'text2',
                 "title": 'Record management',
                 "url": '#',
-                "text": 'Edit, create new records and view the editing history of businesses.',
-                "attributes": {
-                    "data-ga-element": 'card'
-                }
+                "text": 'Edit, create new records and view the editing history of businesses.'
             })
         }}
     </div>
@@ -38,10 +32,7 @@
                 "textId": 'text3',
                 "title": 'Address index',
                 "url": '#',
-                "text": 'The most accurate and geographical dataset of addresses and properties in the UK.',
-                "attributes": {
-                    "data-ga-element": 'card'
-                }
+                "text": 'The most accurate and geographical dataset of addresses and properties in the UK.'
             })
         }}
     </div>

--- a/src/components/checkboxes/_checkbox-macro.njk
+++ b/src/components/checkboxes/_checkbox-macro.njk
@@ -25,7 +25,7 @@
                         "id": params.other.id,
                         "name": params.other.name,
                         "type": params.other.type,
-                        "classes": "input--w-auto " + params.other.classes | default(''),
+                        "classes": params.other.classes | default(''),
                         "attributes": params.other.attributes,
                         "label": {
                             "text": params.other.label.text,

--- a/src/components/checkboxes/_checkbox-macro.njk
+++ b/src/components/checkboxes/_checkbox-macro.njk
@@ -25,7 +25,7 @@
                         "id": params.other.id,
                         "name": params.other.name,
                         "type": params.other.type,
-                        "classes": params.other.classes | default(''),
+                        "classes": "input--w-auto " + params.other.classes | default(''),
                         "attributes": params.other.attributes,
                         "label": {
                             "text": params.other.label.text,

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -15,7 +15,7 @@
         {% endif %}
     {% endif %}
 
-    <footer class="footer {{ params.classes }}" {% if params.attributes %}{% for attribute, value in (params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}>
+    <footer class="footer {{ params.classes }}" data-ga-element="footer" {% if params.attributes %}{% for attribute, value in (params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}>
         <div class="container">
             <div class="grid">
                 {% if params.poweredByONS %}

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -15,7 +15,7 @@
         {% endif %}
     {% endif %}
 
-    <footer class="footer {{ params.classes }}" data-ga-element="footer" {% if params.attributes %}{% for attribute, value in (params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}>
+    <footer class="footer {{ params.classes }}" data-analytics="footer" {% if params.attributes %}{% for attribute, value in (params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}>
         <div class="container">
             <div class="grid">
                 {% if params.poweredByONS %}

--- a/src/components/footer/examples/footer/index.njk
+++ b/src/components/footer/examples/footer/index.njk
@@ -4,9 +4,6 @@
 {% from "components/footer/_macro.njk" import onsFooter %}
 {{ 
     onsFooter({
-        "attributes": {
-            "data-ga-element": 'footer'
-        },
         "cols": [
             {
                 "title": 'Legal information',

--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -101,7 +101,7 @@
       {% if params.navigation %}
           <div class="header__bottom">
               <div class="container container--gutterless@xs@m{{ ' container--full-width' if params.fullWidth }}">
-                  <nav class="header-nav js-header-nav" id="{{ params.navigation.id }}" aria-label="{{ params.navigation.ariaLabel }}" data-analytics="navigation">
+                  <nav class="header-nav js-header-nav" id="{{ params.navigation.id }}" aria-label="{{ params.navigation.ariaLabel }}" data-analytics="header-navigation">
                       <ul class="header-nav__list" aria-label="{{ params.navigation.ariaListLabel }}" role="menubar">
                           {% for item in (params.navigation.itemsList if params.navigation.itemsList is iterable else params.navigation.itemsList.items()) %}
                               <li class="header-nav__item {{ item.classes }}{{ ' header-nav__item--active' if (item.url == params.navigation.currentPath) or (item.url != (params.navigation.siteBasePath | default('/')) and item.url in params.navigation.currentPath) }}">

--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -101,7 +101,7 @@
       {% if params.navigation %}
           <div class="header__bottom">
               <div class="container container--gutterless@xs@m{{ ' container--full-width' if params.fullWidth }}">
-                  <nav class="header-nav js-header-nav" id="{{ params.navigation.id }}" aria-label="{{ params.navigation.ariaLabel }}" data-ga-element="navigation">
+                  <nav class="header-nav js-header-nav" id="{{ params.navigation.id }}" aria-label="{{ params.navigation.ariaLabel }}" data-analytics="navigation">
                       <ul class="header-nav__list" aria-label="{{ params.navigation.ariaListLabel }}" role="menubar">
                           {% for item in (params.navigation.itemsList if params.navigation.itemsList is iterable else params.navigation.itemsList.items()) %}
                               <li class="header-nav__item {{ item.classes }}{{ ' header-nav__item--active' if (item.url == params.navigation.currentPath) or (item.url != (params.navigation.siteBasePath | default('/')) and item.url in params.navigation.currentPath) }}">

--- a/src/patterns/language-selection/examples/cymraeg/index.njk
+++ b/src/patterns/language-selection/examples/cymraeg/index.njk
@@ -13,10 +13,7 @@ layout: none
                 "text": "English",
                 "buttonAriaLabel": "Language selector. Current language: English",
                 "chooseLanguage": "Choose language",
-                "current": false,
-                "attributes" : {
-                    "data-ga-element": "language"
-                }
+                "current": false
             },
             {
                 "url": "#",
@@ -24,10 +21,7 @@ layout: none
                 "text": "Cymraeg",
                 "buttonAriaLabel": "Dewisydd iaith. Iaith gyfredol: Cymraeg",
                 "chooseLanguage": "Dewiswch iaith",
-                "current": true,
-                "attributes" : {
-                    "data-ga-element": "language"
-                }
+                "current": true
             }
         ]
     },


### PR DESCRIPTION
This change has been requested by the analysts working on Google Tag Manager. They need this attribute to be able to track users interacting with the footer.

More details [here](https://docs.google.com/document/d/1Tm65O4k9cU-i_SLMGaMesuUFLTjD4R0FVpyZNwGhWQQ/edit) 

To properly manage the introduction of new attributes in the design system I have removed some attributes which are in examples. We have also taken the decision to change the name of all attributes from "data-ga-element" to  "data-analytics". This is to make it more generic.