### PR TITLE
Different approach, which will fix the IE bug

### DIFF
--- a/src/components/hero/_hero.scss
+++ b/src/components/hero/_hero.scss
@@ -37,6 +37,7 @@
   }
 
   .hero__circle-image {
+    background-color: $color-white;
     z-index: 2;
     top: -117px;
     right: -8px;
@@ -45,9 +46,9 @@
     border-radius: 50%;
 
     img {
+      border-radius: 50%;
       display: block;
       height: 100%;
-      clip-path: circle(191px at center); // Half width of circle
     }
   }
 
@@ -126,10 +127,6 @@
       margin: auto;
       width: 558px;
       height: 558px;
-
-      img {
-        clip-path: circle(279px at center); // Half width of circle
-      }
     }
 
     .hero__circle-gradient {


### PR DESCRIPTION
IE does not support clip-path, so the hero image came out square as shown.

Changing the approach fixes the rendering in IE and simplifies the CSS. This should have been the way I approached it at the beginning, instead of over complicating it.

**IE render before**
<img width="1219" alt="Screenshot 2020-10-22 at 16 00 23" src="https://user-images.githubusercontent.com/4989027/96890803-eb89a280-147f-11eb-8dad-62a415734339.png">

**IE render now**
<img width="1231" alt="Screenshot 2020-10-22 at 16 02 48" src="https://user-images.githubusercontent.com/4989027/96890915-0d832500-1480-11eb-89e4-5a4705ec175a.png">

