### PR TITLE
Change hyphens css setting to manual on summaries

### DIFF
--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -46,7 +46,7 @@ $hub-row-spacing: 1.3rem;
     padding: 0 0 $summary-row-spacing;
     word-wrap: break-word;
     vertical-align: top;
-    hyphens: auto;
+    hyphens: manual;
     overflow-wrap: break-word;
   }
 


### PR DESCRIPTION
### What is the context of this PR?
Change hyphens css setting to manual on summaries. This will cause words to not break and hyphenate a word if they can fit on a new line