### PR TITLE
510 breadcrumbs at 500bp

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -1,8 +1,8 @@
 $breadcrumb-chevron-height: 0.65rem;
 
 .breadcrumb {
-  display: flex;
   align-items: center;
+  display: flex;
   padding: 1rem 0;
 
   &__items {
@@ -13,7 +13,7 @@ $breadcrumb-chevron-height: 0.65rem;
   &__item {
     display: inline-block;
     margin: 0;
-    white-space: nowrap; /* stop items from wrapping, break on chevron only */
+    white-space: nowrap; // stop items from wrapping, break on chevron only
 
     @include mq(xs, s) {
       &:not(:nth-last-child(2)) {
@@ -22,17 +22,15 @@ $breadcrumb-chevron-height: 0.65rem;
 
       &:before {
         @include icon('chevron-left', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
-
         content: '';
         margin: 0 0.2rem 0 0;
         vertical-align: middle;
       }
     }
 
-    @include mq(s) {
+    @include mq(501px) {
       &:not(:last-child):after {
         @include icon('chevron-right', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
-
         content: '';
         margin: 0;
         vertical-align: middle;

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -15,30 +15,35 @@ $breadcrumb-chevron-height: 0.65rem;
     margin: 0;
     white-space: nowrap; // Stop items from wrapping, break on chevron only
 
-    @include mq(xs, s) {
-      &:not(:nth-last-child(2)) {
-        display: none;
-      }
-
-      &:before {
-        @include icon('chevron-left', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
-        content: '';
-        margin: 0 0.2rem 0 0;
-        vertical-align: middle;
-      }
+    &:not(:nth-last-child(2)) {
+      display: none;
     }
 
-    // 1px over small breakpoint
-    @include mq(501px) {
+    &:before {
+      @include icon('chevron-left', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
+      content: '';
+      margin: 0 0.2rem 0 0;
+      vertical-align: middle;
+    }
+
+    @include mq(s) {
+      &:before {
+        content: none;
+      }
+
+      &:not(:nth-last-child(2)) {
+        display: inline-block;
+      }
+
       &:not(:last-child):after {
         @include icon('chevron-right', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
         content: '';
-        margin: 0;
         vertical-align: middle;
+        margin: 0;
 
         // We have to override the icon settings so it renders correctly in ie11
-        width: 1.25rem;
         background-position: center center;
+        width: 1.25rem;
       }
     }
 

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -13,7 +13,7 @@ $breadcrumb-chevron-height: 0.65rem;
   &__item {
     display: inline-block;
     margin: 0;
-    white-space: nowrap; // stop items from wrapping, break on chevron only
+    white-space: nowrap; // Stop items from wrapping, break on chevron only
 
     @include mq(xs, s) {
       &:not(:nth-last-child(2)) {
@@ -28,6 +28,7 @@ $breadcrumb-chevron-height: 0.65rem;
       }
     }
 
+    // 1px over small breakpoint
     @include mq(501px) {
       &:not(:last-child):after {
         @include icon('chevron-right', $breadcrumb-chevron-height, $breadcrumb-chevron-height);


### PR DESCRIPTION
Fixed bug #759 with breadcrumb rendering two arrows at 500px.

This was due to a conflict in breakpoints. Increasing the breakpoint by 1px fixed the issue.