### PR TITLE
Change Census link hover colour

### DIFF
--- a/src/scss/settings/_census.scss
+++ b/src/scss/settings/_census.scss
@@ -1,4 +1,5 @@
 // Census brand
+$color-black: #222;
 $color-branded: #902082;
 $color-branded-tint: rgba(227, 77, 219, 0.15);
 $color-branded-secondary: #ce0f69;
@@ -10,3 +11,4 @@ $color-branded-supporting-tint: rgba(#00a3a6, 0.2);
 $color-header: $color-branded;
 $cta-bg: $color-branded-tint;
 $color-tag-bg: $color-branded-supporting-tint;
+$color-links-hover: $color-black;


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #980 

### How to review 
- Check links on pages with a Census theme are black when hovered
- Check links on pages without a Census theme are blue when hovered