### PR TITLE
Fix chevron style for cookie banner button

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -181,7 +181,7 @@ $button-border-height: 3px;
 
   &--link.btn--secondary &__inner {
     &:after {
-      @include icon($name: 'chevron-right', $height: 0.8rem);
+      @include icon($name: 'chevron-right-black', $height: 0.8rem);
     }
   }
 
@@ -193,7 +193,7 @@ $button-border-height: 3px;
 
   &--link.btn--small.btn--secondary &__inner {
     &:after {
-      @include icon($name: 'chevron-right', $height: 0.7rem);
+      @include icon($name: 'chevron-right-black', $height: 0.7rem);
     }
   }
 

--- a/src/components/cookies-banner/_macro.njk
+++ b/src/components/cookies-banner/_macro.njk
@@ -19,7 +19,7 @@
                             "type": 'button',
                             "url": params.secondaryButtonUrl,
                             "text": params.secondaryButtonText | default('Cookie settings'),
-                            "classes": 'btn--secondary btn--small btn--link'
+                            "classes": 'btn--secondary btn--small'
                         }) 
                     }}
                 </div>


### PR DESCRIPTION
Fixes #670

Also stops `btn--link` class being added to the button twice