### PR TITLE
Added an example of social list icon usage

### DIFF
--- a/src/styles/typography/icons/examples/icons-social-list/index.njk
+++ b/src/styles/typography/icons/examples/icons-social-list/index.njk
@@ -1,0 +1,23 @@
+{% from "components/lists/_macro.njk" import onsList %}
+{{
+    onsList({
+        "classes": 'list--bare',
+        "itemsList": [
+            {
+                "url": '#0',
+                "text": 'Twitter',
+                "prefixIcon": 'twitter'
+            },
+            {
+                "url": '#0',
+                "text": 'Facebook',
+                "prefixIcon": 'facebook'
+            },
+            {
+                "url": '#0',
+                "text": 'Instagram',
+                "prefixIcon": 'instagram'
+            }
+        ]
+    })
+}}

--- a/src/styles/typography/index.njk
+++ b/src/styles/typography/index.njk
@@ -144,6 +144,11 @@ __Our current icon set can be used in the following scenarios:__
 {{
     patternlibExample({"path": "styles/typography/icons/examples/icons-list/index.njk", "componentFolderPath": "components/lists" })
 }}
+
+### List with social icons
+{{
+    patternlibExample({"path": "styles/typography/icons/examples/icons-social-list/index.njk", "componentFolderPath": "components/lists" })
+}}
 __How to use:__ Set `icon` to the name of the icon you want to use on each list item.
 
 ### Link with external link icon


### PR DESCRIPTION
Added an example of a list using the social icons.

**Example**
<img width="160" alt="Screenshot 2020-10-05 at 10 23 03" src="https://user-images.githubusercontent.com/4989027/95062397-d0373d00-06f4-11eb-9958-559dea2bd8a4.png">

