### PR TITLE
Bug fix - in runner when minification is turned off for radios

### DIFF
--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -25,7 +25,7 @@
                             class="radio__input js-radio{{ " " + radio.classes if radio.classes else "" }}"
                             value="{{ radio.value }}" 
                             name="{{ params.name }}"
-                            {% if radio.checked or (params.value and params.value == radio.value) %} checked{% endif %}
+                            {% if radio.checked or (params.value and params.value == radio.value) %} checked {% endif %}
                             {% if radio.other and not radio.other.open %} aria-controls="{{ radio.id }}-other-wrap" aria-haspopup="true"{% endif %}
                             {% if radio.attributes %}{% for attribute, value in (radio.attributes.items() if radio.attributes is mapping and radio.attributes.items else radio.attributes) %}{{ attribute }}{% if value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
                         >


### PR DESCRIPTION
This PR is a bug fix for Raidios in runner that have the checked attribute set when minification is turned off. After this PR there will be a space between `checked` and the next attribute