### PR TITLE
Updated default text in data attributes to match initial values

### DIFF
--- a/src/patterns/download-resources/examples/download-resources/index.njk
+++ b/src/patterns/download-resources/examples/download-resources/index.njk
@@ -89,7 +89,7 @@ layout: none
                                     <button class="adv-filter__reset js-adv-filter__reset" type="reset">Reset all filters</button>
                                     
                                     <!-- Audience -->
-                                    <div class="adv-filter__item js-adv-filter__item" data-default-text="All audience" data-multi-select-text="{n} filters selected">
+                                    <div class="adv-filter__item js-adv-filter__item" data-default-text="All audiences" data-multi-select-text="{n} filters selected">
 
                                         <fieldset class="fieldset" aria-controls="adv-filter-gallery">
 
@@ -159,7 +159,7 @@ layout: none
                                     </div>
 
                                     <!-- Type -->
-                                    <div class="adv-filter__item js-adv-filter__item" data-default-text="All type" data-multi-select-text="{n} filters selected">
+                                    <div class="adv-filter__item js-adv-filter__item" data-default-text="All types" data-multi-select-text="{n} filters selected">
 
                                         <fieldset class="fieldset" aria-controls="adv-filter-gallery">
 


### PR DESCRIPTION
The active filters are set as:

'All audiences, All types, All languages'

When clicking the reset button they are reset using Javascript. 

This text did not match, so I have updated this.