### PR TITLE
Remove field from Upload component

### DIFF
--- a/src/components/upload/_macro.njk
+++ b/src/components/upload/_macro.njk
@@ -1,19 +1,13 @@
 {% macro onsUpload(params) %}
-    {% from "components/field/_macro.njk" import onsField %}
     {% from "components/input/_macro.njk" import onsInput %}
 
-    {% call onsField({
-        "id": params.fieldId,
-        "classes": params.fieldClasses
-    }) %}
-        {{ onsInput({
-            "id": params.id,
-            "type": "file",
-            "label": params.label,
-            "classes": "input--upload",
-            "accept": params.accept,
-            "name": params.name,
-            "attributes": params.attributes
-        }) }}
-    {% endcall %}
+    {{ onsInput({
+        "id": params.id,
+        "type": "file",
+        "label": params.label,
+        "classes": "input--upload",
+        "accept": params.accept,
+        "name": params.name,
+        "attributes": params.attributes
+    }) }}
 {% endmacro %}


### PR DESCRIPTION
This PR is to remove the duplicate field in the Upload component that is causing extra white space. Input component is already wrapped in a Field. So a Field is not needed alongside the Input component in the upload component. Fixes #667 