### PR TITLE
Fix typeahead to be compatible with runner

### DIFF
--- a/src/components/input/_macro-options.md
+++ b/src/components/input/_macro-options.md
@@ -32,20 +32,14 @@
 
 ## Typeahead
 
-| Name          | Type             | Required | Description                                                                     |
-| ------------- | ---------------- | -------- | ------------------------------------------------------------------------------- |
-| content       | TypeaheadContent | true     | Aria and results messaging content                                              |
-| typeaheadData | string           | true     | URL of the JSON file with the typeahead data that needs to be searched          |
-| instructions  | string           | true    | Instructions on how to use the typeahead that will be read out by screenreaders |
-
-## TypeaheadContent
-
-| Name                   | Type   | Required | Description                                                                                      |
-| ---------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------ |
-| aria_you_have_selected | string | true     | Aria message to tell the user that they have selected an answer                                  |
-| aria_min_chars         | string | true     | Aria message to tell the user how many charecters they need to enter before typeahead will start |
-| aria_one_result        | string | true     | Aria message to tell the user there is only one suggestion left                                  |
-| aria_n_results         | string | true     | Aria message to tell the user how many suggestions are left                                      |
-| aria_limited_results   | string | true     | Aria message to tell the user if the results have been limited and what they are limited to      |
-| more_results           | string | true     | Aria message to tell the user to continue to type to refine suggestions                          |
-| results_title          | string | true     | Title of results to be displayed on screen at the top of the results                             |
+| Name                | Type   | Required | Description                                                                                      |
+| ------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------ |
+| typeaheadData       | string | true     | URL of the JSON file with the typeahead data that needs to be searched                           |
+| instructions        | string | true     | Instructions on how to use the typeahead that will be read out by screenreaders                  |
+| ariaYouHaveSelected | string | true     | Aria message to tell the user that they have selected an answer                                  |
+| ariaMinChars        | string | true     | Aria message to tell the user how many charecters they need to enter before typeahead will start |
+| ariaOneResult       | string | true     | Aria message to tell the user there is only one suggestion left                                  |
+| ariaNResults        | string | true     | Aria message to tell the user how many suggestions are left                                      |
+| ariaLimitedResults  | string | true     | Aria message to tell the user if the results have been limited and what they are limited to      |
+| moreResults         | string | true     | Aria message to tell the user to continue to type to refine suggestions                          |
+| resultsTitle        | string | true     | Title of results to be displayed on screen at the top of the results                             |

--- a/src/components/input/_macro.njk
+++ b/src/components/input/_macro.njk
@@ -21,15 +21,23 @@
             <div
                 id="{{ params.id }}-container"
                 class="js-typeahead typeahead-input {{ params.classes }}"
-                data-content="{{ params.typeahead.content | dump }}"
-                typeahead-data="{{ params.typeahead.typeaheadData }}"
+                data-instructions="{{ params.typeahead.instructions }}"
+                data-aria-you-have-selected="{{ params.typeahead.ariaYouHaveSelected }}"
+                data-aria-min-chars="{{ params.typeahead.ariaMinChars }}"
+                data-aria-one-result="{{ params.typeahead.ariaOneResult }}"
+                data-aria-n-results="{{ params.typeahead.ariaNResults }}"
+                data-aria-limited-results="{{ params.typeahead.ariaLimitedResults }}"
+                data-more-results="{{ params.typeahead.moreResults }}"
+                data-results-title="{{ params.typeahead.resultsTitle }}"
+                data-typeahead-data="{{ params.typeahead.typeaheadData }}"
+                data-no-results="{{ params.typeahead.noResults }}"
             >
         {% endif %}
 
                 <input
                     type="{{ type }}"
                     id="{{ params.id }}"
-                    class="input input--text input-type__input js-typeahead-input {{ params.classes }}{{ exclusiveClass }}"
+                    class="input input--text input-type__input {% if params.typeahead %} js-typeahead-input {% endif %} {{ params.classes }}{{ exclusiveClass }}"
                     {% if params.prefix or params.suffix %}title="{{ params.prefix.title if params.prefix }}{{ params.suffix.title if params.suffix }}"{% endif %}
                     {% if params.name is defined %}name="{{ params.name }}"{% endif %}
                     {% if params.accessiblePlaceholder is defined %}required{% endif %}
@@ -48,7 +56,7 @@
 
         {% if params.typeahead.typeaheadData %}
                 <div class="typeahead-input__results js-typeahead-results">
-                    <header class="typeahead-input__results-title u-fs-s">{{ params.typeahead.content.results_title }}</header>
+                    <header class="typeahead-input__results-title u-fs-s">{{ params.typeahead.resultsTitle }}</header>
                     <ul class="typeahead-input__listbox js-typeahead-listbox" role="listbox" id="{{ params.id }}-listbox" tabindex="-1"></ul>
                 </div>
 

--- a/src/components/input/examples/country-of-birth/index.njk
+++ b/src/components/input/examples/country-of-birth/index.njk
@@ -12,16 +12,15 @@
             "autocomplete": "off",
             "typeahead":{
                 "instructions": "Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.",
-                "content": {
-                    "aria_you_have_selected": "You have selected",
-                    "aria_min_chars": "Enter 3 or more characters for suggestions.",
-                    "aria_one_result": "There is one suggestion available.",
-                    "aria_n_results": "There are {n} suggestions available.",
-                    "aria_limited_results": "Results have been limited to 10 suggestions. Type more characters to improve your search.",
-                    "more_results": "Continue entering to improve suggestions",
-                    "results_title": "Suggestions"
-                },
-                "typeaheadData": "https://gist.githubusercontent.com/rmccar/c123023fa6bd1b137d7f960c3ffa1fed/raw/368a3ea741f72c62c735c319ff7e33e3c1bfdc53/country-of-birth.json"
+                "ariaYouHaveSelected": "You have selected",
+                "ariaMinChars": "Enter 3 or more characters for suggestions.",
+                "ariaOneResult": "There is one suggestion available.",
+                "ariaNResults": "There are {n} suggestions available.",
+                "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search.",
+                "moreResults": "Continue entering to improve suggestions",
+                "resultsTitle": "Suggestions",
+                "typeaheadData": "https://gist.githubusercontent.com/rmccar/c123023fa6bd1b137d7f960c3ffa1fed/raw/368a3ea741f72c62c735c319ff7e33e3c1bfdc53/country-of-birth.json",
+                "noResults": "No results found"
             }
         }) }}
 

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -60,7 +60,7 @@ Typeaheads are used to suggest options for answers by searching code lists such 
 
 Providing the component with a `typeahead` object will turn the component into a typeahead input using the data in the JSON file.
 This object will need to include a path to a JSON file using the `typeaheadData` parameter, a `instructions` parameter to add screenreader instructions
-to make it accessable and a `content` object that will contain various aria messages also for screenreaders.
+to make it accessable and various parameters for aria messages also used for screenreaders.
 
 To use this component it is advised that autocomplete is switched off by setting the `autocomplete` parameter to false.
 

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -60,7 +60,7 @@ Typeaheads are used to suggest options for answers by searching code lists such 
 
 Providing the component with a `typeahead` object will turn the component into a typeahead input using the data in the JSON file.
 This object will need to include a path to a JSON file using the `typeaheadData` parameter, a `instructions` parameter to add screenreader instructions
-to make it accessable and various parameters for aria messages also used for screenreaders.
+to make it accessible and various parameters for aria messages also used for screenreaders.
 
 To use this component it is advised that autocomplete is switched off by setting the `autocomplete` parameter to false.
 

--- a/src/components/input/typeahead.ui.js
+++ b/src/components/input/typeahead.ui.js
@@ -26,6 +26,14 @@ export default class TypeaheadUI {
     onUnsetResult,
     suggestionFunction,
     lang,
+    ariaYouHaveSelected,
+    ariaMinChars,
+    ariaOneResult,
+    ariaNResults,
+    ariaLimitedResults,
+    moreResults,
+    resultsTitle,
+    noResults,
   }) {
     // DOM Elements
     this.context = context;
@@ -36,8 +44,17 @@ export default class TypeaheadUI {
     this.ariaStatus = context.querySelector(`.${baseClass}-aria-status`);
 
     // Settings
-    this.typeaheadData = typeaheadData || context.getAttribute('typeahead-data');
-    this.content = JSON.parse(context.getAttribute('data-content'));
+    this.typeaheadData = typeaheadData || context.getAttribute('data-typeahead-data');
+
+    this.ariaYouHaveSelected = ariaYouHaveSelected || context.getAttribute('data-aria-you-have-selected');
+    this.ariaMinChars = ariaMinChars || context.getAttribute('data-aria-min-chars');
+    this.ariaOneResult = ariaOneResult || context.getAttribute('data-aria-one-result');
+    this.ariaNResults = ariaNResults || context.getAttribute('data-aria-n-results');
+    this.ariaLimitedResults = ariaLimitedResults || context.getAttribute('data-aria-limited-results');
+    this.moreResults = moreResults || context.getAttribute('data-more-results');
+    this.resultsTitle = resultsTitle || context.getAttribute('data-results-title');
+    this.noResults = noResults || context.getAttribute('data-no-results');
+
     this.listboxId = this.listbox.getAttribute('id');
     this.minChars = minChars || 3;
     this.resultLimit = resultLimit || 10;
@@ -348,7 +365,7 @@ export default class TypeaheadUI {
           const listElement = document.createElement('li');
           listElement.className = `${classTypeaheadOption} ${classTypeaheadOptionMoreResults}`;
           listElement.setAttribute('aria-hidden', 'true');
-          listElement.innerHTML = this.content.more_results;
+          listElement.innerHTML = this.moreResults;
           this.listbox.appendChild(listElement);
         }
 
@@ -358,9 +375,8 @@ export default class TypeaheadUI {
         this.context.classList[!!this.numberOfResults ? 'add' : 'remove'](classTypeaheadHasResults);
       }
     }
-
-    if (this.numberOfResults === 0 && this.content.no_results) {
-      this.listbox.innerHTML = `<li class="${classTypeaheadOption} ${classTypeaheadOptionNoResults}">${this.content.no_results}</li>`;
+    if (this.numberOfResults === 0 && this.noResults) {
+      this.listbox.innerHTML = `<li class="${classTypeaheadOption} ${classTypeaheadOptionNoResults}">${this.noResults}</li>`;
       this.input.setAttribute('aria-expanded', true);
     }
   }
@@ -392,16 +408,16 @@ export default class TypeaheadUI {
       const noResults = this.numberOfResults === 0;
 
       if (queryTooShort) {
-        content = this.content.aria_min_chars;
+        content = this.ariaMinChars;
       } else if (noResults) {
-        content = `${this.content.aria_no_results}: "${this.query}"`;
+        content = `${this.ariaNoResults}: "${this.query}"`;
       } else if (this.numberOfResults === 1) {
-        content = this.content.aria_one_result;
+        content = this.ariaOneResult;
       } else {
-        content = this.content.aria_n_results.replace('{n}', this.numberOfResults);
+        content = this.ariaNResults.replace('{n}', this.numberOfResults);
 
         if (this.resultLimit && this.foundResults > this.resultLimit) {
-          content += ` ${this.content.aria_limited_results}`;
+          content += ` ${this.ariaLimitedResults}`;
         }
       }
     }
@@ -438,7 +454,7 @@ export default class TypeaheadUI {
 
       this.onSelect(result).then(() => (this.settingResult = false));
 
-      const ariaMessage = `${this.content.aria_you_have_selected}: ${result.displayText}.`;
+      const ariaMessage = `${this.ariaYouHaveSelected}: ${result.displayText}.`;
 
       this.clearListbox();
       this.setAriaStatus(ariaMessage);

--- a/src/tests/spec/typeahead/typeahead.ui.spec.js
+++ b/src/tests/spec/typeahead/typeahead.ui.spec.js
@@ -28,17 +28,15 @@ const params = {
   typeahead: {
     instructions:
       'Use up and down keys to navigate suggestions once youve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.',
-    content: {
-      aria_you_have_selected: 'You have selected',
-      aria_found_by_alternative_name: 'found by alternative name',
-      aria_min_chars: 'Enter 3 or more characters for suggestions.',
-      aria_one_result: 'There is one suggestion available.',
-      aria_n_results: 'There are {n} suggestions available.',
-      aria_limited_results: 'Results have been limited to 10 suggestions. Enter more characters to improve your search.',
-      more_results: 'Continue entering to improve suggestions',
-      results_title: 'Suggestions',
-      no_results: 'No results found',
-    },
+    ariaYouHaveSelected: 'You have selected',
+    ariaFoundByAlternativeName: 'found by alternative name',
+    ariaMinChars: 'Enter 3 or more characters for suggestions.',
+    ariaOneResult: 'There is one suggestion available.',
+    ariaNResults: 'There are {n} suggestions available.',
+    ariaLimitedResults: 'Results have been limited to 10 suggestions. Enter more characters to improve your search.',
+    moreResults: 'Continue entering to improve suggestions',
+    resultsTitle: 'Suggestions',
+    noResults: 'No results found',
     typeaheadData:
       'https://gist.githubusercontent.com/rmccar/c123023fa6bd1b137d7f960c3ffa1fed/raw/368a3ea741f72c62c735c319ff7e33e3c1bfdc53/country-of-birth.json',
   },
@@ -868,7 +866,7 @@ describe('Typeahead.ui component', function() {
           });
 
           it('then the message should be set to type the minimum amount of characters', function() {
-            expect(this.typeahead.ariaStatus.innerHTML).to.equal(params.typeahead.content.aria_min_chars);
+            expect(this.typeahead.ariaStatus.innerHTML).to.equal(params.typeahead.ariaMinChars);
           });
         });
 
@@ -881,7 +879,7 @@ describe('Typeahead.ui component', function() {
           });
 
           it('then the no results message should be set', function() {
-            expect(this.typeahead.ariaStatus.innerHTML).to.equal(`${params.typeahead.content.aria_no_results}: "${this.typeahead.query}"`);
+            expect(this.typeahead.ariaStatus.innerHTML).to.equal(`${params.typeahead.ariaNoResults}: "${this.typeahead.query}"`);
           });
         });
 
@@ -893,7 +891,7 @@ describe('Typeahead.ui component', function() {
           });
 
           it('then the one result message should be set', function() {
-            expect(this.typeahead.ariaStatus.innerHTML).to.equal(params.typeahead.content.aria_one_result);
+            expect(this.typeahead.ariaStatus.innerHTML).to.equal(params.typeahead.ariaOneResult);
           });
         });
 
@@ -906,7 +904,7 @@ describe('Typeahead.ui component', function() {
 
           it('then the multiple results message should be set', function() {
             expect(this.typeahead.ariaStatus.innerHTML).to.equal(
-              params.typeahead.content.aria_n_results.replace('{n}', this.typeahead.numberOfResults),
+              params.typeahead.ariaNResults.replace('{n}', this.typeahead.numberOfResults),
             );
           });
         });
@@ -922,9 +920,7 @@ describe('Typeahead.ui component', function() {
 
           it('then the multiple results message should be set', function() {
             expect(this.typeahead.ariaStatus.innerHTML).to.equal(
-              `${params.typeahead.content.aria_n_results.replace('{n}', this.typeahead.numberOfResults)} ${
-                params.typeahead.content.aria_limited_results
-              }`,
+              `${params.typeahead.ariaNResults.replace('{n}', this.typeahead.numberOfResults)} ${params.typeahead.ariaLimitedResults}`,
             );
           });
         });
@@ -980,7 +976,7 @@ describe('Typeahead.ui component', function() {
         });
 
         it('then setAriaStatus should be called', function() {
-          expect(this.setAriaStatusSpy).to.have.been.called.with.exactly(`${params.typeahead.content.aria_you_have_selected}: Yes.`);
+          expect(this.setAriaStatusSpy).to.have.been.called.with.exactly(`${params.typeahead.ariaYouHaveSelected}: Yes.`);
         });
       });
 
@@ -992,7 +988,7 @@ describe('Typeahead.ui component', function() {
         });
 
         it('then setAriaStatus should be called stating the result was found from the alternative', function() {
-          expect(this.setAriaStatusSpy).to.have.been.called.with.exactly(`${params.typeahead.content.aria_you_have_selected}: Ie.`);
+          expect(this.setAriaStatusSpy).to.have.been.called.with.exactly(`${params.typeahead.ariaYouHaveSelected}: Ie.`);
         });
       });
     });
@@ -1027,7 +1023,7 @@ describe('Typeahead.ui component', function() {
 
           it('then the listbox innerHTML should show the no results message', function() {
             expect(this.typeahead.listbox.innerHTML).to.equal(
-              `<li class="${classTypeaheadOption} ${classTypeaheadOptionNoResults}">${params.typeahead.content.no_results}</li>`,
+              `<li class="${classTypeaheadOption} ${classTypeaheadOptionNoResults}">${params.typeahead.noResults}</li>`,
             );
           });
 
@@ -1042,7 +1038,7 @@ describe('Typeahead.ui component', function() {
 
         describe('if there isnt any "no results" content', function() {
           beforeEach(function() {
-            this.typeahead.content.no_results = null;
+            this.typeahead.noResults = null;
             this.typeahead.handleResults({
               totalResults: 0,
               results: [],
@@ -1165,7 +1161,7 @@ describe('Typeahead.ui component', function() {
           it('then the more results item should be added', function() {
             const option1 = `<li class="${classTypeaheadOption}" id="${this.typeahead.listboxId}__option--0" role="option" aria-label="Yes"><strong>Yes</strong></li>`;
             const option2 = `<li class="${classTypeaheadOption}" id="${this.typeahead.listboxId}__option--1" role="option" aria-label="Yes"><strong>Yes</strong></li>`;
-            const option3 = `<li class="${classTypeaheadOption} ${classTypeaheadOptionMoreResults}" aria-hidden="true">${params.typeahead.content.more_results}</li>`;
+            const option3 = `<li class="${classTypeaheadOption} ${classTypeaheadOptionMoreResults}" aria-hidden="true">${params.typeahead.moreResults}</li>`;
             const html = option1 + option2 + option3;
 
             expect(this.typeahead.listbox.innerHTML).to.equal(html);


### PR DESCRIPTION
Changes made to allow the typeahead to work with runner:
- The variable names have been changed to make them conform with the standard
- The content object has been removed and params flattened
- If statement has been added about the typeahead classes