### PR TITLE
Tidy up sass and docs for breadcrumbs

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -60,5 +60,9 @@ $breadcrumb-chevron-height: 0.65rem;
   &__link {
     color: $color-text;
     text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -58,7 +58,7 @@ $breadcrumb-chevron-height: 0.65rem;
   }
 
   &__link {
-    color: #222;
+    color: $color-text;
     text-decoration: underline;
   }
 }

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -49,6 +49,7 @@ $breadcrumb-chevron-height: 0.65rem;
   }
 
   &__link {
-    text-decoration: none;
+    color: #222;
+    text-decoration: underline;
   }
 }

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -22,7 +22,7 @@ $breadcrumb-chevron-height: 0.65rem;
     &:before {
       @include icon('chevron-left', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
       content: '';
-      margin: 0 0.2rem 0 0;
+      margin: 0 0.2rem 0 -0.14rem;
       vertical-align: middle;
     }
 
@@ -39,7 +39,7 @@ $breadcrumb-chevron-height: 0.65rem;
         &:before {
           @include icon('chevron-left', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
           content: '';
-          margin: 0 0.2rem 0 0;
+          margin: 0 0.2rem 0 -0.14rem;
           vertical-align: middle;
         }
       }

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -35,6 +35,15 @@ $breadcrumb-chevron-height: 0.65rem;
         display: inline-block;
       }
 
+      &:first-child:nth-last-child(1) {
+        &:before {
+          @include icon('chevron-left', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
+          content: '';
+          margin: 0 0.2rem 0 0;
+          vertical-align: middle;
+        }
+      }
+
       &:not(:last-child):after {
         @include icon('chevron-right', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
         content: '';

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -1,8 +1,8 @@
 $breadcrumb-chevron-height: 0.65rem;
 
 .breadcrumb {
-  align-items: center;
   display: flex;
+  align-items: center;
   padding: 1rem 0;
 
   &__items {
@@ -38,17 +38,13 @@ $breadcrumb-chevron-height: 0.65rem;
       &:not(:last-child):after {
         @include icon('chevron-right', $breadcrumb-chevron-height, $breadcrumb-chevron-height);
         content: '';
-        vertical-align: middle;
         margin: 0;
+        width: 1.25rem;
 
         // We have to override the icon settings so it renders correctly in ie11
         background-position: center center;
-        width: 1.25rem;
+        vertical-align: middle;
       }
-    }
-
-    &--current {
-      color: $color-text-light;
     }
   }
 

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -15,7 +15,7 @@ $breadcrumb-chevron-height: 0.65rem;
     margin: 0;
     white-space: nowrap; // Stop items from wrapping, break on chevron only
 
-    &:not(:nth-last-child(2)) {
+    &:not(:nth-last-child(1)) {
       display: none;
     }
 
@@ -31,7 +31,7 @@ $breadcrumb-chevron-height: 0.65rem;
         content: none;
       }
 
-      &:not(:nth-last-child(2)) {
+      &:not(:nth-last-child(1)) {
         display: inline-block;
       }
 

--- a/src/components/breadcrumb/_macro.njk
+++ b/src/components/breadcrumb/_macro.njk
@@ -1,9 +1,9 @@
 {% macro onsBreadcrumb(params) %}
   <nav class="breadcrumb" aria-label="{{ params.ariaLabel }}" {% if params.id %} id="{{ params.id }}"{% endif %}>
-    <ol class="breadcrumb__items">
+    <ol class="breadcrumb__items u-fs-s">
         {% for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) %}
             {% if not item.current %}
-                <li id="breadcrumb-{{ loop.index }}" class="breadcrumb__item u-fs-s">
+                <li id="breadcrumb-{{ loop.index }}" class="breadcrumb__item">
                         <a href="{{ item.url }}" class="breadcrumb__link">{{ item.text }}</a>
                 </li>
             {% endif %}

--- a/src/components/breadcrumb/examples/breadcrumb-single/index.njk
+++ b/src/components/breadcrumb/examples/breadcrumb-single/index.njk
@@ -1,0 +1,17 @@
+{% from "components/breadcrumb/_macro.njk" import onsBreadcrumb %}
+{{
+    onsBreadcrumb({
+        "ariaLabel": 'Breadcrumb',
+        "itemsList": [
+            {
+                "url": '/',
+                "text": 'Home'
+            },
+            {
+                "url": '/components/breadcrumbs',
+                "text": 'Breadcrumbs',
+                "current": true
+            }
+        ]
+    })
+}}

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -11,8 +11,7 @@ A breadcrumb trail consists of a list of links to the parent pages of the curren
 }}
 
 ## When to use this component
-Use the breadcrumbs component when you need to help users understand and move between the multiple levels of a website. We recomend not using it on
-pages that are only one level deep in the page hierarchy. As we would like to avoid 'home' being the only link, when it’s directly under a menu that also has ‘home’.
+Use the breadcrumbs component when you need to help users understand and move between the multiple levels of a website.
 
 ## When not to use this component
 Don’t use the breadcrumbs component on websites with a flat structure, or to show progress through a linear journey or transaction.

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -11,7 +11,8 @@ A breadcrumb trail consists of a list of links to the parent pages of the curren
 }}
 
 ## When to use this component
-Use the breadcrumbs component when you need to help users understand and move between the multiple levels of a website.
+Use the breadcrumbs component when you need to help users understand and move between the multiple levels of a website. We recomend not using it on
+pages that are only one level deep in the page hierarchy. As we would like to avoid 'home' being the only link, when it’s directly under a menu that also has ‘home’.
 
 ## When not to use this component
 Don’t use the breadcrumbs component on websites with a flat structure, or to show progress through a linear journey or transaction.

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -38,6 +38,16 @@ If you’re using other navigational elements on the page, such as a sidebar, co
     })
 }}
 
+## Variants
+
+### Single breadcrumb
+
+When the component only has a single breadcrumb it will display like this.
+
+{{
+    patternlibExample({"path": "components/breadcrumb/examples/breadcrumb-single/index.njk"})
+}}
+
 ## Research on this component
 Based uppon [W3 principles](https://w3c.github.io/aria-practices/examples/breadcrumb/index.html)
 

--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -31,7 +31,6 @@ $hub-row-spacing: 1.3rem;
 
     &--error {
       border-left: 8px solid $color-errors;
-
       background: $color-errors-tint;
     }
   }
@@ -45,7 +44,10 @@ $hub-row-spacing: 1.3rem;
   &__values,
   &__actions {
     padding: 0 0 $summary-row-spacing;
+    word-wrap: break-word;
     vertical-align: top;
+    hyphens: auto;
+    overflow-wrap: break-word;
   }
 
   &__item-title {


### PR DESCRIPTION
### What is the context of this PR?
- Removed redundant css
- Added guidance on when to use breadcrumbs
- Fixed bug on mobiles that was showing the last but one link, not the last one
- Updated style
- Changed desktop version to display left chevron before link if only one link

### How to review 
- Tests pass
- Check mobile version shows correct link