### PR TITLE
Add content attributes to collapsibles

### DIFF
--- a/src/components/accordion/_macro-options.md
+++ b/src/components/accordion/_macro-options.md
@@ -6,14 +6,16 @@
 | allButton | `AccordionButton`      | false    | Settings for the show all / hide all button. If not specified the button will not render |
 
 ## AccordionItem
-| Name | Type | Required | Description |
-| ----------------- | --------------------- | -------- | -------------------------------------------------------------------------------------- |
-| title | string | true | The title of the accordion item |
-| titleTag | string | false | The HTML tag that is used the title e.g. `h2`. Defaults to `div` |
-| content | string | true | The content of the accordion item |
-| button | `AccordionItemButton` | false | Settings for the button |
-| attributes | object | false | HTML attributes (for example data attributes) to add to the collapsible element |
-| headerAttributes | object | false | HTML attributes (for example data attributes) to add to the collapsible header element |
+
+| Name              | Type                  | Required | Description                                                                             |
+| ----------------- | --------------------- | -------- | --------------------------------------------------------------------------------------- |
+| title             | string                | true     | The title of the accordion item                                                         |
+| titleTag          | string                | false    | The HTML tag that is used the title e.g. `h2`. Defaults to `div`                        |
+| content           | string                | true     | The content of the accordion item                                                       |
+| button            | `AccordionItemButton` | false    | Settings for the button                                                                 |
+| attributes        | object                | false    | HTML attributes (for example data attributes) to add to the collapsible element         |
+| headingAttributes | object                | false    | HTML attributes (for example data attributes) to add to the collapsible header element  |
+| contentAttributes | object                | false    | HTML attributes (for example data attributes) to add to the collapsible content element |
 
 ## AccordionButton
 

--- a/src/components/accordion/_macro.njk
+++ b/src/components/accordion/_macro.njk
@@ -29,6 +29,7 @@
                     "button": item.button,
                     "attributes": item.attributes,
                     "headingAttributes": item.headingAttributes,
+                    "contentAttributes": item.contentAttributes,
                     "title": item.title,
                     "titleTag": item.titleTag,
                     "content": item.content,

--- a/src/components/collapsible/_macro-options.md
+++ b/src/components/collapsible/_macro-options.md
@@ -1,14 +1,15 @@
-| Name             | Type                | Required | Description                                                                            |
-| ---------------- | ------------------- | -------- | -------------------------------------------------------------------------------------- |
-| id               | string              | true     | id for the collapsible                                                                 |
-| title            | string              | true     | The title for the collapsible                                                          |
-| titleTag         | string              | false    | The HTML tag to wrap the title text in. Will default to a `div`                        |
-| content          | string              | true     | HTML content for the collapsible                                                       |
-| button           | `CollapsibleButton` | false    | Settings for the close button. If not specified button will not render                 |
-| classes          | string              | false    | Classes to add to the collapsible element                                              |
-| saveState        | boolean             | false    | Allows saving of collapsible state (open or closed) locally                            |
-| attributes       | object              | false    | HTML attributes (for example data attributes) to add to the collapsible element        |
-| headerAttributes | object              | false    | HTML attributes (for example data attributes) to add to the collapsible header element |
+| Name              | Type                | Required | Description                                                                             |
+| ----------------- | ------------------- | -------- | --------------------------------------------------------------------------------------- |
+| id                | string              | true     | id for the collapsible                                                                  |
+| title             | string              | true     | The title for the collapsible                                                           |
+| titleTag          | string              | false    | The HTML tag to wrap the title text in. Will default to a `div`                         |
+| content           | string              | true     | HTML content for the collapsible                                                        |
+| button            | `CollapsibleButton` | false    | Settings for the close button. If not specified button will not render                  |
+| classes           | string              | false    | Classes to add to the collapsible element                                               |
+| saveState         | boolean             | false    | Allows saving of collapsible state (open or closed) locally                             |
+| attributes        | object              | false    | HTML attributes (for example data attributes) to add to the collapsible element         |
+| headingAttributes | object              | false    | HTML attributes (for example data attributes) to add to the collapsible header element  |
+| contentAttributes | object              | false    | HTML attributes (for example data attributes) to add to the collapsible content element |
 
 ## CollapsibleButton
 

--- a/src/components/collapsible/_macro.njk
+++ b/src/components/collapsible/_macro.njk
@@ -30,7 +30,9 @@
                 {% endif %}
             </div>
         </div>
-        <div id="{{ params.id }}-content" class="collapsible__content js-collapsible-content">
+        <div id="{{ params.id }}-content" class="collapsible__content js-collapsible-content"
+            {% if params.contentAttributes %}{% for attribute, value in (params.contentAttributes.items() if params.contentAttributes is mapping and params.contentAttributes.items else params.contentAttributes) %}{{ attribute }}{% if value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
+        >
             {% if params.isAccordion %}
                 {{ params.content | safe }}{{ caller() if caller }}
             {% else %}


### PR DESCRIPTION
### What is the context of this PR?
This is to allow content attributes to be set on collapsibles. This is to allow `data-qa` attributes to be set on the content in runner to allow selectors to use them for tests

### How to review 
Tests pass, can set an attribute on a collapsible