### PR TITLE
Change Checkboxes to snap to full width on 's' screen size

### DIFF
--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -17,7 +17,7 @@
       margin-bottom: 0;
     }
 
-    @include mq(m) {
+    @include mq(s) {
       width: auto;
       min-width: 20rem;
     }


### PR DESCRIPTION
### What is the context of this PR?
Change Checkboxes to snap to full width on 's' screen size to conform with other components. Fixes: #974 

### How to review 
Check that Checkboxes on snap to full width only when the screen size is reduced to 500px width