### PR TITLE
Fix chevron colour on button focus

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -56,6 +56,11 @@ $button-border-height: 3px;
   &:focus:not(:active):not(:hover) &__inner {
     color: $color-focus-text;
     background-color: $color-focus;
+    &:after {
+      background: {
+        image: url(#{$static}/img/icons/icons--chevron-down-black.svg);
+      }
+    }
   }
 
   &:not([class*='btn--secondary']):not([class*='btn--print']):not([class*='btn--ghost-blue']):focus:hover &__inner {


### PR DESCRIPTION
Fixes [#621 ](https://trello.com/c/3LMzbuPj/433-issue-621-mobile-menu-focus-state-using-wrong-colour-chevron)