### PR TITLE
Fix long words breaking summaries

### DIFF
--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -31,7 +31,6 @@ $hub-row-spacing: 1.3rem;
 
     &--error {
       border-left: 8px solid $color-errors;
-
       background: $color-errors-tint;
     }
   }
@@ -45,7 +44,10 @@ $hub-row-spacing: 1.3rem;
   &__values,
   &__actions {
     padding: 0 0 $summary-row-spacing;
+    word-wrap: break-word;
     vertical-align: top;
+    hyphens: auto;
+    overflow-wrap: break-word;
   }
 
   &__item-title {


### PR DESCRIPTION
### What is the context of this PR?
Long words are breaking summaries and causing elements to be pushed off the page this PR will add css to break long words onto multiple lines and hyphenate them

### How to review 
- Tests pass
- Change and example to have a long word in it to see if the word is broken onto multiple lines