### PR TITLE
Adjustments made to warning panel

### DIFF
--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -79,9 +79,10 @@
 
   &--warn & {
     &__body {
-      padding-top: 0.1rem;
+      padding-top: 0.222rem; // 4px
       padding-left: 1.8rem;
       font-weight: $font-weight-bold;
+      min-height: 2rem; // Height of icon
     }
 
     &__icon {


### PR DESCRIPTION
Fix panel text alignment and collapse.

Text was not correctly aligned centrally. The minimum height should be the height of the icon. Due to the icon being absolutely positioned a min-height was required.

**Problem**

<img width="1024" alt="Screenshot 2020-08-17 at 09 53 12" src="https://user-images.githubusercontent.com/4989027/90380985-a8244980-e074-11ea-9c81-9ffa8f07d613.png">

<img width="836" alt="Screenshot 2020-08-17 at 09 39 14" src="https://user-images.githubusercontent.com/4989027/90381260-051fff80-e075-11ea-92c2-c5259c72ab78.png">

**Fixed**
![image](https://user-images.githubusercontent.com/4989027/90381445-4c0df500-e075-11ea-9c4c-ab1a3c462cc0.png)

![image](https://user-images.githubusercontent.com/4989027/90381518-6516a600-e075-11ea-98ad-e0cc1a55d74e.png)


