### PR TITLE
striptags from action.ariaLabel

### DIFF
--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -37,7 +37,7 @@
                                     <span class="summary__icon icon--{{ rowItem.icon }}"></span>
                                 {% endif %}
 
-                                {{ rowItem.title | default(row.title) }} {{ hasIcons }}
+                                {{ rowItem.title | default(row.title) | safe }} {{ hasIcons }}
 
                                 {# Render section status for mobile if is hub #}
                                 {% if params.hub and rowItem.valueList %}
@@ -80,7 +80,7 @@
                                         <a
                                             href="{{ action.url }}"
                                             class="summary__button"
-                                            {% if action.ariaLabel %} aria-label="{{ action.ariaLabel }}"{% endif %}
+                                            {% if action.ariaLabel %} aria-label="{{ action.ariaLabel | striptags() }}"{% endif %}
                                             {% if action.attributes %}{% for attribute, value in (action.attributes.items() if action.attributes is mapping and action.attributes.items else action.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
                                         >{{ action.text }}</a>
                                     {% endfor %}

--- a/src/components/summary/examples/summary/index.njk
+++ b/src/components/summary/examples/summary/index.njk
@@ -4,7 +4,7 @@
         "title": "Turnover",
         "rows": [
             {
-                "title": "What are the dates of the sales period you are reporting for?",
+                "title": "What are the <em>dates of the sales</em> period you are reporting for?",
                 "rowItems": [
                     {
                         "valueList": [ 
@@ -15,7 +15,7 @@
                         "actions": [
                             {
                                 "text": "Change",
-                                "ariaLabel": "Change answer for: What are the dates of the sales period you are reporting for?",
+                                "ariaLabel": "Change answer for: What are the <em>dates of the sales</em> period you are reporting for?",
                                 "url": "#"
                             }
                         ]


### PR DESCRIPTION
## What is the context of this PR?
The HTML used to emphasise parts of a question title was being included in the aria-label associated with the ‘Change’ link on the summary. This could confuse some users navigating out of
context who may be unaware of the purpose or meaning of the HTML. 
```html
<td class="summary__actions">
<a href="/questionnaire/accommodation-type/#accommodation-type-answer"
class="summary__button" aria-label="Change your answer for: What type of
accommodation is <em>68 Abingdon Road, Goathill</em>?" data-qa="accommodationtype-answer-edit">Change</a>
</td>
```
_Originally posted by @jrbarnes9 in https://github.com/ONSdigital/design-system/issues/84#issuecomment-538338400_

## How to review
- Add html markup to Summary component `action.arialLabel` and view screen reader output.
- html markup should not be present in `arial-label` value.