### PR TITLE
Added background style to all headings containing emphasis tag

### DIFF
--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -21,6 +21,9 @@ h5,
 h6 {
   margin: 0 0 1rem;
   line-height: 1.2;
+  & em {
+    background-color: $color-highlight;
+  }
 }
 
 code {


### PR DESCRIPTION
### What is the context of this PR?
- Runner needs to be able to put highlight styling on h1 and h2 headings without adding the "highlight" class.  (as it causes issues for translation)
- There is no specific classes on the general template in runner to target, so we would have to style any heading that contained an `<em>`

### How to review 
- Check any heading containing an `<em>` is styled as the 'highlight' pattern specifies
- Check no other content containing an `<em>` is styled as the 'highlight' pattern specifies 