### PR TITLE
Fix bug with ghost button example being transparent

### DIFF
--- a/src/components/button/examples/button-ghost/index.njk
+++ b/src/components/button/examples/button-ghost/index.njk
@@ -2,7 +2,7 @@
 fullWidth: true
 ---
 {% from "components/button/_macro.njk" import onsButton %}
-<div style="padding: 1rem 1.5rem; background: $color-astral-blue">
+<div style="padding: 1rem 1.5rem; background: #3b7a9e">
     {{
         onsButton({
             "type": 'button',


### PR DESCRIPTION
### What is the context of this PR?
After the recent CSS update the example for ghost buttons became transparent as when the example was opened in a new window it no longer had access to the colour variables.

### How to review 
- Check to make sure ghost button example displays correctly when opening in a new window