### PR TITLE
Add nonce to js-enabled script element in main page template

### DIFF
--- a/src/styles/page-template/_template.njk
+++ b/src/styles/page-template/_template.njk
@@ -63,7 +63,7 @@
         {% block head %}{% endblock %}
     </head>
     <body{% if page.bodyClasses %} class="{{ page.bodyClasses }}"{% endif %}>
-        <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+        <script{% if csp_nonce %} nonce="{{ csp_nonce() }}"{% endif %}>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
         {% block bodyStart %}{% endblock %}
         {% block body %}
             <div class="page">


### PR DESCRIPTION
The nonce value was missing in the script element that sets the `js-enabled` class leading to this CSP error:

![image](https://user-images.githubusercontent.com/1754822/66458537-f0450980-ea6a-11e9-97e7-02e6c9f12b79.png)

This pr adds the nonce value. I tested it by using it in survey runner and checking the developer tools console log.