### PR TITLE
Content changes for footer copyright example

### DIFF
--- a/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
+++ b/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
@@ -9,10 +9,6 @@
             {
                 "itemsList": [
                     {
-                        "text": 'About the census',
-                        "url": '#0'
-                    },
-                    {
                         "text": 'Help',
                         "url": '#0'
                     },
@@ -34,6 +30,10 @@
                     },
                     {
                         "text": 'Privacy and data protection',
+                        "url": '#0'
+                    },
+                    {
+                        "text": 'Terms and conditions',
                         "url": '#0'
                     }
                 ]

--- a/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
+++ b/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
@@ -13,7 +13,7 @@
                         "url": '#0'
                     },
                     {
-                        "text": 'Help with the census',
+                        "text": 'Help',
                         "url": '#0'
                     },
                     {
@@ -42,7 +42,7 @@
         "copyrightDeclaration": {
             "copyright": 'Crown copyright and database rights 2020 OS 100019153.',
             "usage": {
-                "text": 'Use of address data for the postcode lookups is subject to the',
+                "text": 'Use of address data is subject to the',
                 "link": 'terms and conditions',
                 "url": '#0'
             }


### PR DESCRIPTION
Content changes to the copyright details in the footer and help link label.

<img width="1108" alt="Screenshot 2020-10-21 at 10 32 36" src="https://user-images.githubusercontent.com/4989027/96701698-cd8d4680-1388-11eb-9807-5448f25b732c.png">

