### PR TITLE
Move Question outside of Relationships

### DIFF
--- a/src/components/relationships/_macro.njk
+++ b/src/components/relationships/_macro.njk
@@ -1,26 +1,16 @@
 {% from "components/radios/_macro.njk" import onsRadios %}
-{% from "components/question/_macro.njk" import onsQuestion %}
 
 {% macro onsRelationships(params) %}
-
-    {% call onsQuestion({
-        "title": params.question.title,
-        "description": params.question.description,
-        "readDescriptionFirst": true
-    }) %}
-
-        <div
-            {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %}
-            class="relationships js-relationships{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
-        >
-            {{ onsRadios({
-                "legend": params.legend,
-                "legendClasses": "js-relationships-legend" + (" " + params.legendClasses if params.legendClasses else ""),
-                "name": params.name,
-                "radios": params.radios
-            }) }}
-            <p class="relationships__playback js-relationships-playback u-d-no" aria-live="polite">{{ params.playback | safe }}</p>
-        </div>
-
-    {% endcall %}
+    <div
+        {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %}
+        class="relationships js-relationships{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
+    >
+        {{ onsRadios({
+            "legend": params.legend,
+            "legendClasses": "js-relationships-legend" + (" " + params.legendClasses if params.legendClasses else ""),
+            "name": params.name,
+            "radios": params.radios
+        }) }}
+        <p class="relationships__playback js-relationships-playback u-d-no" aria-live="polite">{{ params.playback | safe }}</p>
+    </div>
 {% endmacro %}

--- a/src/components/relationships/examples/relationships-you/index.njk
+++ b/src/components/relationships/examples/relationships-you/index.njk
@@ -2,6 +2,7 @@
 layout: none
 ---
 {% extends "styles/page-template/_template.njk" %}
+{% from "components/question/_macro.njk" import onsQuestion %}
 {% from "components/relationships/_macro.njk" import onsRelationships %}
 
 {% set pageConfig = {
@@ -9,160 +10,162 @@ layout: none
 } %}
 
 {% block main %}
-    {{ onsRelationships({
-        "question": {
-            "title": "Joe Bloggs is your <em>…</em>",
-            "description": "<p>Complete the sentence by selecting the appropriate relationship.</p>"
-        },
-        "legend": "Joe Bloggs is your <em>…</em>",
-        "legendClasses": "u-vh",
-        "playback": "Joe Bloggs is your <em>…</em>",
-        "name": "relationship",
-        "radios": [
-            {
-                "id": "husband-wife",
-                "value": "husband-wife",
-                "label": {
-                    "text": "Husband or wife"
+    {% call onsQuestion({
+        "title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>…</em>",
+        "description": "<p>Complete the sentence by selecting the appropriate relationship.</p>",
+        "readDescriptionFirst": true
+    }) %}
+        {{ onsRelationships({
+            "legend": "Joe Bloggs is your <em>…</em>",
+            "legendClasses": "u-vh",
+            "playback": "Joe Bloggs is your <em>…</em>",
+            "name": "relationship",
+            "radios": [
+                {
+                    "id": "husband-wife",
+                    "value": "husband-wife",
+                    "label": {
+                        "text": "Husband or wife"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>husband or wife</em>",
+                        "data-playback": "Joe Bloggs is your <em>husband or wife</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>husband or wife</em>",
-                    "data-playback": "Joe Bloggs is your <em>husband or wife</em>"
-                }
-            },
-            {
-                "id": "civil-partner",
-                "value": "civil-partner",
-                "label": {
-                    "text": "Legally registered civil partner"
+                {
+                    "id": "civil-partner",
+                    "value": "civil-partner",
+                    "label": {
+                        "text": "Legally registered civil partner"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>legally registered civil partner</em>",
+                        "data-playback": "Joe Bloggs is your <em>legally registered civil partner</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>legally registered civil partner</em>",
-                    "data-playback": "Joe Bloggs is your <em>legally registered civil partner</em>"
-                }
-            },
-            {
-                "id": "partner",
-                "value": "partner",
-                "label": {
-                    "text": "Partner"
+                {
+                    "id": "partner",
+                    "value": "partner",
+                    "label": {
+                        "text": "Partner"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>partner</em>",
+                        "data-playback": "Joe Bloggs is your <em>partner</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>partner</em>",
-                    "data-playback": "Joe Bloggs is your <em>partner</em>"
-                }
-            },
-            {
-                "id": "son-daughter",
-                "value": "son-daughter",
-                "label": {
-                    "text": "Son or daughter"
+                {
+                    "id": "son-daughter",
+                    "value": "son-daughter",
+                    "label": {
+                        "text": "Son or daughter"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>son or daughter</em>",
+                        "data-playback": "Joe Bloggs is your <em>son or daughter</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>son or daughter</em>",
-                    "data-playback": "Joe Bloggs is your <em>son or daughter</em>"
-                }
-            },
-            {
-                "id": "stepchild",
-                "value": "stepchild",
-                "label": {
-                    "text": "Stepchild"
+                {
+                    "id": "stepchild",
+                    "value": "stepchild",
+                    "label": {
+                        "text": "Stepchild"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>stepchild</em>",
+                        "data-playback": "Joe Bloggs is your <em>stepchild</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>stepchild</em>",
-                    "data-playback": "Joe Bloggs is your <em>stepchild</em>"
-                }
-            },
-            {
-                "id": "brother-sister",
-                "value": "brother-sister",
-                "label": {
-                    "text": "Brother or sister"
+                {
+                    "id": "brother-sister",
+                    "value": "brother-sister",
+                    "label": {
+                        "text": "Brother or sister"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>brother or sister</em>",
+                        "data-playback": "Joe Bloggs is your <em>brother or sister</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>brother or sister</em>",
-                    "data-playback": "Joe Bloggs is your <em>brother or sister</em>"
-                }
-            },
-            {
-                "id": "stepbrother-stepsister",
-                "value": "stepbrother-stepsister",
-                "label": {
-                    "text": "Stepbrother or stepsister"
+                {
+                    "id": "stepbrother-stepsister",
+                    "value": "stepbrother-stepsister",
+                    "label": {
+                        "text": "Stepbrother or stepsister"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>stepbrother or sister</em>",
+                        "data-playback": "Joe Bloggs is your <em>stepbrother or sister</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>stepbrother or sister</em>",
-                    "data-playback": "Joe Bloggs is your <em>stepbrother or sister</em>"
-                }
-            },
-            {
-                "id": "mother-father",
-                "value": "mother-father",
-                "label": {
-                    "text": "Mother or father"
+                {
+                    "id": "mother-father",
+                    "value": "mother-father",
+                    "label": {
+                        "text": "Mother or father"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>mother or father</em>",
+                        "data-playback": "Joe Bloggs is your <em>mother or father</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>mother or father</em>",
-                    "data-playback": "Joe Bloggs is your <em>mother or father</em>"
-                }
-            },
-            {
-                "id": "stepmother-stepfather",
-                "value": "stepmother-stepfather",
-                "label": {
-                    "text": "Stepmother or stepfather"
+                {
+                    "id": "stepmother-stepfather",
+                    "value": "stepmother-stepfather",
+                    "label": {
+                        "text": "Stepmother or stepfather"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>stepmother or stepfather</em>",
+                        "data-playback": "Joe Bloggs is your <em>stepmother or stepfather</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>stepmother or stepfather</em>",
-                    "data-playback": "Joe Bloggs is your <em>stepmother or stepfather</em>"
-                }
-            },
-            {
-                "id": "grandchild",
-                "value": "grandchild",
-                "label": {
-                    "text": "Grandchild"
+                {
+                    "id": "grandchild",
+                    "value": "grandchild",
+                    "label": {
+                        "text": "Grandchild"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>grandchild</em>",
+                        "data-playback": "Joe Bloggs is your <em>grandchild</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>grandchild</em>",
-                    "data-playback": "Joe Bloggs is your <em>grandchild</em>"
-                }
-            },
-            {
-                "id": "grandparent",
-                "value": "grandparent",
-                "label": {
-                    "text": "Grandparent"
+                {
+                    "id": "grandparent",
+                    "value": "grandparent",
+                    "label": {
+                        "text": "Grandparent"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>grandparent</em>",
+                        "data-playback": "Joe Bloggs is your <em>grandparent</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>grandparent</em>",
-                    "data-playback": "Joe Bloggs is your <em>grandparent</em>"
-                }
-            },
-            {
-                "id": "other-relation",
-                "value": "other-relation",
-                "label": {
-                    "text": "Other relation"
+                {
+                    "id": "other-relation",
+                    "value": "other-relation",
+                    "label": {
+                        "text": "Other relation"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is your <em>other relation</em>",
+                        "data-playback": "Joe Bloggs is your <em>other relation</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Joe Bloggs is your <em>other relation</em>",
-                    "data-playback": "Joe Bloggs is your <em>other relation</em>"
+                {
+                    "id": "unrelated",
+                    "value": "unrelated",
+                    "label": {
+                        "text": "Unrelated",
+                        "description": "Including foster child"
+                    },
+                    "attributes": {
+                        "data-title": "Joe Bloggs is <em>unrelated</em> to you",
+                        "data-playback": "Joe Bloggs is <em>unrelated</em> to you"
+                    }
                 }
-            },
-            {
-                "id": "unrelated",
-                "value": "unrelated",
-                "label": {
-                    "text": "Unrelated",
-                    "description": "Including foster child"
-                },
-                "attributes": {
-                    "data-title": "Joe Bloggs is <em>unrelated</em> to you",
-                    "data-playback": "Joe Bloggs is <em>unrelated</em> to you"
-                }
-            }
-        ]
-    }) }}
+            ]
+        }) }}
+    {% endcall %}
 {% endblock %}

--- a/src/components/relationships/examples/relationships/index.njk
+++ b/src/components/relationships/examples/relationships/index.njk
@@ -2,6 +2,7 @@
 layout: none
 ---
 {% extends "styles/page-template/_template.njk" %}
+{% from "components/question/_macro.njk" import onsQuestion %}
 {% from "components/relationships/_macro.njk" import onsRelationships %}
 
 {% set pageConfig = {
@@ -9,160 +10,162 @@ layout: none
 } %}
 
 {% block main %}
-    {{ onsRelationships({
-        "question": {
-            "title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>…</em>",
-            "description": "<p>Complete the sentence by selecting the appropriate relationship.</p>"
-        },
-        "legend": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>…</em>",
-        "legendClasses": "u-vh",
-        "playback": "Amanda Bloggs is Joe Bloggs' <em>…</em>",
-        "name": "relationship",
-        "radios": [
-            {
-                "id": "husband-wife",
-                "value": "husband-wife",
-                "label": {
-                    "text": "Husband or wife"
+    {% call onsQuestion({
+        "title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>…</em>",
+        "description": "<p>Complete the sentence by selecting the appropriate relationship.</p>",
+        "readDescriptionFirst": true
+    }) %}
+        {{ onsRelationships({
+            "legend": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>…</em>",
+            "legendClasses": "u-vh",
+            "playback": "Amanda Bloggs is Joe Bloggs' <em>…</em>",
+            "name": "relationship",
+            "radios": [
+                {
+                    "id": "husband-wife",
+                    "value": "husband-wife",
+                    "label": {
+                        "text": "Husband or wife"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>husband or wife</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>husband or wife</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>husband or wife</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>husband or wife</em>"
-                }
-            },
-            {
-                "id": "civil-partner",
-                "value": "civil-partner",
-                "label": {
-                    "text": "Legally registered civil partner"
+                {
+                    "id": "civil-partner",
+                    "value": "civil-partner",
+                    "label": {
+                        "text": "Legally registered civil partner"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>legally registered civil partner</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>legally registered civil partner</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>legally registered civil partner</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>legally registered civil partner</em>"
-                }
-            },
-            {
-                "id": "partner",
-                "value": "partner",
-                "label": {
-                    "text": "Partner"
+                {
+                    "id": "partner",
+                    "value": "partner",
+                    "label": {
+                        "text": "Partner"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>partner</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>partner</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>partner</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>partner</em>"
-                }
-            },
-            {
-                "id": "son-daughter",
-                "value": "son-daughter",
-                "label": {
-                    "text": "Son or daughter"
+                {
+                    "id": "son-daughter",
+                    "value": "son-daughter",
+                    "label": {
+                        "text": "Son or daughter"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>son or daughter</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>son or daughter</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>son or daughter</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>son or daughter</em>"
-                }
-            },
-            {
-                "id": "stepchild",
-                "value": "stepchild",
-                "label": {
-                    "text": "Stepchild"
+                {
+                    "id": "stepchild",
+                    "value": "stepchild",
+                    "label": {
+                        "text": "Stepchild"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>stepchild</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>stepchild</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>stepchild</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>stepchild</em>"
-                }
-            },
-            {
-                "id": "brother-sister",
-                "value": "brother-sister",
-                "label": {
-                    "text": "Brother or sister"
+                {
+                    "id": "brother-sister",
+                    "value": "brother-sister",
+                    "label": {
+                        "text": "Brother or sister"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>brother or sister</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>brother or sister</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>brother or sister</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>brother or sister</em>"
-                }
-            },
-            {
-                "id": "stepbrother-stepsister",
-                "value": "stepbrother-stepsister",
-                "label": {
-                    "text": "Stepbrother or stepsister"
+                {
+                    "id": "stepbrother-stepsister",
+                    "value": "stepbrother-stepsister",
+                    "label": {
+                        "text": "Stepbrother or stepsister"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>stepbrother or sister</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>stepbrother or sister</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>stepbrother or sister</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>stepbrother or sister</em>"
-                }
-            },
-            {
-                "id": "mother-father",
-                "value": "mother-father",
-                "label": {
-                    "text": "Mother or father"
+                {
+                    "id": "mother-father",
+                    "value": "mother-father",
+                    "label": {
+                        "text": "Mother or father"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>mother or father</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>mother or father</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>mother or father</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>mother or father</em>"
-                }
-            },
-            {
-                "id": "stepmother-stepfather",
-                "value": "stepmother-stepfather",
-                "label": {
-                    "text": "Stepmother or stepfather"
+                {
+                    "id": "stepmother-stepfather",
+                    "value": "stepmother-stepfather",
+                    "label": {
+                        "text": "Stepmother or stepfather"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>stepmother or stepfather</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>stepmother or stepfather</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>stepmother or stepfather</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>stepmother or stepfather</em>"
-                }
-            },
-            {
-                "id": "grandchild",
-                "value": "grandchild",
-                "label": {
-                    "text": "Grandchild"
+                {
+                    "id": "grandchild",
+                    "value": "grandchild",
+                    "label": {
+                        "text": "Grandchild"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>grandchild</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>grandchild</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>grandchild</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>grandchild</em>"
-                }
-            },
-            {
-                "id": "grandparent",
-                "value": "grandparent",
-                "label": {
-                    "text": "Grandparent"
+                {
+                    "id": "grandparent",
+                    "value": "grandparent",
+                    "label": {
+                        "text": "Grandparent"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>grandparents</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>grandparents</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>grandparents</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>grandparents</em>"
-                }
-            },
-            {
-                "id": "other-relation",
-                "value": "other-relation",
-                "label": {
-                    "text": "Other relation"
+                {
+                    "id": "other-relation",
+                    "value": "other-relation",
+                    "label": {
+                        "text": "Other relation"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>other relation</em>",
+                        "data-playback": "Amanda Bloggs is Joe Bloggs' <em>other relation</em>"
+                    }
                 },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is their <em>other relation</em>",
-                    "data-playback": "Amanda Bloggs is Joe Bloggs' <em>other relation</em>"
+                {
+                    "id": "unrelated",
+                    "value": "unrelated",
+                    "label": {
+                        "text": "Unrelated",
+                        "description": "Including foster child"
+                    },
+                    "attributes": {
+                        "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is <em>unrelated</em> to Joe Bloggs",
+                        "data-playback": "Amanda Bloggs is <em>unrelated</em> to Joe Bloggs"
+                    }
                 }
-            },
-            {
-                "id": "unrelated",
-                "value": "unrelated",
-                "label": {
-                    "text": "Unrelated",
-                    "description": "Including foster child"
-                },
-                "attributes": {
-                    "data-title": "Thinking of Joe Bloggs, Amanda Bloggs is <em>unrelated</em> to Joe Bloggs",
-                    "data-playback": "Amanda Bloggs is <em>unrelated</em> to Joe Bloggs"
-                }
-            }
-        ]
-    }) }}
+            ]
+        }) }}
+    {% endcall %}
 {% endblock %}

--- a/src/patterns/question/index.njk
+++ b/src/patterns/question/index.njk
@@ -29,6 +29,8 @@ Questions should be wrapped in a fieldset when:
 * If one of the answers to the question is a [Date](/patterns/dates)
 * If any of the answers to the question are a [Duration](/patterns/durations)
 
+If this is wrapping a relationships pattern its recommended that `readDescriptionFirst` is set to true on so that the description is read first by screenreaders which will make more sense to the user.
+
 ## Examples
 
 ### Question as a fieldset

--- a/src/patterns/relationships/index.njk
+++ b/src/patterns/relationships/index.njk
@@ -8,6 +8,8 @@ group: Ask users for...
 
 Help users define relationships between household memebers.
 
+If this is used within a the question macro its recommended that `readDescriptionFirst` in the question params is set to true on so that the description is read first by screenreaders which will make more sense to the user.
+
 {{
     patternlibExample({"path": "components/relationships/examples/relationships/index.njk"})
 }}

--- a/src/patterns/relationships/index.njk
+++ b/src/patterns/relationships/index.njk
@@ -8,7 +8,13 @@ group: Ask users for...
 
 Help users define relationships between household memebers.
 
-If this is used within a the question macro its recommended that `readDescriptionFirst` in the question params is set to true on so that the description is read first by screenreaders which will make more sense to the user.
+## When to use this pattern 
+This pattern should be used when you need to collect the relationship between two people.
+
+## How to use this pattern 
+Call `onsRelationships` within `onsQuestion`, setting `readDescriptionFirst: true` so the description is read before the incomplete heading sentence by screen readers, to add context.
+
+The pattern is enhanced with javascript, to complete the sentence in the heading and `playback` when the user selects a radio option.
 
 {{
     patternlibExample({"path": "components/relationships/examples/relationships/index.njk"})

--- a/src/patterns/relationships/index.njk
+++ b/src/patterns/relationships/index.njk
@@ -8,6 +8,10 @@ group: Ask users for...
 
 Help users define relationships between household memebers.
 
+{{
+    patternlibExample({"path": "components/relationships/examples/relationships/index.njk"})
+}}
+
 ## When to use this pattern 
 This pattern should be used when you need to collect the relationship between two people.
 
@@ -15,10 +19,6 @@ This pattern should be used when you need to collect the relationship between tw
 Call `onsRelationships` within `onsQuestion`, setting `readDescriptionFirst: true` so the description is read before the incomplete heading sentence by screen readers, to add context.
 
 The pattern is enhanced with javascript, to complete the sentence in the heading and `playback` when the user selects a radio option.
-
-{{
-    patternlibExample({"path": "components/relationships/examples/relationships/index.njk"})
-}}
 
 ## Other examples
 


### PR DESCRIPTION
### What is the context of this PR?
This is a change to a previous breaking change to make screen readers read out the question description first to make more sense to the user. This change was difficult to implement in runner so this change is to reverse the breaking part of that PR (moving question inside of relationships) and just advise the user to make sure to use `readDescriptionFirst` on relationships wrapped in questions.

### How to review 
- Check docs and code make sense
- Examples work as they should
- Description is read out first on relationship examples