### PR TITLE
Fix Cookie Banner button spacing at 500px

### DIFF
--- a/src/components/cookies-banner/_cookies-banner.scss
+++ b/src/components/cookies-banner/_cookies-banner.scss
@@ -14,7 +14,7 @@
   }
 
   &__btn {
-    @include mq('xs', 's') {
+    @include mq('xs', 499px) {
       display: block;
       width: 100%;
     }


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #283 

### How to review 
Check that cookie banner buttons display correctly when screen size is reduced to 500px