### PR TITLE
Update Skip Link style

### DIFF
--- a/src/components/skip-to-content/_macro.njk
+++ b/src/components/skip-to-content/_macro.njk
@@ -1,5 +1,3 @@
 {% macro onsSkipToContent(params) %}
-    <div class="skip">
-        <a class="skip__link" href="{{ params.url }}">{{ params.text }}</a>
-    </div>
+    <a class="skip__link" href="{{ params.url }}">{{ params.text }}</a>
 {% endmacro %}

--- a/src/components/skip-to-content/_skip.scss
+++ b/src/components/skip-to-content/_skip.scss
@@ -1,15 +1,6 @@
-.skip {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-}
-
 .skip__link {
   display: block;
-  position: absolute;
   top: 0;
-  width: 100%;
   height: 1px;
   overflow: hidden;
   font-size: 1.1rem;

--- a/src/components/skip-to-content/_skip.scss
+++ b/src/components/skip-to-content/_skip.scss
@@ -8,16 +8,14 @@
 .skip__link {
   display: block;
   position: absolute;
-  top: -30px;
+  top: 0;
   width: 100%;
   height: 1px;
   overflow: hidden;
   font-size: 1.1rem;
   font-weight: $font-weight-bold;
-  transition: top 100ms;
 
   &:focus {
-    top: 0;
     padding: 1rem;
     height: auto;
     max-height: 20em;

--- a/src/components/skip-to-content/_skip.scss
+++ b/src/components/skip-to-content/_skip.scss
@@ -1,5 +1,4 @@
 .skip {
-  z-index: 999999;
   position: absolute;
   top: 0;
   right: 0;
@@ -13,8 +12,6 @@
   width: 100%;
   height: 1px;
   overflow: hidden;
-  background: $color-dark-blue;
-  color: $color-white;
   font-size: 1.1rem;
   font-weight: $font-weight-bold;
   transition: top 100ms;
@@ -24,7 +21,10 @@
     padding: 1rem;
     height: auto;
     max-height: 20em;
-    box-shadow: 0 3px 0 0 $color-white;
-    color: $color-white;
+    outline: none;
+    background-color: $color-focus;
+    box-shadow: 0;
+    color: $color-focus-text;
+    text-decoration: underline;
   }
 }

--- a/src/scss/base/_global.scss
+++ b/src/scss/base/_global.scss
@@ -35,7 +35,7 @@ a {
     color: $color-links-hover;
     text-decoration: none;
   }
-  &:focus:not(.btn--link):not(.btn--ghost):not(.js-clear-btn):not(.download__thumbnail--link):not(.header__logo-link):not(.header__title-link):not(.tab--row) {
+  &:focus:not(.btn--link):not(.btn--ghost):not(.js-clear-btn):not(.download__thumbnail--link):not(.header__logo-link):not(.header__title-link):not(.tab--row):not(.skip__link) {
     outline: 3px solid transparent;
     background-color: $color-focus;
     box-shadow: 0 -2px $color-focus, 0 4px $color-focus-text;


### PR DESCRIPTION
### What is the context of this PR?
Update 'Skip to content' banner to match GDS and improve accessibility. Updates are to stop the Skip Link overlapping other content and change the style to match GDS.

### How to review 
- Check Skip Link looks like the GDS equivalent
- Check that Skip Link no longer appears over the top of the page content