### PR TITLE
Change block name on page exploded example

### DIFF
--- a/src/styles/page-template/examples/block-areas/index.njk
+++ b/src/styles/page-template/examples/block-areas/index.njk
@@ -75,7 +75,7 @@ layout: example
         <div class="pattern-lib-block__label">block: page</div>
 
         <div class="pattern-lib-block">
-            <div class="pattern-lib-block__label">block: prePage</div>
+            <div class="pattern-lib-block__label">block: preMain</div>
         </div>
 
         <div class="pattern-lib-block">


### PR DESCRIPTION
Fixes #787  