### PR TITLE
Fix for focus on thumbnail. Added documentation and guidance on use

### DIFF
--- a/src/components/downloads/_downloads.scss
+++ b/src/components/downloads/_downloads.scss
@@ -21,7 +21,9 @@
 
     &:focus {
       border-color: $color-document-border-focus;
+      box-shadow: none;
       outline: 4px solid $color-focus !important;
+      outline-offset: 0;
     }
   }
 

--- a/src/components/downloads/_macro-options.md
+++ b/src/components/downloads/_macro-options.md
@@ -1,0 +1,26 @@
+| Name      | Type        | Required | Description                                                                          |
+| --------- | ----------- | -------- | ------------------------------------------------------------------------------------ |
+| title     | string      | true     | The title for the download                                                           |
+| excerpt   | string      | true     | A short extract of text (e.g. a short sentence to give some context of the download) |
+| url       | string      | true     | The url for the document download (e.g. a pdf file, zip file)                        |
+| type      | string      | true     | Type of file (e.g. Poster, Booklet, Flyer)                                           |
+| classes   | string      | false    | Custom classes to add to the downloads                                               |
+| thumbnail | `Thumbnail` | true     | An object containing path and filename attributes for the image                      |
+| meta      | `Meta`      | true     | An object containing information about file type, size and number of pages           |
+
+## Thumbnail
+
+| Name     | Type   | Required | Description                                                 |
+| -------- | ------ | -------- | ----------------------------------------------------------- |
+| smallSrc | string | true     | Path to the non-retina version of the image                 |
+| largeSrc | string | true     | Path to the retina version of the image                     |
+| filename | string | true     | Filename including type extension (e.g. placeholder.png)    |
+| alt      | string | true     | Alt tag to explain the appearance and function of the image |
+
+## Meta
+
+| Name      | Type   | Required | Description                      |
+| --------- | ------ | -------- | -------------------------------- |
+| fileType  | string | true     | File type (e.g. PDF, DOC, XLS)   |
+| fileSize  | string | true     | Size of file (e.g. 850kb, 1.5mb) |
+| filePages | string | false    | Quantity of pages                |

--- a/src/components/downloads/index.njk
+++ b/src/components/downloads/index.njk
@@ -7,6 +7,12 @@ title: Downloads
 
 Displays a link to download an attachment and metadata about the file.
 
+{{	
+    onsPanel({	
+        "body": "This component requires documentation."	
+    })	
+}}
+
 ## Single download
 {{
     patternlibExample({"path": "components/downloads/examples/downloads-single/index.njk"})

--- a/src/components/downloads/index.njk
+++ b/src/components/downloads/index.njk
@@ -5,12 +5,6 @@ title: Downloads
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 
-{{
-    onsPanel({
-        "body": "This component requires documentation."
-    })
-}}
-
 Displays a link to download an attachment and metadata about the file.
 
 ## Single download
@@ -22,6 +16,16 @@ Displays a link to download an attachment and metadata about the file.
 {{
     patternlibExample({"path": "components/downloads/examples/downloads-multiple/index.njk"})
 }}
+
+## How to use this component
+We use two versions of the image, one for standard screens and the other for retina screens.
+
+Image dimension for:
+
+* standard screen is: `96px × 136px`
+* retina screen is: `192px × 272px`
+
+We specify a folder path for both small and large images, which is defined in the macro as `smallSrc` and `largeSrc`. The filename is expected to be the same for both.
 
 ## Research on this pattern
 {% call onsPanel() %}


### PR DESCRIPTION
- Added macro options and documentation
- Fixed a visual bug with focus style on image thumbnail

**Previously like this**
<img width="801" alt="Screenshot 2020-10-09 at 11 48 34" src="https://user-images.githubusercontent.com/4989027/95574766-6e910e80-0a25-11eb-8f3e-7f574ae9cc2a.png">

**Now like this**
<img width="800" alt="Screenshot 2020-10-09 at 11 48 43" src="https://user-images.githubusercontent.com/4989027/95574787-76e94980-0a25-11eb-8a7b-83dca520da46.png">

