### PR TITLE
Fix Related Links not using Census style and tidy css

### DIFF
--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -18,16 +18,16 @@
       <div class="header__top" role="banner">
           <div class="container{{ ' container--full-width' if params.fullWidth }}{{ ' container--wide' if params.wide }}">
               <div class="header__grid-top grid grid--gutterless grid--flex grid--between grid--vertical-center grid--no-wrap {{ 'header__grid-top-' + params.customHeaderLogo if params.customHeaderLogo }}">
-                  
+
                   <div class="grid__col col-auto">
-                    {% if params.logoHref is defined and params.logoHref %}<a class="header__logo-link" href="{{ params.logoHref }}">{% endif %}                      
+                    {% if params.logoHref is defined and params.logoHref %}<a class="header__logo-link" href="{{ params.logoHref }}">{% endif %}
                       <picture>
                         <source media="(max-width: 499px)" srcset="{{ params.assetsURL if params.assetsURL is defined and params.assetsURL }}/img/{{ params.mobileLogo | default('ons-logo-stacked-pos-' + currentLanguageISOCode) }}.svg" alt="{{ params.logoAlt | default('Office for National Statistics logo') }}">
                         <img class="header__logo" src="{{ params.assetsURL if params.assetsURL is defined and params.assetsURL }}/img/{{ params.logo | default('ons-logo-pos-' + currentLanguageISOCode) }}.svg" alt="{{ params.logoAlt | default('Office for National Statistics logo') }}">
                       </picture>
                     {% if params.logoHref is defined and params.logoHref %}</a>{% endif %}
                   </div>
-                  
+
                   {% if params.language is defined and params.language or params.serviceLinks is defined and params.serviceLinks %}
                       <div class="header__links grid__col col-auto">
                           {% if params.language is defined and params.language %}

--- a/src/scss/helpers/_functions.scss
+++ b/src/scss/helpers/_functions.scss
@@ -1,11 +1,11 @@
 @function ems($pxval, $base: $base) {
-  $emSize: $pxval / $base;
-  @return #{$emSize}em;
+  $em-size: $pxval / $base;
+  @return #{$em-size}em;
 }
 
 @function rems($pxval, $base: $base) {
-  $remSize: $pxval / $base;
-  @return #{$remSize}rem;
+  $rem-size: $pxval / $base;
+  @return #{$rem-size}rem;
 }
 
 @function strip-unit($num) {
@@ -22,7 +22,7 @@
 
 @function map-set($map, $key, $value) {
   $new: (
-    $key: $value
+    $key: $value,
   );
 
   @return map-merge($map, $new);

--- a/src/scss/patternlib.scss
+++ b/src/scss/patternlib.scss
@@ -1,6 +1,5 @@
 @import 'vars/index';
 @import 'helpers/*.scss';
-@import 'base/*.scss';
 
 @import '../views/partials/**/*.scss';
 @import '../styles/page-template/examples/block-areas/block-areas';

--- a/src/views/layouts/_master.njk
+++ b/src/views/layouts/_master.njk
@@ -7,7 +7,7 @@
 {% endif %}
 
 {% if pageConfig.lang is defined and pageConfig.lang %}
-   {% set pageConfig =  pageConfig | setAttributes({
+   {% set pageConfig = pageConfig | setAttributes({
        "language": {
            "languages": [
                 {
@@ -22,7 +22,7 @@
 {% if example is defined and example %}
     {% set bodyClasses = bodyClasses + " patternlib-page--example" %}
     {% if page.theme is defined and page.theme %}
-        {% set pageConfig =  pageConfig | setAttributes({
+        {% set pageConfig = pageConfig | setAttributes({
             "theme": page.theme
         }) %}
     {% endif %}
@@ -32,7 +32,7 @@
     {% set bodyClasses = bodyClasses + " u-p-no" %}
 {% endif %}
 
-{% set pageConfig =  pageConfig | setAttribute("bodyClasses", bodyClasses) %}
+{% set pageConfig = pageConfig | setAttribute("bodyClasses", bodyClasses) %}
 
 {% block head %}
     <link rel="stylesheet" href="/css/patternlib.css">


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #1008 
This removes the base.css being imported twice into DS examples because it has already been imported before in the main.css for the page. When census.css was being used instead it would then overwrite the census style by still importing the base.css again.
It also removes some whitespace and tidies up some variables to make the naming style consistent with others

### How to review 
Because the change in this affects all examples they all need to be checked to make sure they look and work correctly