### PR TITLE
Category may or may not have a url defined and should render differently

### DIFF
--- a/src/components/articles/_macro.njk
+++ b/src/components/articles/_macro.njk
@@ -32,7 +32,16 @@
 
                         <ul class="u-fs-s article__meta">
                             {%- if article.date is defined and article.date %}<li class="article__meta-item"><span class="u-hidden">Posted on </span> <time datetime="{{ article.date.iso }}">{{ article.date.short }}</time></li>{% endif %}
-                            {%- if article.category is defined and article.category %}<li class="article__meta-item"><span class="u-hidden">in </span> <a class="article__meta-link" href="{{ article.category.url }}">{{ article.category.title }}</a></li>{% endif %}
+                            {%- if article.category is defined and article.category %}
+                                <li class="article__meta-item">
+                                    <span class="u-hidden">in </span> 
+                                    {%- if article.category.url is defined and article.category.url %}
+                                        <a class="article__meta-link" href="{{ article.category.url }}">{{ article.category.title }}</a>
+                                    {% else %}
+                                        {{ article.category.title }}
+                                    {% endif %}
+                                </li>
+                            {% endif %}
                         </ul>
 
                         {% if article.excerpt is defined and article.excerpt %}


### PR DESCRIPTION
Depending on where the article is being used, changes how the category is displayed. 

If we are looking at 'Press releases', we would not want to link to 'press releases'. If category url not defined, simply show the category name, else, show the category as a link.

**With category link**
<img width="850" alt="Screenshot 2020-10-13 at 10 24 36" src="https://user-images.githubusercontent.com/4989027/95842373-60513400-0d3e-11eb-89d0-66cc58ff14d9.png">

**Without category link**
<img width="849" alt="Screenshot 2020-10-13 at 10 25 00" src="https://user-images.githubusercontent.com/4989027/95842408-6a733280-0d3e-11eb-8c45-958cb924fcbf.png">

