### PR TITLE
Allow Selects to be used in Radio buttons

### DIFF
--- a/src/components/checkboxes/_checkbox-macro.njk
+++ b/src/components/checkboxes/_checkbox-macro.njk
@@ -23,7 +23,9 @@
         }) }}
 
         {% if params.other is defined and params.other %}
+            {% set otherType = params.other.otherType | default('input') %}
             <span class="checkbox__other {{ 'checkbox__other--open' if params.other.open }}" id="{{ params.id }}-other-wrap">
+            {% if otherType == "input" %}
                 {% from "components/input/_macro.njk" import onsInput %}
                 {{
                     onsInput({
@@ -41,6 +43,23 @@
                         "value": params.other.value
                     })
                 }}
+            {% elif otherType == "select" %}
+                {% from "components/select/_macro.njk" import onsSelect %}
+                {{
+                    onsSelect({
+                        "id": params.other.id,
+                        "name": params.other.name,
+                        "options": params.other.options,
+                        "label": {
+                            "id": params.other.id + "-label",
+                            "text": params.other.label.text,
+                            "classes": 'u-fs-s--b'
+                        },
+                        "dontWrap": true,
+                        "value": params.other.value
+                    })
+                }}
+            {% endif %}
             </span>
         {% endif %}
     </span>

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -79,6 +79,10 @@ $checkbox-label-vertical-padding: 0.75rem;
   &__other {
     display: block;
     padding: 0 $checkbox-padding $checkbox-padding;
+
+    .input--select {
+      width: 18.5rem !important;
+    }
   }
 
   &__input:checked + &__label:before {

--- a/src/components/checkboxes/_macro-options.md
+++ b/src/components/checkboxes/_macro-options.md
@@ -12,15 +12,16 @@
 
 ## Checkbox
 
-| Name         | Type                                 | Required | Description                                                                        |
-| ------------ | ------------------------------------ | -------- | ---------------------------------------------------------------------------------- |
-| id           | string                               | true     | The id of the checkbox                                                             |
-| name         | string                               | true     | The name of the checkbox                                                           |
-| value        | string                               | true     | The value of the checkbox                                                          |
-| classes      | string                               | false    | Classes to apply to the checkbox                                                   |
-| inputClasses | string                               | false    | Classes to apply to the checkbox input                                             |
-| checked      | boolean                              | false    | Whether the checkbox should be checked                                             |
-| label        | `Label` [_(ref)_](/components/label) | true     | Settings for the checkbox label                                                    |
-| other        | `Input` [_(ref)_](/components/input) | false    | Object with settings for other input                                               |
-| attributes   | object                               | false    | HTML attributes (for example data attributes) to add to the checkbox input element |
-| error        | `Error` [_(ref)_](/components/error) | false    | Configuration for validation errors                                                |
+| Name         | Type                                                                           | Required                       | Description                                                                        |
+| ------------ | ------------------------------------------------------------------------------ | ------------------------------ | ---------------------------------------------------------------------------------- |
+| id           | string                                                                         | true                           | The id of the checkbox                                                             |
+| name         | string                                                                         | true                           | The name of the checkbox                                                           |
+| value        | string                                                                         | true                           | The value of the checkbox                                                          |
+| classes      | string                                                                         | false                          | Classes to apply to the checkbox                                                   |
+| inputClasses | string                                                                         | false                          | Classes to apply to the checkbox input                                             |
+| checked      | boolean                                                                        | false                          | Whether the checkbox should be checked                                             |
+| label        | `Label` [_(ref)_](/components/label)                                           | true                           | Settings for the checkbox label                                                    |
+| other        | `Input` [_(ref)_](/components/input) or `Select` [_(ref)_](/components/select) | false                          | Object with settings for other input or select                                     |
+| otherType    | string                                                                         | false (true if other provided) | Can be set to `select` or `input` to set what other input you want in a radio      |
+| attributes   | object                                                                         | false                          | HTML attributes (for example data attributes) to add to the checkbox input element |
+| error        | `Error` [_(ref)_](/components/error)                                           | false                          | Configuration for validation errors                                                |

--- a/src/components/checkboxes/_macro.njk
+++ b/src/components/checkboxes/_macro.njk
@@ -35,6 +35,8 @@
                                 "id": checkbox.other.id,
                                 "name": checkbox.other.name,
                                 "type": checkbox.other.type,
+                                "otherType": checkbox.other.otherType,
+                                "options": checkbox.other.options,
                                 "classes": checkbox.other.classes | default('') + exclusiveClass | default(''),
                                 "attributes": checkbox.other.attributes,
                                 "label": {

--- a/src/components/checkboxes/examples/checkboxes-select/index.njk
+++ b/src/components/checkboxes/examples/checkboxes-select/index.njk
@@ -1,0 +1,77 @@
+{% from "components/checkboxes/_macro.njk" import onsCheckboxes %}
+{{
+    onsCheckboxes({
+        "legend": "Select your favourite topping",
+        "checkboxesLabel": "Select all that apply",
+        "name": "food-other",
+        "checkboxes": [
+            {
+                "id": "bacon-other",
+                "label": {
+                    "text": "Bacon"
+                },
+                "value": "bacon"
+            },
+            {
+                "id": "olives-other",
+                "label": {
+                    "text": "Olives"
+                },
+                "value": "olives"
+            },
+            {
+                "id": "other-radio",
+                "label": {
+                    "text": "Other",
+                    "description": "An answer is required"
+                },
+                "value": "other",
+                "other": {
+                    "open": true,
+                    "otherType": "select",
+                    "id": "other-select",
+                    "name": "other-answer",
+                    "label": {
+                        "text": "Please specify other"
+                    },
+                    "options": [
+                        {
+                            "value": "",
+                            "text": "Select an option",
+                            "disabled": true,
+                            "selected": true
+                        },
+                        {
+                            "value": "bart",
+                            "text": "Bart Simpson"
+                        },
+                        {
+                            "value": "homer",
+                            "text": "Homer Simpson"
+                        },
+                        {
+                            "value": "marge",
+                            "text": "Marge Simpson"
+                        },
+                        {
+                            "value": "lisa",
+                            "text": "Lisa Simpson"
+                        },
+                        {
+                            "value": "maggie",
+                            "text": "Maggie Simpson"
+                        },
+                        {
+                            "value": "ned",
+                            "text": "Ned Flanders"
+                        },
+                        {
+                            "value": "7-dwarves",
+                            "text": "The 7 Dwarves: Grumpy, Happy, Sleepy, Bashful, Sneezy, Dopey, Doc"
+                        }
+                    ]
+                }
+            }
+        ]
+    })
+}}

--- a/src/components/checkboxes/index.njk
+++ b/src/components/checkboxes/index.njk
@@ -40,6 +40,13 @@ This variant of the 'Other' checkbox input type shows the input instead of waiti
     patternlibExample({"path": "components/checkboxes/examples/checkboxes-other-open/index.njk"})
 }}
 
+### Other - select
+This variant of the 'Other' checkboxes input type uses a select instead of an input.
+
+{{
+    patternlibExample({"path": "components/checkboxes/examples/checkboxes-select/index.njk"})
+}}
+
 
 ## Research on this components
 {% call onsPanel() %}

--- a/src/components/radios/_macro-options.md
+++ b/src/components/radios/_macro-options.md
@@ -15,15 +15,16 @@
 
 ## Radio
 
-| Name       | Type                                 | Required | Description                                                                     |
-| ---------- | ------------------------------------ | -------- | ------------------------------------------------------------------------------- |
-| id         | string                               | true     | The id of the radio                                                             |
-| name       | string                               | true     | The name of the radio                                                           |
-| value      | string                               | true     | The value of the radio                                                          |
-| checked    | boolean                              | false    | Whether the radio should be checked                                             |
-| label      | `Label` [_(ref)_](/components/label) | true     | Settings for the radio label                                                    |
-| other      | `Input` [_(ref)_](/components/input) | false    | Object with settings for other input                                            |
-| attributes | object                               | false    | HTML attributes (for example data attributes) to add to the radio input element |
+| Name       | Type                                                                           | Required                       | Description                                                                     |
+| ---------- | ------------------------------------------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------- |
+| id         | string                                                                         | true                           | The id of the radio                                                             |
+| name       | string                                                                         | true                           | The name of the radio                                                           |
+| value      | string                                                                         | true                           | The value of the radio                                                          |
+| checked    | boolean                                                                        | false                          | Whether the radio should be checked                                             |
+| label      | `Label` [_(ref)_](/components/label)                                           | true                           | Settings for the radio label                                                    |
+| other      | `Input` [_(ref)_](/components/input) or `Select` [_(ref)_](/components/select) | false                          | Object with settings for other input or select                                  |
+| otherType  | string                                                                         | false (true if other provided) | Can be set to `select` or `input` to set what other input you want in a radio   |
+| attributes | object                                                                         | false                          | HTML attributes (for example data attributes) to add to the radio input element |
 
 ## ClearRadios
 

--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -39,8 +39,9 @@
                         }) }}
 
                         {% if radio.other is defined and radio.other %}
+                            {% set otherType = params.other.otherType | default('input') %}
                             <span class="radio__other{{ " " + 'radio__other--open' if radio.other.open else "" }}" id="{{ radio.id }}-other-wrap">
-                            {% if radio.other.otherType is defined and radio.other.otherType and radio.other.otherType == "input" %}
+                            {% if otherType == "input" %}
                                 {% from "components/input/_macro.njk" import onsInput %}
                                 {{
                                     onsInput({
@@ -58,7 +59,7 @@
                                         "value": radio.other.value
                                     })
                                 }}
-                            {% elif radio.other.otherType is defined and radio.other.otherType and radio.other.otherType == "select" %}
+                            {% elif otherType == "select" %}
                                 {% from "components/select/_macro.njk" import onsSelect %}
                                 {{
                                     onsSelect({

--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -40,6 +40,7 @@
 
                         {% if radio.other is defined and radio.other %}
                             <span class="radio__other{{ " " + 'radio__other--open' if radio.other.open else "" }}" id="{{ radio.id }}-other-wrap">
+                            {% if radio.other.otherType is defined and radio.other.otherType and radio.other.otherType == "input" %}
                                 {% from "components/input/_macro.njk" import onsInput %}
                                 {{
                                     onsInput({
@@ -57,7 +58,22 @@
                                         "value": radio.other.value
                                     })
                                 }}
-                            </span>
+                            {% elif radio.other.otherType is defined and radio.other.otherType and radio.other.otherType == "select" %}
+                                {% from "components/select/_macro.njk" import onsSelect %}
+                                {{
+                                    onsSelect({
+                                        "id": radio.other.id,
+                                        "name": radio.other.name,
+                                        "options": radio.other.options,
+                                        "label": {
+                                            "id": radio.other.id + "-label",
+                                            "text": radio.other.label.text,
+                                            "classes": 'u-fs-s--b'
+                                        }
+                                    })
+                                }}
+                            {% endif %}
+                             </span>
                         {% endif %}
                     </span>
                 </p>

--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -39,7 +39,7 @@
                         }) }}
 
                         {% if radio.other is defined and radio.other %}
-                            {% set otherType = params.other.otherType | default('input') %}
+                            {% set otherType = radio.other.otherType | default('input') %}
                             <span class="radio__other{{ " " + 'radio__other--open' if radio.other.open else "" }}" id="{{ radio.id }}-other-wrap">
                             {% if otherType == "input" %}
                                 {% from "components/input/_macro.njk" import onsInput %}

--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -69,7 +69,9 @@
                                             "id": radio.other.id + "-label",
                                             "text": radio.other.label.text,
                                             "classes": 'u-fs-s--b'
-                                        }
+                                        },
+                                        "dontWrap": true,
+                                        "value": radio.other.value
                                     })
                                 }}
                             {% endif %}

--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -76,7 +76,7 @@
                                     })
                                 }}
                             {% endif %}
-                             </span>
+                            </span>
                         {% endif %}
                     </span>
                 </p>

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -28,6 +28,9 @@
 
   &__other {
     @extend .checkbox__other;
+    .input--select {
+      width: 18.5rem !important;
+    }
   }
 
   &__input:not(:checked) ~ &__other--open {

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -28,9 +28,6 @@
 
   &__other {
     @extend .checkbox__other;
-    .input--select {
-      width: 18.5rem !important;
-    }
   }
 
   &__input:not(:checked) ~ &__other--open {

--- a/src/components/radios/examples/radios-other-open/index.njk
+++ b/src/components/radios/examples/radios-other-open/index.njk
@@ -19,13 +19,14 @@
                 "value": "olives"
             },
             {
-                "id": "other-checkbox",
+                "id": "other-radio",
                 "label": {
                     "text": "Other"
                 },
                 "value": "other",
                 "other": {
                     "open": true,
+                    "otherType": "input",
                     "id": "other-textbox",
                     "name": "other-answer",
                     "label": {

--- a/src/components/radios/examples/radios-other/index.njk
+++ b/src/components/radios/examples/radios-other/index.njk
@@ -19,13 +19,14 @@
                 "value": "olives"
             },
             {
-                "id": "other-checkbox",
+                "id": "other-radio",
                 "label": {
                     "text": "Other",
                     "description": "Any other topping"
                 },
                 "value": "other",
                 "other": {
+                    "otherType": "input",
                     "id": "other-textbox",
                     "name": "other-answer",
                     "label": {

--- a/src/components/radios/examples/radios-select/index.njk
+++ b/src/components/radios/examples/radios-select/index.njk
@@ -19,18 +19,55 @@
                 "value": "olives"
             },
             {
-                "id": "other-checkbox",
+                "id": "other-radio",
                 "label": {
                     "text": "Other"
                 },
                 "value": "other",
                 "other": {
                     "open": true,
-                    "id": "other-textbox",
+                    "otherType": "select",
+                    "id": "other-select",
                     "name": "other-answer",
                     "label": {
                         "text": "Please specify other"
-                    }
+                    },
+                    "options": [
+                        {
+                            "value": "",
+                            "text": "Select an option",
+                            "disabled": true,
+                            "selected": true
+                        },
+                        {
+                            "value": "bart",
+                            "text": "Bart Simpson"
+                        },
+                        {
+                            "value": "homer",
+                            "text": "Homer Simpson"
+                        },
+                        {
+                            "value": "marge",
+                            "text": "Marge Simpson"
+                        },
+                        {
+                            "value": "lisa",
+                            "text": "Lisa Simpson"
+                        },
+                        {
+                            "value": "maggie",
+                            "text": "Maggie Simpson"
+                        },
+                        {
+                            "value": "ned",
+                            "text": "Ned Flanders"
+                        },
+                        {
+                            "value": "7-dwarves",
+                            "text": "The 7 Dwarves: Grumpy, Happy, Sleepy, Bashful, Sneezy, Dopey, Doc"
+                        }
+                    ]
                 }
             }
         ]

--- a/src/components/radios/examples/radios-select/index.njk
+++ b/src/components/radios/examples/radios-select/index.njk
@@ -1,0 +1,38 @@
+{% from "components/radios/_macro.njk" import onsRadios %}
+{{
+    onsRadios({
+        "legend": "Select your favourite topping",
+        "name": "food-other",
+        "radios": [
+            {
+                "id": "bacon-other",
+                "label": {
+                    "text": "Bacon"
+                },
+                "value": "bacon"
+            },
+            {
+                "id": "olives-other",
+                "label": {
+                    "text": "Olives"
+                },
+                "value": "olives"
+            },
+            {
+                "id": "other-checkbox",
+                "label": {
+                    "text": "Other"
+                },
+                "value": "other",
+                "other": {
+                    "open": true,
+                    "id": "other-textbox",
+                    "name": "other-answer",
+                    "label": {
+                        "text": "Please specify other"
+                    }
+                }
+            }
+        ]
+    })
+}}

--- a/src/components/radios/index.njk
+++ b/src/components/radios/index.njk
@@ -48,6 +48,13 @@ This variant of the 'Other' radio input type shows the input instead of waiting 
     patternlibExample({"path": "components/radios/examples/radios-other-open/index.njk"})
 }}
 
+### Other - select
+This variant of the 'Other' radio input type uses a select instead of an input.
+
+{{
+    patternlibExample({"path": "components/radios/examples/radios-select/index.njk"})
+}}
+
 ### Radios with an 'or' label
 {{
     patternlibExample({"path": "components/radios/examples/radios-with-or/index.njk"})


### PR DESCRIPTION
### What is the context of this PR?
Allow Selects to be used in Radio buttons for the Census Feedback form.

<img width="539" alt="Screenshot 2020-10-07 at 15 30 28" src="https://user-images.githubusercontent.com/42928680/95558946-eacc2780-0a0e-11eb-92a3-3029956e8b1e.png">

To keep the similarities between the way Checkboxes and Radios are configured and used I have also added the Select functionality to Checkboxes.

### How to review 
- Test to see that Radios all still work correctly
- Test to see that Checkboxes all still work correctly
- Test new Select ability works as expected for Radios and Checkboxes