### PR TITLE
Change aria-describedby name to avoid duplicate ids

### DIFF
--- a/src/components/input/_macro.njk
+++ b/src/components/input/_macro.njk
@@ -41,7 +41,7 @@
             {% if params.charCheck is defined %}data-char-check-ref="{{ params.id }}-check-remaining" data-char-check-num="{{ params.charCheck.limit }}"{% endif %}
             {% if params.charCheck is defined and params.charCheck.charcheckCountdown is defined %}data-char-check-countdown="true"{% endif %}
             {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
-            {% if params.label is defined and params.label.description is defined %}{% if params.label.id %}aria-describedby="{{params.id}}-label-description-hint"{% else %}aria-describedby="label-description-hint"{% endif %}{% endif %}
+            {% if params.label is defined and params.label.description is defined %}{% if params.label.id %}aria-describedby="{{params.id}}-description-hint"{% else %}aria-describedby="description-hint"{% endif %}{% endif %}
         />
     {% endset %}
     {% set field %}

--- a/src/components/label/_macro.njk
+++ b/src/components/label/_macro.njk
@@ -1,7 +1,7 @@
 {% macro onsLabel(params) %}
     <label
       class="{% if not params.inputType %}label {% endif %}{{ params.classes if params.classes else "" }}{% if params.description %} label--with-description{% endif %} {{' label--placeholder ' if params.accessiblePlaceholder else "" }}"
-      {% if params.id %} aria-describedby="{{ params.id }}-label-description-hint"{% else %}aria-describedby="label-description-hint"{% endif %}
+      {% if params.id %} aria-describedby="{{ params.id }}-description-hint"{% else %}aria-describedby="description-hint"{% endif %}
       {% if params.for %} for="{{ params.for }}"{% endif %}
       {% if params.id %} id="{{ params.id }}"{% endif %}
       {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}
@@ -10,7 +10,7 @@
     </label>
     {%- if params.description %}
       <span
-        {% if params.id %} id="{{ params.id }}-label-description-hint"{% else %}id="label-description-hint"{% endif %}
+        {% if params.id %} id="{{ params.id }}-description-hint"{% else %}id="description-hint"{% endif %}
         class="label__description {% if params.inputType %}{{ params.inputType }}__label--with-description{% else %} input--with-description{% endif %}">
           {{ params.description }}
       </span>


### PR DESCRIPTION
Integrating version 18 into runner made me realise we could end up with either duplicate ids after moving the hint outside the label. or by adding `-label` on the end of the input id to form the label id would give hint ids of `inputid-label-label-description-hint`. The double label not looking like a good id. So this PR is to solve that.