### PR TITLE
Add ci task files

### DIFF
--- a/ci/tasks/build.yaml
+++ b/ci/tasks/build.yaml
@@ -1,0 +1,36 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: node
+    tag: 10.14.2
+
+inputs:
+  - name: ons-design-system-release
+
+outputs:
+  - name: ons-design-system-release-artifact
+  - name: ons-design-system-release-templates
+
+run:
+  path: sh
+  args:
+  - -exc
+  - |
+    apt-get update && apt-get install -y --allow-unauthenticated zip
+
+    cd ons-design-system-release
+
+    mkdir design-system
+    tar -xzf source.tar.gz -C design-system --strip-components=1
+
+    cd design-system
+
+    design_system_release=$(cat ../../ons-design-system-release/version)
+
+    yarn
+    RELEASE_VERSION=$design_system_release yarn cdn-bundle
+
+    mkdir ../../ons-design-system-release-artifact/$design_system_release
+    cp -R build/* ../../ons-design-system-release-artifact/$design_system_release
+    zip -r ../../ons-design-system-release-templates/templates.zip templates/*

--- a/ci/tasks/deploy_gcp.yaml
+++ b/ci/tasks/deploy_gcp.yaml
@@ -25,4 +25,4 @@ run:
       gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
       gcloud config set project "${PROJECT_ID}"
 
-      gsutil -m cp -r ons-design-system-release-artifact gs://census-eq-cdn/design-system/
+      gsutil -m cp -r ons-design-system-release-artifact/** gs://census-eq-cdn/design-system/

--- a/ci/tasks/deploy_gcp.yaml
+++ b/ci/tasks/deploy_gcp.yaml
@@ -1,0 +1,28 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+    tag: alpine
+
+params:
+  SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+  PROJECT_ID:
+
+inputs:
+- name: ons-design-system-release-artifact
+
+run:
+  path: bash
+  args:
+    - -exc
+    - |
+      export GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
+      cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+      $SERVICE_ACCOUNT_JSON
+      EOL
+      
+      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+      gcloud config set project "${PROJECT_ID}"
+
+      gsutil -m cp -r ons-design-system-release-artifact gs://census-eq-cdn/design-system/


### PR DESCRIPTION
Adds CI task files to be used for building a release and publishing to a GCP bucket. 

The existing Concourse has pipeline in this repo has not been updated to use the build task as we don't currently have access to the Concourse it's deployed to to test any changes.