### PR TITLE
Fix spacing for Fields

### DIFF
--- a/src/components/address/_macro.njk
+++ b/src/components/address/_macro.njk
@@ -90,7 +90,7 @@
                     {{
                         onsInput({
                             "id": params.id + "-autosuggest",
-                            "classes": "address-input__autosuggest js-autosuggest-input input--w-50",
+                            "classes": "address-input__autosuggest js-autosuggest-input input--w-50 u-mb-s",
                             "label": {
                                 "text": params.autosuggest.label.text,
                                 "classes": "js-autosuggest-label"

--- a/src/components/field/_field.scss
+++ b/src/components/field/_field.scss
@@ -1,6 +1,5 @@
 .field {
   position: relative;
-  margin-bottom: 1rem;
 
   &__other {
     display: none;
@@ -11,12 +10,6 @@
     input:checked ~ & {
       display: block;
     }
-  }
-}
-
-.mutually-exclusive {
-  .field {
-    margin-bottom: 0rem;
   }
 }
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #956 
Because of this fix it will also bring Password, Textarea and Select into line with other components with regards to spacing. None of these components will automatically have a margin bottom of 1rem anymore which is the case with other components in the Design System.

### How to review 
- Check Field spacing in Fieldsets
- Check spacing on Password, Textarea and Select are correct