### PR TITLE
Bug fix - set id on checkbox labels

### DIFF
--- a/src/components/checkboxes/_checkbox-macro.njk
+++ b/src/components/checkboxes/_checkbox-macro.njk
@@ -14,10 +14,11 @@
         >
 
         {{ onsLabel({
+            "id": params.id + "-label",
             "for": params.id,
             "inputType": "checkbox",
             "text": params.label.text,
-            "classes": "radio__label " + params.label.classes | default(''),
+            "classes": "checkbox__label " + params.label.classes | default(''),
             "description": params.label.description
         }) }}
 
@@ -32,6 +33,7 @@
                         "classes": "input--w-auto " + params.other.classes | default(''),
                         "attributes": params.other.attributes,
                         "label": {
+                            "id": params.other.id + "-label",
                             "text": params.other.label.text,
                             "classes": 'u-fs-s--b'
                         },


### PR DESCRIPTION
There is a bug introduced in #763. Ids are no longer being set on checkbox labels. This PR is to fix that.