### PR TITLE
Fix Footer exit button icon colour

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -232,7 +232,7 @@ $button-border-height: 3px;
       background: transparent;
       color: $color-blue;
       .svg-icon {
-        fill: $color-blue;
+        fill: $color-blue !important;
       }
     }
   }

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -64,7 +64,6 @@
                                     "value": params.button.value,
                                     "attributes": params.button.attributes,
                                     "url": params.button.url,
-                                    "exit": params.button.exit,
                                     "buttonStyle": params.button.buttonStyle
                                 })
                             }}


### PR DESCRIPTION
### What is the context of this PR?
In runner the exit icon on the exit button when it goes into the footer is still white. This change will force it to go blue to fit in with the rest of the button

Also removes the redundant param `exit`

### How to review 
Check button has a blue icon when the screen width is reduced it moves into the footer