### PR TITLE
Update error summary guidance

### DIFF
--- a/src/components/breadcrumb/_macro.njk
+++ b/src/components/breadcrumb/_macro.njk
@@ -4,7 +4,7 @@
     <nav class="breadcrumb" aria-label="{{ params.ariaLabel }}" {% if params.id is defined and params.id %} id="{{ params.id }}"{% endif %}>
         <ol class="breadcrumb__items u-fs-s">
             {% for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) %}
-                 {% if item.current is not defined %}
+                {% if item.current is not defined %}
                     <li id="breadcrumb-{{ loop.index }}" class="breadcrumb__item">
                         <a href="{{ item.url }}" class="breadcrumb__link" id="{{ item.id }}"
                         {% if item.attributes is defined and item.attributes %}{% for attribute, value in (item.attributes.items() if item.attributes is mapping and item.attributes.items else item.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}

--- a/src/components/panel/_macro-options.md
+++ b/src/components/panel/_macro-options.md
@@ -2,7 +2,7 @@
 | ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | body       | string  | true     | The contents of the panel. This can be a string of HTML                                                                            |
 | title      | string  | false    | The title for the panel. If this is not provided the inline/simple version will be rendered                                        |
-| titleTag   | string  | false    | The html tag to wrap the title text in. Will default to a `div`                                                                    |
+| titleTag   | string  | false    | The html tag to wrap the title text in. Will default to a `div` (for error summaries we recommend this is set to `h1`)             |
 | type       | string  | false    | The type of panel to render. Available options are `success`, `warn`, `error` and `branded`                                        |
 | spacious   | boolean | false    | Will render a more spacious version of the panel if set to `true`                                                                  |
 | classes    | string  | false    | Custom classes to add to the panel                                                                                                 |

--- a/src/components/panel/index.njk
+++ b/src/components/panel/index.njk
@@ -31,6 +31,7 @@ There are two panel types for errors; error with header and error. See the [corr
 #### Error with header
 Used to provide feedback to the user that something is in an error state. This can range from input validation errors to server downtime.
 Content should be descriptive of the error and always direct the user towards a resolution.
+We recommend setting `titleTag` to `h1` if used for error summaries like the example below.
 {{
     patternlibExample({"path": "components/panel/examples/error-header/index.njk"})
 }}

--- a/src/patterns/error-validation/examples/error-summary/index.njk
+++ b/src/patterns/error-validation/examples/error-summary/index.njk
@@ -4,7 +4,8 @@
 {% call
     onsPanel({
         title: "There are 2 problems with your answer",
-        type: "error"
+        type: "error",
+        "titleTag": "h1"
     })
 %}
 

--- a/src/patterns/error-validation/examples/errors-proto/errors/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/errors/index.njk
@@ -50,7 +50,8 @@ layout: none
     {% call onsPanel({
             "title": "There are 7 problems with your answer",
             "type": "error",
-            "classes": "question__errors"
+            "classes": "question__errors",
+            "titleTag": "h1"
         })
     %}
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #1079 

### How to review 
Make sure error summary examples now use h1 tag for headers and docs make sense