### PR TITLE
Change single breadcrumb breakpoint

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -36,7 +36,7 @@ $breadcrumb-chevron-height: 0.65rem;
       }
     }
 
-    @include mq(s) {
+    @include mq(m) {
       //big screen
       &:not(:nth-last-child(1)) {
         //not last child

--- a/src/components/breadcrumb/_macro.njk
+++ b/src/components/breadcrumb/_macro.njk
@@ -6,7 +6,7 @@
             {% for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) %}
                 <li id="breadcrumb-{{ loop.index }}" class="breadcrumb__item">
                     <a href="{{ item.url }}" class="breadcrumb__link" id="{{ item.id }}"
-                    {% if item.attributes is defined and item.attributes %}{% for attribute, value in (item.attributes.items() if item.attributes is mapping and item.attributes.items else item.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
+                        {% if item.attributes is defined and item.attributes %}{% for attribute, value in (item.attributes.items() if item.attributes is mapping and item.attributes.items else item.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
                     >{{ item.text }}</a>
                     {{
                         onsIcon({


### PR DESCRIPTION
### What is the context of this PR?
Breadcrumbs switching to single happens after language header removal and sign out button moving to footer. This will fix this issue so all things change at the same point.

Also fixes some indentation

### How to review 
Check the customised page template example and make the viewport smaller to see changes