### PR TITLE
Bug fix - stop aria-describedby being added if no description

### DIFF
--- a/src/components/label/_macro.njk
+++ b/src/components/label/_macro.njk
@@ -1,7 +1,7 @@
 {% macro onsLabel(params) %}
     <label
       class="{% if not params.inputType %}label {% endif %}{{ params.classes if params.classes else "" }}{% if params.description %} label--with-description{% endif %} {{' label--placeholder ' if params.accessiblePlaceholder else "" }}"
-      {% if params.id %} aria-describedby="{{ params.id }}-description-hint"{% else %}aria-describedby="description-hint"{% endif %}
+      {% if params.description %}{% if params.id %} aria-describedby="{{ params.id }}-description-hint"{% else %}aria-describedby="description-hint"{% endif %}{% endif %}
       {% if params.for %} for="{{ params.for }}"{% endif %}
       {% if params.id %} id="{{ params.id }}"{% endif %}
       {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}


### PR DESCRIPTION
Just noticed that aria-describedby is being added if there is no description. Added an if to stop this.