### PR TITLE
Replaced block with inline-block to fix the bug with the bare list

### DIFF
--- a/src/components/lists/_list.scss
+++ b/src/components/lists/_list.scss
@@ -56,6 +56,6 @@ $list-inline-spacing: 2rem;
 }
 
 .list__link {
-  display: block;
+  display: inline-block;
   overflow: hidden;
 }


### PR DESCRIPTION
### What is the context of this PR?
I changed the display property to fix a bug with the bare list.

### How to review 

From this:
![image](https://user-images.githubusercontent.com/4989027/87539507-eacdbd00-c695-11ea-9b7d-5a874def7774.png)
To this:
![image](https://user-images.githubusercontent.com/4989027/87539437-cd98ee80-c695-11ea-9c77-356c4c935399.png)
