### PR TITLE
Add newTabWarning to Footer and update docs

### DIFF
--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -13,6 +13,10 @@
     background-color: $color-grey-4;
   }
 
+  &__new-tab-warning {
+    padding-left: 1rem;
+  }
+
   &--body {
     padding: 2rem 0 4rem;
     background-color: $color-grey-5;

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -38,5 +38,12 @@
     .list__link {
       margin-right: 0;
     }
+
+    .poweredbylogo {
+      @include mq('xs', 'm') {
+        margin-top: 1.5rem;
+        width: 100% !important;
+      }
+    }
   }
 }

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -38,12 +38,5 @@
     .list__link {
       margin-right: 0;
     }
-
-    .poweredbylogo {
-      @include mq('xs', 'm') {
-        margin-top: 1.5rem;
-        width: 100% !important;
-      }
-    }
   }
 }

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -13,11 +13,6 @@
     background-color: $color-grey-4;
   }
 
-  &__new-tab-warning {
-    margin-bottom: 1.5rem;
-    padding-left: 1rem;
-  }
-
   &--body {
     padding: 2rem 0 4rem;
     background-color: $color-grey-5;

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -14,6 +14,7 @@
   }
 
   &__new-tab-warning {
+    margin-bottom: 1.5rem;
     padding-left: 1rem;
   }
 

--- a/src/components/footer/_macro-options.md
+++ b/src/components/footer/_macro-options.md
@@ -1,11 +1,13 @@
-| Name         | Type                                   | Required | Description                                                                                             |
-| ------------ | -------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| OGLLink      | `OGLLink`                              | false    | An object containing settings for the OGL link                                                          |
-| cols         | `Array<FooterCol>`                     | false    | An array of `FooterCol` objects. _Maximum of 3_                                                         |
-| rows         | `Array<FooterRow>`                     | false    | An array of `FooterRow` objects                                                                         |
-| poweredByONS | boolean &#124; `PoweredByONS`          | false    | Whether to show the ONS logo, and optionally settings for the logo                                      |
-| lang         | string                                 | false    | The current page language. Will change out the ONS logo if `poweredByONS` is provided. Defaults to `en` |
-| button       | `Button` [_(ref)_](/components/button) | false    | Settings for save and sign out using the button component                                               |
+| Name                 | Type                                   | Required | Description                                                                                             |
+| -------------------- | -------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| OGLLink              | `OGLLink`                              | false    | An object containing settings for the OGL link                                                          |
+| footerWarning        | `footerWarning`                        | false    | An object containing settings for the Footer Warning                                                    |
+| copyrightDeclaration | `copyrightDeclaration`                 | false    | An object containing settings for the Copyright Declaration                                             |
+| cols                 | `Array<FooterCol>`                     | false    | An array of `FooterCol` objects. _Maximum of 3_                                                         |
+| rows                 | `Array<FooterRow>`                     | false    | An array of `FooterRow` objects                                                                         |
+| poweredByONS         | boolean &#124; `PoweredByONS`          | false    | Whether to show the ONS logo, and optionally settings for the logo                                      |
+| lang                 | string                                 | false    | The current page language. Will change out the ONS logo if `poweredByONS` is provided. Defaults to `en` |
+| button               | `Button` [_(ref)_](/components/button) | false    | Settings for save and sign out using the button component                                               |
 
 ## OGLLink
 
@@ -24,6 +26,15 @@
 | url  | string | true     | The url for the warning link     |
 | link | string | true     | The text of the warning link     |
 | post | string | true     | The text after the warning link  |
+
+## CopyrightDeclaration
+
+| Name      | Type   | Required | Description                                                      |
+| --------- | ------ | -------- | ---------------------------------------------------------------- |
+| copyright | string | true     | The text for the copyright declaration                           |
+| text      | string | true     | The text that comes before the link on the copyright declaration |
+| link      | string | true     | The text for the copyright link                                  |
+| url       | string | true     | The url for the copyright link                                   |
 
 ## FooterCol
 

--- a/src/components/footer/_macro-options.md
+++ b/src/components/footer/_macro-options.md
@@ -1,13 +1,15 @@
-| Name                 | Type                                   | Required | Description                                                                                             |
-| -------------------- | -------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| OGLLink              | `OGLLink`                              | false    | An object containing settings for the OGL link                                                          |
-| footerWarning        | `footerWarning`                        | false    | An object containing settings for the Footer Warning                                                    |
-| copyrightDeclaration | `copyrightDeclaration`                 | false    | An object containing settings for the Copyright Declaration                                             |
-| cols                 | `Array<FooterCol>`                     | false    | An array of `FooterCol` objects. _Maximum of 3_                                                         |
-| rows                 | `Array<FooterRow>`                     | false    | An array of `FooterRow` objects                                                                         |
-| poweredByONS         | boolean &#124; `PoweredByONS`          | false    | Whether to show the ONS logo, and optionally settings for the logo                                      |
-| lang                 | string                                 | false    | The current page language. Will change out the ONS logo if `poweredByONS` is provided. Defaults to `en` |
-| button               | `Button` [_(ref)_](/components/button) | false    | Settings for save and sign out using the button component                                               |
+| Name                 | Type                                   | Required | Description                                                                                          |
+| -------------------- | -------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| OGLLink              | `OGLLink`                              | false    | An object containing settings for the OGL link                                                       |
+| footerWarning        | `footerWarning`                        | false    | An object containing settings for the Footer Warning                                                 |
+| copyrightDeclaration | `copyrightDeclaration`                 | false    | An object containing settings for the Copyright Declaration                                          |
+| cols                 | `Array<FooterCol>`                     | false    | An array of `FooterCol` objects. _Maximum of 3_                                                      |
+| rows                 | `Array<FooterRow>`                     | false    | An array of `FooterRow` objects                                                                      |
+| poweredBy            | boolean &#124; `PoweredBy`             | false    | Whether to show the ONS logo, and optionally settings for the logo                                   |
+| lang                 | string                                 | false    | The current page language. Will change out the ONS logo if `poweredBy` is provided. Defaults to `en` |
+| button               | `Button` [_(ref)_](/components/button) | false    | Settings for save and sign out using the button component                                            |
+| newTabWarning        | string                                 | false    | Text for warning of links opening in new tabs                                                        |
+| crest                | boolean                                | false    | If set to true will add the UK coat of arms to the footer                                            |
 
 ## OGLLink
 

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -209,10 +209,8 @@
                 {% if params.copyrightDeclaration is defined and params.copyrightDeclaration %}
                 <div class="grid">
                     <div class="grid__col u-mt-m">
-                        {% if params.copyrightDeclaration is defined and params.copyrightDeclaration.HTML %}
-                            {{ params.copyrightDeclaration.HTML | safe }}
-                        {% else %}
-                            <p class="u-fs-s u-mb-no">&copy; {{ params.copyrightDeclaration.copyright }} <br> {{ params.copyrightDeclaration.usage.text }} <a href="{{ params.copyrightDeclaration.usage.url }}">{{ params.copyrightDeclaration.usage.link }}</a>.</p>
+                        {% if params.copyrightDeclaration is defined and params.copyrightDeclaration %}
+                            <p class="u-fs-s u-mb-no">&copy; {{ params.copyrightDeclaration.copyright }} <br> {{ params.copyrightDeclaration.text }} <a href="{{ params.copyrightDeclaration.url }}">{{ params.copyrightDeclaration.link }}</a>.</p>
                         {% endif %}
                     </div>
                 </div>

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -133,7 +133,7 @@
                             <div class="grid__col">
                                 {{
                                     onsList({
-                                        "classes": 'list--bare list--inline@l u-mb-no',
+                                        "classes": 'list--bare u-mb-no list--inline@l',
                                         "itemsList": row.itemsList
                                     })
                                 }}
@@ -148,7 +148,7 @@
 
                             {% if params.OGLLink is not defined and params.crest is not defined %}
                                 {% if loop.last %}
-                                    <div class="grid__col grid__col--flex u-mt-m@xs@m">
+                                    <div class="grid__col grid__col--flex poweredbylogo">
                                         {{ poweredByLogo | safe }}
                                     </div>
                                 {% endif %}
@@ -171,7 +171,7 @@
                         {% endfor %}
 
                     {% elif params.rows is not defined and params.cols is not defined and params.poweredBy is not defined and params.OGLLink is not defined and params.crest is not defined %}
-                        <div class="grid__col grid__col--flex u-mt-m@xs@m">
+                        <div class="grid__col grid__col--flex poweredbylogo">
                             {{ poweredByLogo | safe }}
                         </div>
                     {% endif %}

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -94,6 +94,10 @@
                         </div>
                     {% endif %}
 
+                    {% if params.newTabWarning is defined and params.newTabWarning %}
+                        <p class="u-fs-r footer__new-tab-warning">{{ params.newTabWarning }}</p>
+                    {% endif %}
+
                     {% if params.cols is defined and params.cols %}
                         {% for col in params.cols %}
                             <div class="grid__col col-4@m{{ " u-mt-m@xs@m" if loop.index > 1 }}">
@@ -117,6 +121,7 @@
                     {% endif %}
 
                     {% if params.rows is defined and params.rows %}
+
                         {% for row in params.rows %}
 
                            {% if params.OGLLink is not defined %}

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -122,6 +122,13 @@
 
                     {% if params.rows is defined and params.rows %}
                         {% for row in params.rows %}
+                            {% if row.itemsList | length > 2 and ((params.crest is defined and params.crest) or (params.poweredBy is defined and params.poweredBy) or (params.OGLLink is not defined and params.crest is not defined)) %}
+                                {% set listSpacing = " list--inline@l" %}
+                            {% elif row.itemsList | length > 2 %}
+                                {% set listSpacing = " list--inline@m" %}
+                            {% else %}
+                                {% set listSpacing = " list--inline@s" %}
+                            {% endif %}
 
                            {% if params.OGLLink is not defined %}
                                 {% if loop.last %}
@@ -133,7 +140,7 @@
                             <div class="grid__col">
                                 {{
                                     onsList({
-                                        "classes": 'list--bare u-mb-no list--inline@l',
+                                        "classes": "list--bare u-mb-no" ~ listSpacing,
                                         "itemsList": row.itemsList
                                     })
                                 }}

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -121,7 +121,6 @@
                     {% endif %}
 
                     {% if params.rows is defined and params.rows %}
-
                         {% for row in params.rows %}
 
                            {% if params.OGLLink is not defined %}

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -95,7 +95,9 @@
                     {% endif %}
 
                     {% if params.newTabWarning is defined and params.newTabWarning %}
-                        <p class="u-fs-s footer__new-tab-warning">{{ params.newTabWarning }}</p>
+                        <div class="grid__col">
+                            <p class="u-fs-s u-mb-m">{{ params.newTabWarning }}</p>
+                        </div>
                     {% endif %}
 
                     {% if params.cols is defined and params.cols %}

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -148,7 +148,7 @@
 
                             {% if params.OGLLink is not defined and params.crest is not defined %}
                                 {% if loop.last %}
-                                    <div class="grid__col grid__col--flex poweredbylogo">
+                                    <div class="grid__col grid__col--flex u-mt-m@xs@m">
                                         {{ poweredByLogo | safe }}
                                     </div>
                                 {% endif %}
@@ -171,7 +171,7 @@
                         {% endfor %}
 
                     {% elif params.rows is not defined and params.cols is not defined and params.poweredBy is not defined and params.OGLLink is not defined and params.crest is not defined %}
-                        <div class="grid__col grid__col--flex poweredbylogo">
+                        <div class="grid__col grid__col--flex u-mt-m@xs@m">
                             {{ poweredByLogo | safe }}
                         </div>
                     {% endif %}

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -95,7 +95,7 @@
                     {% endif %}
 
                     {% if params.newTabWarning is defined and params.newTabWarning %}
-                        <p class="u-fs-r footer__new-tab-warning">{{ params.newTabWarning }}</p>
+                        <p class="u-fs-s footer__new-tab-warning">{{ params.newTabWarning }}</p>
                     {% endif %}
 
                     {% if params.cols is defined and params.cols %}

--- a/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
+++ b/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
@@ -9,11 +9,7 @@
             {
                 "itemsList": [
                     {
-                        "text": 'About the census',
-                        "url": '#0'
-                    },
-                    {
-                        "text": 'Help with the census',
+                        "text": 'Help',
                         "url": '#0'
                     },
                     {
@@ -35,6 +31,10 @@
                     {
                         "text": 'Privacy and data protection',
                         "url": '#0'
+                    },
+                    {
+                        "text": 'Terms and conditions',
+                        "url": '#0'
                     }
                 ]
             }
@@ -42,7 +42,7 @@
         "copyrightDeclaration": {
             "copyright": 'Crown copyright and database rights 2020 OS 100019153.',
             "usage": {
-                "text": 'Use of address data for the postcode lookups is subject to the',
+                "text": 'Use of address data is subject to the',
                 "link": 'terms and conditions',
                 "url": '#0'
             }

--- a/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
+++ b/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
@@ -5,6 +5,7 @@
 {{
     onsFooter({
         "crest": true,
+        "newTabWarning": 'The following links open in a new tab',
         "rows": [
             {
                 "itemsList": [

--- a/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
+++ b/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
@@ -41,11 +41,9 @@
         ],
         "copyrightDeclaration": {
             "copyright": 'Crown copyright and database rights 2020 OS 100019153.',
-            "usage": {
-                "text": 'Use of address data is subject to the',
-                "link": 'terms and conditions',
-                "url": '#0'
-            }
+            "text": 'Use of address data is subject to the',
+            "link": 'terms and conditions',
+            "url": '#0'
         }
     })
 }}

--- a/src/styles/page-template/_template.njk
+++ b/src/styles/page-template/_template.njk
@@ -180,8 +180,9 @@
                                 "crest": pageConfig.footer.crest,
                                 "OGLLink": pageConfig.footer.OGLLink,
                                 "button": pageConfig.signoutButton,
-                                "serviceLinks": pageConfig.serviceLinks,
-                                "footerWarning": pageConfig.footerWarning
+                                "footerWarning": pageConfig.footer.footerWarning,
+                                "copyrightDeclaration": pageConfig.footer.copyrightDeclaration,
+                                "newTabWarning": pageConfig.footer.newTabWarning
                             })
                         }}
                     {% endif %}

--- a/src/styles/page-template/index.njk
+++ b/src/styles/page-template/index.njk
@@ -167,12 +167,18 @@ Variables can be set with:
 ###### PageFooter
 
 {% md %}
-| Variable Name | Type                                                        | Required | Description                                                        |
-| ------------- | ----------------------------------------------------------- | -------- | ------------------------------------------------------------------ |
-| OGLLink       | `OGLLink` [_(ref)_](/components/footer)                     | true     | An object containing settings for the OGL link                     |
-| cols          | `FooterCol` [_(ref)_](/components/footer)                   | false    | An array of `FooterCol` objects. _Maximum of 3_                    |
-| rows          | `FooterRow` [_(ref)_](/components/footer)                   | false    | An array of `FooterRow` objects                                    |
-| poweredByONS  | boolean &#124; `PoweredByONS` [_(ref)_](/components/footer) | false    | Whether to show the ONS logo, and optionally settings for the logo |
+| Variable Name        | Type                                   | Required | Description                                                                                             |
+| -------------------- | -------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| OGLLink              | `OGLLink`                              | false    | An object containing settings for the OGL link                                                          |
+| footerWarning        | `footerWarning`                        | false    | An object containing settings for the Footer Warning                                                    |
+| copyrightDeclaration | `copyrightDeclaration`                 | false    | An object containing settings for the Copyright Declaration                                             |
+| cols                 | `Array<FooterCol>`                     | false    | An array of `FooterCol` objects. _Maximum of 3_                                                         |
+| rows                 | `Array<FooterRow>`                     | false    | An array of `FooterRow` objects                                                                         |
+| poweredBy            | boolean &#124; `PoweredBy   `          | false    | Whether to show the ONS logo, and optionally settings for the logo                                      |
+| lang                 | string                                 | false    | The current page language. Will change out the ONS logo if `poweredBy` is provided. Defaults to `en`    |
+| button               | `Button` [_(ref)_](/components/button) | false    | Settings for save and sign out using the button component                                               |
+| newTabWarning        | string                                 | false    | Text for warning of links opening in new tabs                                                           |
+| crest                | boolean                                | false    | If set to true will add the UK coat of arms to the footer                                               |
 {% endmd %}
 
 #### Blocks


### PR DESCRIPTION
### What is the context of this PR?
This PR adds the ability to add a warning at the top of the Footer to warn users that links will open in a new tab and updates docs to reflect this.
It also:
- updates the Footer docs to add a recent new param (crest)
- fixes issues setting `footerWarning` and `copyrightDeclaration` using pageConfig
- removes unused param `serviceLinks` from pageConfig
- updates pageConfig docs for Footer
- renames `poweredByONS` to `poweredBy` in docs

### How to review 
- Check footer with warning line looks as it should
- Check docs are up to date