### PR TITLE
Fix autosuggest macro options for Jinja rendering

### DIFF
--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -128,7 +128,7 @@
 
                         {% for row in params.rows %}
 
-                           {% if params.OGLLink is not defined and params.OGLLink %}
+                           {% if params.OGLLink is not defined %}
 
                                 {% if loop.last %}
                                     </div>

--- a/src/components/input/_autosuggest-macro.njk
+++ b/src/components/input/_autosuggest-macro.njk
@@ -21,7 +21,7 @@
         data-error-select="{{ params.errorMessageSelect }}"
         data-error-api="{{ params.errorMessageAPI }}"
         data-error-api-link-text="{{ params.errorMessageAPILinkText }}"
-        {% if params.options %}
+        {% if params.options is defined and params.options %}
         {% if params.options.oneYearAgo is defined and params.options.oneYearAgo %}data-options-one-year-ago="true"{% endif %}
         {% if params.options.regionCode is defined and params.options.regionCode %}data-options-region-code="{{ params.options.regionCode }}"{% endif %}
         {% if params.options.addressType is defined and params.options.addressType %}data-options-address-type="{{ params.options.addressType }}"{% endif %}

--- a/src/components/input/_autosuggest-macro.njk
+++ b/src/components/input/_autosuggest-macro.njk
@@ -21,9 +21,11 @@
         data-error-select="{{ params.errorMessageSelect }}"
         data-error-api="{{ params.errorMessageAPI }}"
         data-error-api-link-text="{{ params.errorMessageAPILinkText }}"
+        {% if params.options %}
         {% if params.options.oneYearAgo is defined and params.options.oneYearAgo %}data-options-one-year-ago="true"{% endif %}
-        {% if params.options.regionCode and params.options.regionCode is defined %}data-options-region-code="{{ params.options.regionCode }}"{% endif %}
-        {% if params.options.addressType and params.options.addressType is defined %}data-options-address-type="{{ params.options.addressType }}"{% endif %}
+        {% if params.options.regionCode is defined and params.options.regionCode %}data-options-region-code="{{ params.options.regionCode }}"{% endif %}
+        {% if params.options.addressType is defined and params.options.addressType %}data-options-address-type="{{ params.options.addressType }}"{% endif %}
+        {% endif %}
     >
         {{ content | safe }}
         <div class="autosuggest-input__results js-autosuggest-results">


### PR DESCRIPTION
### What is the context of this PR?
Checks that `options` key exists before accessing properties, otherwise Jinja fails to render when `options` is not provided.

Currently the [pull request](https://github.com/ONSdigital/eq-questionnaire-runner/pull/309) to update eq-questionnaire-runner to v25.0.0 of the design system is failing because of this.

### How to review 
Test the macro in eq-questionniare-runner with the test_textfield_suggestions schema.