### PR TITLE
Taken out nowrap property to allow list items to have a natural flow

### DIFF
--- a/src/components/lists/_list.scss
+++ b/src/components/lists/_list.scss
@@ -3,7 +3,6 @@
   padding: 0 0 0 1.5rem;
 
   &__item {
-    white-space: nowrap;
     &:last-child {
       margin: 0;
     }


### PR DESCRIPTION
This fixes bug #1048 and #1017 

This will also fix the timeline bug because it currently uses the list pattern.

**Before**
![image](https://user-images.githubusercontent.com/4989027/94567095-fd9e6980-0262-11eb-941c-249d36670af5.png)

**After**
![image](https://user-images.githubusercontent.com/4989027/94566959-dc3d7d80-0262-11eb-9d70-9f3d31442f18.png)
