### PR TITLE
Fix Selects cutting off the bottom of text

### DIFF
--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -70,9 +70,10 @@
 
 .input--select {
   appearance: none;
-  padding: 0.5rem 2rem 0.5rem $input-padding-horizontal;
+  padding: 0.39rem 2rem 0.39rem $input-padding-horizontal;
   background: $color-white url('#{$static}/img/icons--chevron-down.svg') no-repeat center right 10px;
   background-size: 1rem;
+  line-height: 1.3rem;
 
   &::-ms-expand {
     display: none;


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #1156 

### How to review 
- Check selects no longer cut the bottom of text when used
- Check they still look and act as expected