### PR TITLE
new logo focus states for external and internal

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -22,8 +22,10 @@
     display: inline-block;
 
     &:focus {
-      outline: 4px solid $color-focus;
-      background-color: transparent;
+      outline: 3px solid transparent;
+      color: $color-focus-text;
+      background-color: $color-focus;
+      box-shadow: 0 -2px $color-focus, 0 4px $color-focus-text;
     }
   }
 
@@ -98,6 +100,13 @@
   &--internal & {
     &__top {
       background: $color-dark-blue;
+    }
+
+    &__logo-link:focus {
+      background-color: transparent;
+      outline: 3px solid $color-focus;
+      color: $color-focus-text;
+      box-shadow: none;
     }
 
     &__grid-top {

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -105,7 +105,6 @@
     &__logo-link:focus {
       background-color: transparent;
       outline: 3px solid $color-focus;
-      color: $color-focus-text;
       box-shadow: none;
     }
 

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -103,8 +103,8 @@
     }
 
     &__logo-link:focus {
-      background-color: transparent;
       outline: 3px solid $color-focus;
+      background-color: transparent;
       box-shadow: none;
     }
 

--- a/src/tests/config/karma.conf.browserstack-es6-launchers.js
+++ b/src/tests/config/karma.conf.browserstack-es6-launchers.js
@@ -6,11 +6,11 @@ export default function() {
       // 'bs_iphone_xs',
       'bs_samsung_galaxy_s9',
       'bs_mac_chrome',
-      // 'bs_mac_firefox',
+      'bs_mac_firefox',
       'bs_mac_safari',
       'bs_windows_10_IE_edge',
       'bs_windows_10_chrome',
-      // 'bs_windows_10_firefox',
+      'bs_windows_10_firefox',
     ],
 
     customLaunchers: {
@@ -43,12 +43,12 @@ export default function() {
         os: 'OS X',
         os_version: 'Mojave',
       }),
-      // bs_mac_firefox: inheritBase({
-      //   browser: 'firefox',
-      //   browser_version: '66.0',
-      //   os: 'OS X',
-      //   os_version: 'Mojave',
-      // }),
+      bs_mac_firefox: inheritBase({
+        browser: 'firefox',
+        browser_version: '66.0',
+        os: 'OS X',
+        os_version: 'Mojave',
+      }),
       bs_mac_safari: inheritBase({
         browser: 'safari',
         browser_version: '12',
@@ -71,12 +71,12 @@ export default function() {
         browser: 'Chrome',
         browser_version: '75.0',
       }),
-      // bs_windows_10_firefox: inheritBase({
-      //   os: 'Windows',
-      //   os_version: '10',
-      //   browser: 'firefox',
-      //   browser_version: '67.0',
-      // }),
+      bs_windows_10_firefox: inheritBase({
+        os: 'Windows',
+        os_version: '10',
+        browser: 'firefox',
+        browser_version: '67.0',
+      }),
     },
   };
 }

--- a/src/tests/config/karma.conf.browserstack-es6-launchers.js
+++ b/src/tests/config/karma.conf.browserstack-es6-launchers.js
@@ -6,11 +6,11 @@ export default function() {
       // 'bs_iphone_xs',
       'bs_samsung_galaxy_s9',
       'bs_mac_chrome',
-      'bs_mac_firefox',
+      // 'bs_mac_firefox',
       'bs_mac_safari',
       'bs_windows_10_IE_edge',
       'bs_windows_10_chrome',
-      'bs_windows_10_firefox',
+      // 'bs_windows_10_firefox',
     ],
 
     customLaunchers: {
@@ -43,12 +43,12 @@ export default function() {
         os: 'OS X',
         os_version: 'Mojave',
       }),
-      bs_mac_firefox: inheritBase({
-        browser: 'firefox',
-        browser_version: '66.0',
-        os: 'OS X',
-        os_version: 'Mojave',
-      }),
+      // bs_mac_firefox: inheritBase({
+      //   browser: 'firefox',
+      //   browser_version: '66.0',
+      //   os: 'OS X',
+      //   os_version: 'Mojave',
+      // }),
       bs_mac_safari: inheritBase({
         browser: 'safari',
         browser_version: '12',
@@ -71,12 +71,12 @@ export default function() {
         browser: 'Chrome',
         browser_version: '75.0',
       }),
-      bs_windows_10_firefox: inheritBase({
-        os: 'Windows',
-        os_version: '10',
-        browser: 'firefox',
-        browser_version: '67.0',
-      }),
+      // bs_windows_10_firefox: inheritBase({
+      //   os: 'Windows',
+      //   os_version: '10',
+      //   browser: 'firefox',
+      //   browser_version: '67.0',
+      // }),
     },
   };
 }


### PR DESCRIPTION
The outline on logos on white bg in the header fail WCAG 3:1 contrast ratio requirement for non-text elements (i.e. focus state)