### PR TITLE
Updated visible writein tabindex

### DIFF
--- a/src/components/radios/check-radios.js
+++ b/src/components/radios/check-radios.js
@@ -4,10 +4,21 @@ export default class CheckRadios {
     this.openOther = openOther;
     this.input = this.openOther.querySelector('.input');
 
+    this.setInputBlurAttributes();
     this.input.addEventListener('focus', this.checkRadio.bind(this));
+    this.radio.addEventListener('focus', this.setInputFocusAttributes.bind(this));
+    this.radio.addEventListener('blur', this.setInputBlurAttributes.bind(this));
   }
 
   checkRadio() {
     this.radio.checked = true;
+  }
+
+  setInputFocusAttributes() {
+    this.input.tabIndex = 0;
+  }
+
+  setInputBlurAttributes() {
+    this.input.tabIndex = -1;
   }
 }

--- a/src/components/radios/check-radios.js
+++ b/src/components/radios/check-radios.js
@@ -6,7 +6,7 @@ export default class CheckRadios {
 
     this.setInputBlurAttributes();
     this.input.addEventListener('focus', this.checkRadio.bind(this));
-    this.radio.addEventListener('focus', this.setInputFocusAttributes.bind(this));
+    this.radio.addEventListener('change', this.setInputFocusAttributes.bind(this));
     this.radio.addEventListener('blur', this.setInputBlurAttributes.bind(this));
   }
 
@@ -15,7 +15,7 @@ export default class CheckRadios {
   }
 
   setInputFocusAttributes() {
-    this.input.tabIndex = 0;
+    this.input.tabIndex = this.radio.checked ? 0 : -1;
   }
 
   setInputBlurAttributes() {

--- a/src/tests/spec/radios/radios.spec.js
+++ b/src/tests/spec/radios/radios.spec.js
@@ -210,6 +210,7 @@ describe('Component: Radios', function() {
 
     describe('and there is a visible input and the radio is focused', function() {
       beforeEach(function() {
+        this.input = this.openOther.querySelector('.input');
         this.radioInput.focus();
       });
 

--- a/src/tests/spec/radios/radios.spec.js
+++ b/src/tests/spec/radios/radios.spec.js
@@ -206,6 +206,12 @@ describe('Component: Radios', function() {
           done();
         }, 300);
       });
+    });
+
+    describe('and there is a visible input and the radio is focused', function() {
+      beforeEach(function() {
+        this.radioInput.focus();
+      });
 
       it('then the input should have a tab index of 0', function(done) {
         setTimeout(() => {

--- a/src/tests/spec/radios/radios.spec.js
+++ b/src/tests/spec/radios/radios.spec.js
@@ -196,13 +196,20 @@ describe('Component: Radios', function() {
 
     describe('and there is a visible input which is focused', function() {
       beforeEach(function() {
-        const input = this.openOther.querySelector('.input');
-        input.focus();
+        this.input = this.openOther.querySelector('.input');
+        this.input.focus();
       });
 
       it('then the radio button should be checked', function(done) {
         setTimeout(() => {
           expect(this.radioInput.checked).to.equal(true);
+          done();
+        }, 300);
+      });
+
+      it('then the input should have a tab index of 0', function(done) {
+        setTimeout(() => {
+          expect(this.input.getAttribute('tabindex')).to.equal('0');
           done();
         }, 300);
       });

--- a/src/tests/spec/radios/radios.spec.js
+++ b/src/tests/spec/radios/radios.spec.js
@@ -208,10 +208,10 @@ describe('Component: Radios', function() {
       });
     });
 
-    describe('and there is a visible input and the radio is focused', function() {
+    describe('and there is a visible input and the radio is checked', function() {
       beforeEach(function() {
         this.input = this.openOther.querySelector('.input');
-        this.radioInput.focus();
+        this.radioInput.click();
       });
 
       it('then the input should have a tab index of 0', function(done) {


### PR DESCRIPTION
### What is the context of this PR?
DAC raised an issue with the visible write in which exists on both radio and checkbox components. Using tabbing to navigate in and out of the fieldset, the visible input would receive focus (and check the radio/checkbox). This made it impossible to not check that field for keyboard users.

This is a JS enhancement. Upon the component loading a negative `tabindex` value is given to the input. When it's associated radio/checkbox receives focus the `tabindex` is changed to `0`. Upon the field blurring, the `tabindex` is again changed to `-1`.
 
### How to review 
View the visible write in radio example. Tab into the component and select the first radio (using spacebar), then tab and you should skip out of the component (not focus inside the input which is what currently happens).