### PR TITLE
Update inpagelink js to target different element

### DIFF
--- a/src/components/error/_macro.njk
+++ b/src/components/error/_macro.njk
@@ -6,13 +6,14 @@
             class="panel__error"
             {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
         >
-            <strong {% if params.id %}id="{{ params.id }}"{% endif %}>{{ params.text }}</strong>
+            <strong>{{ params.text }}</strong>
         </p>
         {{ caller() }}
     {% endset %}
 
     {% call onsPanel({
-        "type": "error"
+        "type": "error",
+        "id": params.id
     }) %}
        {{ content | safe }}
     {% endcall %}

--- a/src/components/error/index.njk
+++ b/src/components/error/index.njk
@@ -14,7 +14,7 @@ Generally speaking you should not need to [call](https://mozilla.github.io/nunju
 | Name       | Type   | Required | Description                                                       |
 | ---------- | ------ | -------- | ----------------------------------------------------------------- |
 | text       | string | true     | The text that describes the error message                                       |
-| id         | string | false    | The id that the error link can anchor to                          |
+| id         | string | true    | The id that the error link can anchor to                          |
 | attributes | object | false    | HTML attributes (for example data attributes) to add to the field |
 {% endmd %}
 

--- a/src/js/inpagelink.js
+++ b/src/js/inpagelink.js
@@ -11,25 +11,19 @@ export default function inPageLinks(links) {
 
 function focusOnInput(id) {
   const container = document.getElementById(id);
-  let input;
+  container.scrollIntoView();
 
-  if (['INPUT', 'TEXTAREA', 'SELECT'].includes(container.tagName)) {
-    input = container;
-  } else {
-    input = [
-      ...container.getElementsByTagName('INPUT'),
-      ...container.getElementsByTagName('TEXTAREA'),
-      ...container.getElementsByTagName('SELECT'),
-    ].filter(input => {
-      const type = input.getAttribute('type');
+  const input = [
+    ...container.getElementsByTagName('INPUT'),
+    ...container.getElementsByTagName('TEXTAREA'),
+    ...container.getElementsByTagName('SELECT'),
+  ].filter(input => {
+    const type = input.getAttribute('type');
 
-      return type !== 'readonly' && type !== 'hidden';
-    })[0];
-  }
+    return type !== 'readonly' && type !== 'hidden' && type !== 'checkbox' && type !== 'radio';
+  })[0];
 
   if (input) {
     input.focus();
-  } else {
-    container.scrollIntoView();
   }
 }

--- a/src/patterns/error-validation/examples/errors-proto/errors/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/errors/index.njk
@@ -9,6 +9,7 @@ layout: none
 {% from "components/input/_macro.njk" import onsInput %}
 {% from "components/button/_macro.njk" import onsButton %}
 {% from "components/radios/_macro.njk" import onsRadios %}
+{% from "components/date-input/_macro.njk" import onsDateInput %}
 
 {% set pageConfig =  {
     "title": "Errors Prototype"
@@ -29,21 +30,27 @@ layout: none
                 "classes": "list--bare",
                 "itemsList": [
                     {
-                        "text": "Enter a number.",
+                        "text": "Enter a number",
                         "index": true,
                         "url": "#number",
                         "classes": "js-inpagelink"
                     },
                     {
-                        "text": "Enter a number less than or equal to 100.",
+                        "text": "Enter a number less than or equal to 100",
                         "index": true,
                         "url": "#suffixed",
                         "classes": "js-inpagelink"
                     },
                     {
-                        "text": "Select one answer.",
+                        "text": "Select one answer",
                         "index": true,
                         "url": "#error",
+                        "classes": "js-inpagelink"
+                    },
+                    {
+                        "text": "Enter a date",
+                        "index": true,
+                        "url": "#date",
                         "classes": "js-inpagelink"
                     }
                 ]
@@ -56,8 +63,8 @@ layout: none
     }) %}
         {{
             onsInput({
-                "id": "number",
                 "type": "number",
+                "id": "number-0",
                 "classes": "input--w-5",
                 "fieldClasses": "question__answer",
                 "attributes": {
@@ -68,6 +75,7 @@ layout: none
                     "text": "Number of employees paid monthly"
                 },
                 "error": {
+                    "id": "number",
                     "text": "Enter a number."
                 }
             })
@@ -75,8 +83,8 @@ layout: none
 
         {{
             onsInput({
-                "id": "suffixed",
                 "type": "number",
+                "id": "number-input",
                 "classes": "input--w-2",
                 "fieldClasses": "question__answer",
                 "value": "101",
@@ -91,7 +99,8 @@ layout: none
                     "text": "%"
                 },
                 "error": {
-                    "text": "Enter a number less than or equal to 100."
+                    "id": "suffixed",
+                    "text": "Enter a number less than or equal to 100"
                 }
             })
         }}
@@ -100,8 +109,9 @@ layout: none
             onsRadios({
                 "legend": "How many employees do you employ?",
                 "name": "food",
+                "id": "radios-1",
                 "error": {
-                    "text": "Select one answer.",
+                    "text": "Select one answer",
                     "id": "error"
                 },
                 "radios": [
@@ -121,7 +131,47 @@ layout: none
                     }
                 ]
             }) 
-        }}    {% endcall %}
+        }}    
+
+        {{
+            onsDateInput({
+                "legend": "Date of birth",
+                "description": "For example, 31 3 1980",
+                "id": "dates",
+                "day": {
+                    "label": {
+                        "text": "Day"
+                    },
+                    "name": "day",
+                    "attributes": {
+                        "autocomplete": "bday-day"
+                    }
+                },
+                "month": {
+                    "label": {
+                        "text": "Month"
+                    },
+                    "name": "month",
+                    "attributes": {
+                        "autocomplete": "bday-month"
+                    }
+                },
+                "year": {
+                    "label": {
+                        "text": "Year"
+                    },
+                    "name": "year",
+                    "attributes": {
+                        "autocomplete": "bday-year"
+                    }
+                },
+                "error": {
+                    "text": "Enter a date",
+                    "id": "date"
+                }
+            })
+        }}
+    {% endcall %}
 
     {{
         onsButton({

--- a/src/patterns/error-validation/examples/errors-proto/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/index.njk
@@ -7,6 +7,7 @@ layout: none
 {% from "components/input/_macro.njk" import onsInput %}
 {% from "components/button/_macro.njk" import onsButton %}
 {% from "components/radios/_macro.njk" import onsRadios %}
+{% from "components/date-input/_macro.njk" import onsDateInput %}
 
 {% set pageConfig =  {
     "title": "Errors Prototype"
@@ -81,6 +82,40 @@ layout: none
                     }
                 ]
             }) 
+        }}
+
+        {{
+            onsDateInput({
+                "legend": "Date of birth",
+                "description": "For example, 31 3 1980",
+                "day": {
+                    "label": {
+                        "text": "Day"
+                    },
+                    "name": "day",
+                    "attributes": {
+                        "autocomplete": "bday-day"
+                    }
+                },
+                "month": {
+                    "label": {
+                        "text": "Month"
+                    },
+                    "name": "month",
+                    "attributes": {
+                        "autocomplete": "bday-month"
+                    }
+                },
+                "year": {
+                    "label": {
+                        "text": "Year"
+                    },
+                    "name": "year",
+                    "attributes": {
+                        "autocomplete": "bday-year"
+                    }
+                }
+            })
         }}
     {% endcall%}
 

--- a/src/patterns/error-validation/index.njk
+++ b/src/patterns/error-validation/index.njk
@@ -35,8 +35,7 @@ The error `panel__header` must display the number of errors on the page.
 
 The error `panel__body` must contain an anchored list to each erroneous field or fieldset on the page, each describing the specific error and directing the user towards a resolution. 
 
-Each list item `url` key should contain a value that matches the id of the input that has an error and preceded with a hash i.e. `#email-input`. Javascript will focus the corresponding input.
-If the input is a fieldset of checkboxes or radios then the id should match the id provided to the error message within the error details for the input.
+Each list item `url` key should contain a value that matches the id of the `panel` that wraps the input that has an error and preceded with a hash i.e. `#email-input`. Javascript will focus the corresponding input.
 
 Guidance on specific error messages can be found with each applicable [component](/components).
 


### PR DESCRIPTION
The inpagelink behaviour will now target inputs for focus but also scroll to the parent (panel). This is to provide a consistent approach/behaviour for all elements and js/no js

/patterns/error-validation/examples/errors-proto/