### PR TITLE
Fix vulnerability in links opening in new tabs

### DIFF
--- a/src/components/accordion/index.njk
+++ b/src/components/accordion/index.njk
@@ -58,7 +58,7 @@ Accordions hide content so make sure your section headings are clear so the user
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/81" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/81" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -43,7 +43,7 @@ Based uppon [W3 principles](https://w3c.github.io/aria-practices/examples/breadc
 
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-    <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/43" target="_blank">Design System forum</a>.</p>
+    <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/43" target="_blank" rel="noopener">Design System forum</a>.</p>
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/button/_macro.njk
+++ b/src/components/button/_macro.njk
@@ -14,7 +14,7 @@
       {% if params.value %}value="{{ params.value }}"{% endif %}
       {% if params.name %}name="{{ params.name }}"{% endif %}
       {% if params.disabled %} disabled{% endif %}
-      {% if params.url and params.newWindow %}target="_blank"{% endif %}
+      {% if params.url and params.newWindow %}target="_blank" rel="noopener"{% endif %}
       {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
       >
       <span class="btn__inner{% if params.innerClasses %} {{ params.innerClasses }}{% endif %}{% if params.newWindow %} icon--external-link{% endif %}">{{- params.html | safe if params.html else params.text -}}</span>

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -90,7 +90,7 @@ The `print` parameter can be set to `true` to render a print button. This will t
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/45" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/45" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/card/index.njk
+++ b/src/components/card/index.njk
@@ -44,7 +44,7 @@ The example below shows a row of 3 cards with thumbnail images.
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/48" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/48" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/error/index.njk
+++ b/src/components/error/index.njk
@@ -21,7 +21,7 @@ Generally speaking you should not need to [call](https://mozilla.github.io/nunju
 ## Research on this component
 
 {% call onsPanel() %}
-   <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/534" target="_blank">Design System forum</a>.</p>
+   <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/534" target="_blank" rel="noopener">Design System forum</a>.</p>
 {% endcall %}
 
 ## Design System forum

--- a/src/components/field/index.njk
+++ b/src/components/field/index.njk
@@ -25,7 +25,7 @@ The field will render as a `<p>` with the class `field`.
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/35" target="_blank">Design System forum</a>.</p>
+   <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/35" target="_blank" rel="noopener">Design System forum</a>.</p>
 {% endcall %}
 
 ## Design System forum

--- a/src/components/fieldset/index.njk
+++ b/src/components/fieldset/index.njk
@@ -27,7 +27,7 @@ Generally speaking you should not need to [call](https://mozilla.github.io/nunju
 ## Research on this component
 
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/501" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/501" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/components/footer/index.njk
+++ b/src/components/footer/index.njk
@@ -65,7 +65,7 @@ For badged services where ONS is providing services to external organisations, w
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/172" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/172" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -99,7 +99,7 @@ The typeahead component will search the `cy` or the `en-gb` data to find results
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/163" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/163" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -54,7 +54,7 @@ Use the optional `label__description` to show hint text to help the majority of 
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/40" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/40" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/metadata/index.njk
+++ b/src/components/metadata/index.njk
@@ -21,7 +21,7 @@ Use the `metadataLabel` to succinctly describe the description list.
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/91" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/91" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/components/mutually-exclusive/index.njk
+++ b/src/components/mutually-exclusive/index.njk
@@ -55,7 +55,7 @@ Inputs, radios, checkboxes, date inputs, and textareas all call this macro autom
 ## Research on this component
 
 {% call onsPanel() %}
-   <p>If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/29" target="_blank">Design System forum</a>.</p>
+   <p>If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/29" target="_blank" rel="noopener">Design System forum</a>.</p>
 {% endcall %}
 
 ## Design System forum

--- a/src/components/pagination/index.njk
+++ b/src/components/pagination/index.njk
@@ -54,7 +54,7 @@ If the pagination component sits inline with other content on the page, then the
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/70" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/70" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/panel/index.njk
+++ b/src/components/panel/index.njk
@@ -45,7 +45,7 @@ The spacious variant can be used on all inline variants.
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/49" target="_blank">Design System forum</a>.</p>
+   <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/49" target="_blank" rel="noopener">Design System forum</a>.</p>
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/password/index.njk
+++ b/src/components/password/index.njk
@@ -17,7 +17,7 @@ The `<input>` and `<label>` is separated by a [checkbox component](/components/c
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/141" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/141" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/section-navigation/index.njk
+++ b/src/components/section-navigation/index.njk
@@ -18,7 +18,7 @@ This component can be implemented with main navigation in the [Header](/componen
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/174" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/174" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -31,7 +31,7 @@ Because the expanded list cannot be styled, this may cause usability issues wher
 ## Research on this component
 
 {% call onsPanel() %}
-   <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/50" target="_blank">Design System forum</a></p>
+   <p>If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/50" target="_blank" rel="noopener">Design System forum</a></p>
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/status/index.njk
+++ b/src/components/status/index.njk
@@ -55,7 +55,7 @@ Each status 'dot' has a small variant which is applied by adding a `<status type
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/77" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/77" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/table/index.njk
+++ b/src/components/table/index.njk
@@ -61,7 +61,7 @@ The 'basic table' is the default style for a table. There are variations availab
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/102" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/102" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/components/tabs/index.njk
+++ b/src/components/tabs/index.njk
@@ -75,7 +75,7 @@ Tabs hide content and are displayed horizontally, so it's important to use tab l
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/82" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/82" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/components/upload/index.njk
+++ b/src/components/upload/index.njk
@@ -19,7 +19,7 @@ The `<input>` value is set to `type="file"`. A file upload input also takes the 
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/97" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/97" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/patterns/addresses/index.njk
+++ b/src/patterns/addresses/index.njk
@@ -28,7 +28,7 @@ An additional field may be configured on the address input if you need to ask fo
 ## Research on this pattern
 
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/412" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/412" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/patterns/durations/index.njk
+++ b/src/patterns/durations/index.njk
@@ -24,7 +24,7 @@ Duration inputs can be created by using the duration component. For example:
 ## Research on this pattern
 
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/19" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/19" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/patterns/error-status-pages/index.njk
+++ b/src/patterns/error-status-pages/index.njk
@@ -190,7 +190,7 @@ The page should have:
 ## Research on this pattern
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/237" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/237" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/patterns/feedback/index.njk
+++ b/src/patterns/feedback/index.njk
@@ -31,7 +31,7 @@ The feedback pattern is baked into the base [page template](/styles/page-templat
 ## Research on this pattern
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/236" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/236" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/patterns/highlight/index.njk
+++ b/src/patterns/highlight/index.njk
@@ -24,7 +24,7 @@ It should be noted that highlight should be applied to an `<em>` element. If it 
 ## Research on this pattern
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/24" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/24" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/patterns/language-selection/index.njk
+++ b/src/patterns/language-selection/index.njk
@@ -27,7 +27,7 @@ Language selection is achieved by rendering a language selector in the header el
 ## Research on this pattern
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/109" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/109" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/patterns/message/index.njk
+++ b/src/patterns/message/index.njk
@@ -37,7 +37,7 @@ Each message can be stacked to display the conversation/thread.
 ## Research on this component
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/676" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this component, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/676" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/patterns/numeric-values/index.njk
+++ b/src/patterns/numeric-values/index.njk
@@ -61,7 +61,7 @@ Use the `suffix` parameter to specify the abbreviated suffix unit e.g. 'cm', and
 
 ## Research on this pattern
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/279" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/279" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/patterns/question/index.njk
+++ b/src/patterns/question/index.njk
@@ -51,7 +51,7 @@ Questions should be wrapped in a fieldset when:
 ## Research on this pattern
 
 {% call onsPanel() %} 
-    If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/367" target="_blank">Design System forum</a>.
+    If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/367" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/patterns/relationships/index.njk
+++ b/src/patterns/relationships/index.njk
@@ -21,7 +21,7 @@ Help users select define relationships between household memebers.
 
 ## Research on this pattern
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/464" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/464" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/patterns/uac/index.njk
+++ b/src/patterns/uac/index.njk
@@ -11,7 +11,7 @@ group: Ask users for...
 
 ## Research on this pattern
 {% call onsPanel() %}
-   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/414" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this pattern, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/414" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum

--- a/src/styles/colours/index.njk
+++ b/src/styles/colours/index.njk
@@ -356,7 +356,7 @@ Also, ensure you test colour contrast with people of all abilities.
 ## Research on this style
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this style, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/232" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this style, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/232" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/styles/typography/index.njk
+++ b/src/styles/typography/index.njk
@@ -140,13 +140,13 @@ __How to use:__ Use `icon--lock` class on a `<p>` element.
 ### Contribute to icons
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have any requests for icons or research findings please feed back via the <a href="https://github.com/ONSdigital/design-system/issues/95" target="_blank">Design System forum</a>.
+   If you have any requests for icons or research findings please feed back via the <a href="https://github.com/ONSdigital/design-system/issues/95" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Research on this style
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% call onsPanel() %}
-   If you have conducted any user research using this style, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/233" target="_blank">Design System forum</a>.
+   If you have conducted any user research using this style, please feed back your findings via the <a href="https://github.com/ONSdigital/design-system/issues/233" target="_blank" rel="noopener">Design System forum</a>.
 {% endcall %}
 
 ## Design System forum 

--- a/src/views/partials/example/_macro.njk
+++ b/src/views/partials/example/_macro.njk
@@ -1,7 +1,7 @@
 {% macro patternlibExample(params) %}
   {% set params = helpers.generateExampleParams(params, helpers.addDependency) %}
   <div class="patternlib-example js-example">
-    <a href="{{ params.link }}" target="_blank" class="patternlib-example__link u-fs-s">Open this example in a new window</a>
+    <a href="{{ params.link }}" target="_blank" rel="noopener" class="patternlib-example__link u-fs-s">Open this example in a new window</a>
     <div class="patternlib-example__frame">
         <iframe class="patternlib-example__iframe" frameborder="0" scrolling="auto" src="{{ params.link }}" style="background-color: {{ params.backgroundColor | default ('#fff') }}"></iframe>
     </div>


### PR DESCRIPTION
Adding `rel="noopener"` to all `target="_blank"` links