### PR TITLE
Updated CTA with correct content and colour

### DIFF
--- a/src/components/call-to-action/examples/call-to-action-census/index.njk
+++ b/src/components/call-to-action/examples/call-to-action-census/index.njk
@@ -5,12 +5,12 @@
 {% from "components/call-to-action/_macro.njk" import onsCallToAction %}
 {{-
     onsCallToAction({
-        "headingText": "Ready to start your census survey?",
-        "paragraphText": "You'll need the access code from the letter we sent you.",
+        "headingText": 'Ready to start your census?',
+        "paragraphText": 'You’ll need the access code from the letter we sent you.',
         "button": {
-            "text": "Start survey",
+            "text": 'Start census',
             "classes": 'btn--small btn--link',
-            "url": "#"
+            "url": '#0'
         }
     })
 }}

--- a/src/components/call-to-action/examples/call-to-action-default/index.njk
+++ b/src/components/call-to-action/examples/call-to-action-default/index.njk
@@ -4,13 +4,13 @@
 {% from "components/call-to-action/_macro.njk" import onsCallToAction %}
 {{-
     onsCallToAction({
-        "headingText": "Call to action heading.",
-        "paragraphText": "Descriptive text about call to action",
+        "headingText": 'Call to action heading.',
+        "paragraphText": 'Descriptive text about call to action',
         "button": {
-            "text": "Start",
+            "text": 'Start',
             "classes": 'btn--small',
-            "innerClasses": "icon--chevron-right-white",
-            "url": "#"
+            "innerClasses": 'icon--chevron-right-white',
+            "url": '#0'
         }
     })
 }}

--- a/src/components/call-to-action/index.njk
+++ b/src/components/call-to-action/index.njk
@@ -11,12 +11,13 @@ title: Call to action
     })
 }}
 
-## Call to action - default
+## Default
 {{
     patternlibExample({"path": "components/call-to-action/examples/call-to-action-default/index.njk"})
 }}
 
-## Call to action - census
+## Census 2021
+A persistent call to action to start census.
 {{
     patternlibExample({"path": "components/call-to-action/examples/call-to-action-census/index.njk"})
 }}

--- a/src/scss/settings/_census.scss
+++ b/src/scss/settings/_census.scss
@@ -1,7 +1,7 @@
 // Census brand
 $color-black: #222;
 $color-branded: #902082;
-$color-branded-tint: rgba(227, 77, 219, 0.15);
+$color-branded-tint: rgba(144, 32, 130, 0.1); // 10% of brand colour
 $color-branded-secondary: #df0667;
 $color-branded-tertiary: #3c388e;
 $color-branded-supporting: #00a3a6;


### PR DESCRIPTION
Updated CTA to use correct content and colour.

**Old version**
<img width="1032" alt="Screenshot 2020-10-27 at 15 45 39" src="https://user-images.githubusercontent.com/4989027/97326038-7e08b800-186b-11eb-9ac6-98b8636e8d18.png">

**Updated version**
<img width="956" alt="Screenshot 2020-10-27 at 15 46 22" src="https://user-images.githubusercontent.com/4989027/97326122-94af0f00-186b-11eb-8830-7210f4a28906.png">
