### PR TITLE
Fix classes param for checkbox selects

### DIFF
--- a/src/components/checkboxes/_checkbox-macro.njk
+++ b/src/components/checkboxes/_checkbox-macro.njk
@@ -50,7 +50,7 @@
                         "id": params.other.id,
                         "name": params.other.name,
                         "options": params.other.options,
-                        "classes": radio.other.classes,
+                        "classes": params.other.classes,
                         "label": {
                             "id": params.other.id + "-label",
                             "text": params.other.label.text,


### PR DESCRIPTION
### What is the context of this PR?
Bug in checkbox selects where classes aren't being passed because of typo

### How to review 
Check that checkbox selects work correctly with classes being passed correctly