### PR TITLE
Address autosuggest - Added a check for input values and toggle the mode appropriately

### DIFF
--- a/src/components/address/_macro.njk
+++ b/src/components/address/_macro.njk
@@ -20,13 +20,13 @@
                 {% if params.line1 is defined %}
                 {{
                     onsInput({
-                        "id": params.id + "-line-1",
+                        "id": params.id + "-line1",
                         "value": params.line1.value,
                         "label": {
                             "text": params.line1.label
                         },
-                        "classes": "input--w-20@m js-address-line-1",
-                        "name": params.id + "-line-1",
+                        "classes": "input--w-20@m js-address-line1",
+                        "name": params.id + "-line1",
                         "error": params.line1.error
                     })
                 }}
@@ -34,13 +34,13 @@
                 {% if params.line2 is defined %}
                 {{
                     onsInput({
-                        "id": params.id + "-line-2",
+                        "id": params.id + "-line2",
                         "value": params.line2.value,
                         "label": {
                             "text": params.line2.label
                         },
-                        "classes": "input--w-20@m js-address-line-2",
-                        "name": params.id + "-line-2"
+                        "classes": "input--w-20@m js-address-line2",
+                        "name": params.id + "-line2"
                     })
                 }}
                 {% endif %}

--- a/src/components/input/autosuggest/autosuggest.address.setter.js
+++ b/src/components/input/autosuggest/autosuggest.address.setter.js
@@ -2,8 +2,8 @@ import triggerEvent from 'js/utils/trigger-event';
 import AddressError from './autosuggest.address.error';
 
 const classAutosuggestInput = 'js-autosuggest-input';
-const classLine1 = 'js-address-line-1';
-const classLine2 = 'js-address-line-2';
+const classLine1 = 'js-address-line1';
+const classLine2 = 'js-address-line2';
 const classTown = 'js-address-town';
 const classPostcode = 'js-address-postcode';
 const classSearch = 'js-address-input__search';
@@ -41,12 +41,10 @@ export default class AddressSetter {
     }
 
     // Set mode
-    if (!(this.line1.value || this.line2.value || this.town.value || this.postcode.value)) {
+    if (this.line1.value || this.line2.value || this.town.value || this.postcode.value || this.errorPanel) {
+      this.setManualMode(true, false);
+    } else {
       this.toggleMode();
-    }
-
-    if (this.errorPanel) {
-      this.setManualMode(true, true);
     }
   }
 


### PR DESCRIPTION
### What is the context of this PR?
Small changes to address autosuggest:

- Consistent naming of id/params for address-line1 and address-line2.
- Check for manual field input values and toggle mode appropriately.
