### PR TITLE
Remove BEM depth lint rule warning

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -4,7 +4,7 @@ options:
   formatter: stylish
   merge-default-rules: false
 rules:
-  bem-depth: 1
+  bem-depth: 0
   border-zero:
     - 1
     - convention: zero


### PR DESCRIPTION
### What is the context of this PR?
This is to remove the sass lint rule for BEM depth. We have in some components the need to name elements with a BEM depth of more than 1 so these warnings are getting in the way.

### How to review 
Check BEM warnings are now gone. One component this occurs on is summary.