### PR TITLE
Footer and card headings create illogical page structure

### DIFF
--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -9,11 +9,11 @@
         </h3>
       </a>
     {%- else -%}
-      <h3 class="{{ params.titleClasses | default('u-fs-m')}}" id="{{ params.id }}">
+      <h2 class="{{ params.titleClasses | default('u-fs-m')}}" id="{{ params.id }}">
         <a href="{{ params.url }}">
           {{ params.title }}
         </a>
-      </h3>
+      </h2>
     {%- endif -%}
 
     <p id="{{ params.textId }}">{{ params.text }}</p>

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -4,9 +4,9 @@
     {%- if params.image -%}
       <a href="{{ params.url }}" class="u-db">
           <img class="card__image u-mb-s" alt="{{ params.image.alt }}" src="{{ params.image.src }}">
-        <h3 class="{{ params.titleClasses | default('u-fs-m')}}" id="{{ params.id }}">
+        <h2 class="{{ params.titleClasses | default('u-fs-m')}}" id="{{ params.id }}">
           {{ params.title }}
-        </h3>
+        </h2>
       </a>
     {%- else -%}
       <h2 class="{{ params.titleClasses | default('u-fs-m')}}" id="{{ params.id }}">

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -89,7 +89,7 @@
                             {% for col in params.cols %}
                                 <div class="grid__col col-4@m{{ " u-mt-m@xs@m" if loop.index > 1 }}">
                                     {% if col.title %}
-                                        <h4 class="u-fs-r--b footer__heading">{{ col.title }}</h4>
+                                        <h2 class="u-fs-r--b footer__heading">{{ col.title }}</h2>
                                     {% endif %}
                                     {{
                                         onsList({


### PR DESCRIPTION
- Changed card component headings from `<h3>` to `<h2>`
- Change footer cols headings from `<h4>` to `<h2>` 

...to make accessible page structure.  

Resolves issue identified in [DAC Report ](https://drive.google.com/file/d/13NTXPHViAni5C1ABgJtzs8PHHmhQZd7Y/view) where headings were creating an illogical page structure - WCAG Reference: 2.4.10 Section Headings