### PR TITLE
Added a fallback image if none specified

### DIFF
--- a/src/components/downloads/_macro.njk
+++ b/src/components/downloads/_macro.njk
@@ -5,7 +5,11 @@
 
         <div class="download__image" aria-hidden="true">
             <a class="download__image-link" href="{{ download.url }}" tabindex="-1">
-                <img srcset="{{ download.thumbnail.smallSrc }}{{ download.thumbnail.filename }} 1x, {{ download.thumbnail.largeSrc }}{{ download.thumbnail.filename }} 2x" src="{{ download.thumbnail.smallSrc }}{{ download.thumbnail.filename }}" alt="{{ download.thumbnail.alt }}">
+                {% if download.thumbnail is defined and download.thumbnail %}
+                    <img srcset="{{ download.thumbnail.smallSrc }}{{ download.thumbnail.filename }} 1x, {{ download.thumbnail.largeSrc }}{{ download.thumbnail.filename }} 2x" src="{{ download.thumbnail.smallSrc }}{{ download.thumbnail.filename }}" alt="{{ download.thumbnail.alt }}">
+                {% else %}
+                    <img srcset="/patternlib-img/download-resources/img/small/placeholder-portrait.png 1x, /patternlib-img/download-resources/img/large/placeholder-portrait.png 2x" src="/patternlib-img/download-resources/img/small/placeholder-portrait.png" alt="Image placeholder">
+                {% endif %}
             </a>
         </div>
 

--- a/src/components/downloads/examples/downloads-single-noimage/index.njk
+++ b/src/components/downloads/examples/downloads-single-noimage/index.njk
@@ -1,0 +1,16 @@
+{% from "components/downloads/_macro.njk" import onsDownloads %}
+{{ onsDownloads({
+    "downloads": [
+        {
+            "url": "/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf",
+            "title": "Census 2021 matters to everyone",
+            "type": "Poster",
+            "meta": {
+                "fileType": "PDF",
+                "fileSize": "866KB",
+                "filePages": "1 page"
+            },
+            "excerpt": "By taking part and encouraging others to do the same, you’ll make sure your community gets the services it needs."
+        }
+    ]
+}) }}

--- a/src/components/downloads/index.njk
+++ b/src/components/downloads/index.njk
@@ -18,6 +18,12 @@ Displays a link to download an attachment and metadata about the file.
     patternlibExample({"path": "components/downloads/examples/downloads-single/index.njk"})
 }}
 
+## Single download (no image)
+In situations an image is not used, we require a fallback image to prevent a broken link.
+{{
+    patternlibExample({"path": "components/downloads/examples/downloads-single-noimage/index.njk"})
+}}
+
 ## Multiple downloads
 {{
     patternlibExample({"path": "components/downloads/examples/downloads-multiple/index.njk"})


### PR DESCRIPTION
Added a fallback image if none defined.

<img width="934" alt="Screenshot 2020-10-20 at 11 32 54" src="https://user-images.githubusercontent.com/4989027/96574988-1630fb00-12c8-11eb-98ae-500ee8397641.png">
Ideally in the long term we need to look at the build process for images due to me having to reference the 'patternlib' folders, which is not ideal.