### PR TITLE
Fix spacing on inline lists for footers accordions and spacious lists

### DIFF
--- a/src/components/lists/_list.scss
+++ b/src/components/lists/_list.scss
@@ -8,6 +8,12 @@
     }
   }
 
+  &--spacious {
+    .list__item {
+      margin: 0 0 1.5rem;
+    }
+  }
+
   &--bare {
     padding-left: 0;
     list-style: none;

--- a/src/components/lists/_list.scss
+++ b/src/components/lists/_list.scss
@@ -1,5 +1,5 @@
 .list {
-  margin: 0;
+  margin: 0 0 1rem;
   padding: 0 0 0 1.5rem;
 
   &__item {

--- a/src/components/lists/_list.scss
+++ b/src/components/lists/_list.scss
@@ -57,10 +57,10 @@
 
 @include bp-suffix('list--inline') {
   &:not(.list--icons) {
-    margin: 0 1rem;
+    margin: 0 1rem 0 0;
     .list__item {
       display: inline-block;
-      margin: 0 1rem;
+      margin: 0 1rem 0 0;
       vertical-align: top;
     }
   }


### PR DESCRIPTION
### What is the context of this PR?
Fixes issues with inline lists on footers, accordions and spacious lists

![image](https://user-images.githubusercontent.com/42928680/98103094-67c2b380-1e8c-11eb-966b-d7a29e9ec232.png)
<img width="732" alt="Screenshot 2020-11-04 at 10 58 13" src="https://user-images.githubusercontent.com/42928680/98107505-82982680-1e92-11eb-9267-c78200bf7df0.png">
<img width="689" alt="Screenshot 2020-11-04 at 11 00 45" src="https://user-images.githubusercontent.com/42928680/98107513-862bad80-1e92-11eb-8677-b3109ba1adcf.png">

### How to review 
Check footers with inline lists, accordions and spacious lists now look good
