### PR TITLE
Added buttonStyle attribute to fix missing icon

### DIFF
--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -54,7 +54,8 @@
                                     "value": params.button.value,
                                     "attributes": params.button.attributes,
                                     "url": params.button.url,
-                                    "exit": params.button.exit
+                                    "exit": params.button.exit,
+                                    "buttonStyle": params.button.buttonStyle
                                 })
                             }}
                         </div>


### PR DESCRIPTION
### What is the context of this PR?
Added additional button attribute to fix missing icon in page template footer for Save and sign out button.

### How to review 
See the icon that was not previously shown.

**From this:**
![image](https://user-images.githubusercontent.com/4989027/93450610-1192b480-f8ce-11ea-9726-0a9d77da6e9b.png)

**To this:**
![image](https://user-images.githubusercontent.com/4989027/93450559-0770b600-f8ce-11ea-8978-e518e64cc0f2.png)
