### PR TITLE
Added a dashed list example

### DIFF
--- a/src/styles/typography/index.njk
+++ b/src/styles/typography/index.njk
@@ -129,6 +129,12 @@ Bare lists should be used to display a list of navigational links, for example, 
     patternlibExample({"path": "styles/typography/lists/examples/list-bare/index.njk", "componentFolderPath": "components/lists"})
 }}
 
+#### Dashed list
+Dashed lists should be used to display a list of content navigational links.
+{{
+    patternlibExample({"path": "styles/typography/lists/examples/list-dashed/index.njk", "componentFolderPath": "components/lists"})
+}}
+
 #### Inline list
 Inline lists should be used to display a horizontal row of links, for example, a list of pages displayed in the [transactional footer](/components/footer#transactional).
 {{

--- a/src/styles/typography/lists/examples/list-dashed/index.njk
+++ b/src/styles/typography/lists/examples/list-dashed/index.njk
@@ -1,0 +1,20 @@
+{% from "components/lists/_macro.njk" import onsList %}
+{{
+    onsList({
+        "classes": 'list--dashed',
+        "itemsList": [
+            {
+                "text": 'Overview',
+                "current": true
+            },
+            {
+                "url": '#0',
+                "text": 'About Census 2021'
+            },
+            {
+                "url": '#0',
+                "text": 'Why should I take part in the census?'
+            }
+        ]
+    })
+}}


### PR DESCRIPTION
Added an example of a dashed list. Commonly used in content pages.
<img width="425" alt="Screenshot 2020-10-14 at 10 26 43" src="https://user-images.githubusercontent.com/4989027/95970430-da012480-0e07-11eb-851b-067764fad26b.png">
Closes #1022