### PR TITLE
Update descriptive message on cookies hide button

### DIFF
--- a/src/components/cookies-banner/_macro-options.md
+++ b/src/components/cookies-banner/_macro-options.md
@@ -1,10 +1,10 @@
-| Name                       | Type   | Required | Description                                                                                                        |
-| -------------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------ |
-| ariaLabel                  | string | false    | Aria label for the cookie banner region (default is 'cookies banner')                                              |
-| statementTitle             | string | true     | The title text for content for the cookie banner.                                                                  |
-| statementText              | string | true     | The text content for the cookie banner. HTML is allowable to embed links                                           |
-| confirmationText           | string | true     | The text content for the confirmation cookie message. HTML is allowable to embed links                             |
-| primaryButtonText          | string | false    | Text for the primary button (default is 'Accept all cookies')                                                      |
-| secondaryButtonText        | string | false    | Text for the secondary button (default is 'Set cookie preferences')                                                |
-| confirmationButtonText     | string | false    | Text for the confirmation banner button (default is 'Hide')                                                        |
-| confirmationButtonTextAria | string | false    | Additional descriptive text for the confirmation banner button to assist screenreaders (default is 'this message') |
+| Name                       | Type   | Required | Description                                                                                                              |
+| -------------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| ariaLabel                  | string | false    | Aria label for the cookie banner region (default is 'cookies banner')                                                    |
+| statementTitle             | string | true     | The title text for content for the cookie banner.                                                                        |
+| statementText              | string | true     | The text content for the cookie banner. HTML is allowable to embed links                                                 |
+| confirmationText           | string | true     | The text content for the confirmation cookie message. HTML is allowable to embed links                                   |
+| primaryButtonText          | string | false    | Text for the primary button (default is 'Accept all cookies')                                                            |
+| secondaryButtonText        | string | false    | Text for the secondary button (default is 'Set cookie preferences')                                                      |
+| confirmationButtonText     | string | false    | Text for the confirmation banner button (default is 'Hide')                                                              |
+| confirmationButtonTextAria | string | false    | Additional descriptive text for the confirmation banner button to assist screenreaders (default is 'the cookie message') |

--- a/src/components/cookies-banner/_macro.njk
+++ b/src/components/cookies-banner/_macro.njk
@@ -34,7 +34,7 @@
                     onsButton({
                         "type": 'button',
                         "text": params.confirmationButtonText | default('Hide'),
-                        "buttonContext": params.confirmationButtonTextAria | default('this message'),
+                        "buttonContext": params.confirmationButtonTextAria | default('the cookie message'),
                         "classes": 'btn--secondary btn--small js-hide-button'
                     }) 
                 }}


### PR DESCRIPTION
### What is the context of this PR?
Cookie 'hide' button has ambiguous aria label this adds a more descriptive label

### How to review 
Check to see that default button explanation is more descriptive