### PR TITLE
Add maxlength to date input

### DIFF
--- a/src/components/date-input/_macro.njk
+++ b/src/components/date-input/_macro.njk
@@ -34,6 +34,7 @@
                 "classes": "input--w-2" + exclusiveClass | default(""),
                 "min": 1,
                 "max": 31,
+                "maxLength": 2,
                 "attributes": params.day.attributes,
                 "label": params.day.label,
                 "value": params.day.value
@@ -48,6 +49,7 @@
                 "classes": "input--w-2" + exclusiveClass | default(""),
                 "min": 1,
                 "max": 12,
+                "maxLength": 2,
                 "attributes": params.month.attributes,
                 "label": params.month.label,
                 "value": params.month.value
@@ -62,6 +64,7 @@
                 "classes": "input--w-4" + exclusiveClass | default(""),
                 "min": 1000,
                 "max": 3000,
+                "maxLength": 4,
                 "attributes": params.year.attributes,
                 "label": params.year.label,
                 "value": params.year.value

--- a/src/components/date-input/examples/date-input/index.njk
+++ b/src/components/date-input/examples/date-input/index.njk
@@ -3,7 +3,7 @@
 {{
     onsDateInput({
         "id": "date",
-        "legend": "Please enter your date of birth",
+        "legend": "Date of birth",
         "description": "For example, 31 3 1980",
         "day": {
             "label": {

--- a/src/components/input/_macro.njk
+++ b/src/components/input/_macro.njk
@@ -30,7 +30,7 @@
             {% if params.min is defined %}min="{{ params.min }}"{% endif %}
             {% if params.max is defined %}max="{{ params.max }}"{% endif %}
             {% if params.minLength is defined %}minlength="{{ params.minLength }}"{% endif %}
-            {% if params.maxLangth is defined %}maxlength="{{ params.maxLangth }}"{% endif %}
+            {% if params.maxLength is defined %}maxlength="{{ params.maxLength }}"{% endif %}
             {% if pattern is defined %}pattern="{{ pattern }}"{% endif %}
             {% if inputmode is defined %}inputmode="{{ inputmode }}"{% endif %}
             {% if params.autocomplete is defined %}autocomplete="{{ params.autocomplete }}"{% endif %}

--- a/src/patterns/dates/index.njk
+++ b/src/patterns/dates/index.njk
@@ -21,7 +21,9 @@ Don't use the date pattern if you're asking the user about an event they are unl
 ## How to use this pattern
 The date pattern provides the user with 3 [input](/components/input) fields to enter a day, month, and year.
 
-The 3 input fields are grouped within a [fieldset](/components/fieldset) with a `<legend>` that lets the user know what they need to do.
+The 3 input fields are grouped within a [fieldset](/components/fieldset) with a `<legend>` that lets the user know what they need to enter.
+
+A `fieldset__description` is used to provide an example of the required format for the date e.g. 'For example, 31 3 1980'.
 
 {{
     onsPanel({
@@ -30,8 +32,6 @@ The 3 input fields are grouped within a [fieldset](/components/fieldset) with a 
     })
 }}
 The date fields have a `maxlength` limit set to the maximum number of digits required for day and month (2), and year (4), to prevent users entering too many digits in a single field. This is to help those users who expect auto-tabbing between the fields by preventing them from entering the full date into the first field.
-
-A `<span>` with `field__description` class is used to provide an example of the required format for the date e.g. 'For example, 31 3 1980'.
 
 Each field uses the `input--w-<number>` class to set the known number of digits required for each field.
 

--- a/src/patterns/dates/index.njk
+++ b/src/patterns/dates/index.njk
@@ -29,6 +29,7 @@ The 3 input fields are grouped within a [fieldset](/components/fieldset) with a 
         "body": "<p><strong>Note:</strong> Never automatically tab the user between the fields.  This can be unexpected and confusing, and may hinder normal keyboard control.</p>"
     })
 }}
+The date fields have a `maxlength` limit set to the maximum number of digits required for day and month (2), and year (4), to prevent users entering too many digits in a single field. This is to help those users who expect auto-tabbing between the fields by preventing them from entering the full date into the first field.
 
 A `<span>` with `field__description` class is used to provide an example of the required format for the date e.g. 'For example, 31 3 1980'.
 


### PR DESCRIPTION
Users have fed back frustrations around the ability to add more than two or four characters in the date inputs.  This is especially frustrating for users who expect auto-tabbing, because they end up entering everything into the first input (which is too small to easily edit/delete)
