### PR TITLE
Fix release 23 runner issues

### DIFF
--- a/src/components/label/_macro.njk
+++ b/src/components/label/_macro.njk
@@ -19,7 +19,7 @@
 
         {% if params.inputType is defined %}
             {% if params.inputType == "checkbox" or params.inputType == "radio" %}
-                {%- if params.description is defined %}
+                {%- if params.description is defined and params.description %}
                     <br>
                     {{ field | safe }}
                 {% endif -%}
@@ -27,7 +27,7 @@
             </label>
         {% else %}
             </label>
-            {%- if params.description is defined %}
+            {%- if params.description is defined and params.description %}
                 {{ field | safe }}
             {% endif -%}
         {% endif %}

--- a/src/components/lists/_macro.njk
+++ b/src/components/lists/_macro.njk
@@ -10,10 +10,10 @@
         {%- for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) -%}
             <li class="list__item {{ item.listclass }}" {% if item.current is defined %}aria-current="true"{% endif %}>
                 {%- if item.index is defined or item.prefix is defined or item.prefixIcon is defined -%}
-                    <span class="list__prefix"{% if listEl !== 'ol' %} aria-hidden="true"{% endif %}>
+                    <span class="list__prefix"{% if listEl != 'ol' %} aria-hidden="true"{% endif %}>
                     {%- if item.prefixText is defined -%}
                         {{- item.prefixText -}}.
-                    {%- elif (item.index is defined and listEl !== 'ol') or (item.index is defined and listEl == 'ol' and 'list--bare' in classes) -%}
+                    {%- elif (item.index is defined and listEl != 'ol') or (item.index is defined and listEl == 'ol' and 'list--bare' in classes) -%}
                         {{- loop.index -}}.
                     {% elif item.prefixIcon is defined %}
                         {% from "components/icons/_macro.njk" import onsIcon %}


### PR DESCRIPTION
### What is the context of this PR?
Fixes issues eq-questionnaire-runner has when using the latest design system release (23.0.1).

Issues were:
- Pages couldn't be rendered as Jinja doesn't support the `!==` comparator
- Checkbox and Radios with no description displayed a description of `None`

### How to review 
Check the changes are appropriate and that eq-questionnaire-runner works as expected with these changes.