### PR TITLE
Fix error panels focusing on DS examples

### DIFF
--- a/src/components/date-input/examples/date-input-error/index.njk
+++ b/src/components/date-input/examples/date-input-error/index.njk
@@ -50,7 +50,8 @@
             "name": "year"
         },
         "error": {
-            "text": "Enter a 'period to' date later than the 'period from' date"
+            "text": "Enter a 'period to' date later than the 'period from' date",
+            "DSExample": true
         }
     })
 }}

--- a/src/components/error/_macro.njk
+++ b/src/components/error/_macro.njk
@@ -14,7 +14,8 @@
     {% call onsPanel({
         "type": "error",
         "id": params.id,
-        "classes": "u-mb-s"
+        "classes": "u-mb-s",
+        "DSExample": params.DSExample
     }) %}
        {{ content | safe }}
     {% endcall %}

--- a/src/components/error/index.njk
+++ b/src/components/error/index.njk
@@ -22,11 +22,12 @@ Generally speaking you should not need to {{
     })
 }} `onsError`.
 {% md %}
-| Name       | Type   | Required | Description                                                       |
-| ---------- | ------ | -------- | ----------------------------------------------------------------- |
-| text       | string | true     | The text that describes the error message                         |
-| id         | string | true     | The id that the error link can anchor to                          |
-| attributes | object | false    | HTML attributes (for example data attributes) to add to the field |
+| Name       | Type    | Required | Description                                                                         |
+| ---------- | ------- | -------- | ----------------------------------------------------------------------------------- |
+| text       | string  | true     | The text that describes the error message                                           |
+| id         | string  | true     | The id that the error link can anchor to                                            |
+| attributes | object  | false    | HTML attributes (for example data attributes) to add to the field                   |
+| DSExample  | boolean | false    | If set to true will not focus on error on page load - *only for use in DS examples* |
 {% endmd %}
 
 ## Research on this component

--- a/src/components/panel/_macro-options.md
+++ b/src/components/panel/_macro-options.md
@@ -1,13 +1,14 @@
-| Name       | Type    | Required | Description                                                                                                                        |
-| ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| body       | string  | true     | The contents of the panel. This can be a string of HTML                                                                            |
-| title      | string  | false    | The title for the panel. If this is not provided the inline/no title version will be rendered                                      |
-| titleTag   | string  | false    | The html tag to wrap the title text in. Will default to a `div` (for error summaries we recommend this is set to `h1`)             |
-| type       | string  | false    | The type of panel to render. Available options are `success`, `warn`, `error` and `branded`                                        |
-| spacious   | boolean | false    | Will render a more spacious version of the panel if set to `true`                                                                  |
-| classes    | string  | false    | Custom classes to add to the panel                                                                                                 |
-| id         | string  | false    | Custom id to add to the panel                                                                                                      |
-| attributes | object  | false    | HTML attributes to apply to the panel (e.g. data attributes)                                                                       |
-| icon       | string  | false    | Set this to the name of the icon you want to be included before the contents of the panel                                          |
-| iconSize   | string  | false    | Set this to the size of the icon you want can be set to "m", "l" "xl" to match heading size. Defaults to the size of regualar text |
-| iconsPath  | string  | false    | Set this to the path to the icon you want to be included before the contents of the panel                                          |
+| Name       | Type    | Required | Description                                                                                                                                                 |
+| ---------- | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| body       | string  | true     | The contents of the panel. This can be a string of HTML                                                                                                     |
+| title      | string  | false    | The title for the panel. If this is not provided the inline/no title version will be rendered                                                               |
+| titleTag   | string  | false    | The html tag to wrap the title text in. Will default to a `div` (for error summaries we recommend this is set to `h1`)                                      |
+| type       | string  | false    | The type of panel to render. Available options are `success`, `warn`, `error` and `branded`                                                                 |
+| spacious   | boolean | false    | Will render a more spacious version of the panel if set to `true`                                                                                           |
+| classes    | string  | false    | Custom classes to add to the panel                                                                                                                          |
+| id         | string  | false    | Custom id to add to the panel                                                                                                                               |
+| attributes | object  | false    | HTML attributes to apply to the panel (e.g. data attributes)                                                                                                |
+| icon       | string  | false    | Set this to the name of the icon you want to be included before the contents of the panel                                                                   |
+| iconSize   | string  | false    | Set this to the size of the icon you want can be set to "m", "l" "xl" to match heading size. Defaults to the size of regualar text                          |
+| iconsPath  | string  | false    | Set this to the path to the icon you want to be included before the contents of the panel                                                                   |
+| DSExample  | boolean | false    | Set this to `true` when using error panels in Design System examples. This will stop the page focusing on the panel on load - _only for use in DS examples_ |

--- a/src/components/panel/_macro.njk
+++ b/src/components/panel/_macro.njk
@@ -9,7 +9,7 @@
 
     {% if params is defined and params and params.type is defined and params.type %}
         {% set typeClass = ' panel--' + params.type %}
-        {% if params is defined and params and params.type == 'error' %}
+        {% if params is defined and params and params.type == 'error' and params.DSExample != true %}
             {% set errorJsClass = ' js-error-panel' %}
         {% endif %}
     {% else %}

--- a/src/components/panel/examples/error-header/index.njk
+++ b/src/components/panel/examples/error-header/index.njk
@@ -4,7 +4,8 @@
 {% call onsPanel({
         "title": "There are 2 problems with your answer",
         "titleTag": "h1",
-        "type": "error"
+        "type": "error",
+        "DSExample": true
 }) %}
 
     {{

--- a/src/components/panel/examples/error/index.njk
+++ b/src/components/panel/examples/error/index.njk
@@ -13,7 +13,8 @@
             "text": "Number of employees paid monthly"
         },
         "error": {
-            "text": "Enter a number"
+            "text": "Enter a number",
+            "DSExample": true
         }
     })
 }}

--- a/src/components/uac/examples/uac-error/index.njk
+++ b/src/components/uac/examples/uac-error/index.njk
@@ -14,7 +14,8 @@ layout: none
     {% call
         onsPanel({
             title: "There is a problem with your answer",
-            type: "error"
+            type: "error",
+            "DSExample": true
         })
     %}
 
@@ -49,7 +50,8 @@ layout: none
         "securityMessage": "Your personal information is protected by law and will be kept confidential.",
         "error": {
             "id": "uac",
-            "text": "Enter an access code"
+            "text": "Enter an access code",
+            "DSExample": true
         }
     }) }}
 

--- a/src/patterns/error-validation/examples/error-details/index.njk
+++ b/src/patterns/error-validation/examples/error-details/index.njk
@@ -12,7 +12,8 @@
             "text": "Number of employees paid monthly"
         },
         "error": {
-            "text": "Enter a number"
+            "text": "Enter a number",
+            "DSExample": true
         }
     })
 }}
@@ -34,7 +35,8 @@
             "text": "%"
         },
         "error": {
-            "text": "Enter a number less than or equal to 100"
+            "text": "Enter a number less than or equal to 100",
+            "DSExample": true
         }
     })
 }}

--- a/src/patterns/error-validation/examples/error-summary/index.njk
+++ b/src/patterns/error-validation/examples/error-summary/index.njk
@@ -5,7 +5,8 @@
     onsPanel({
         title: "There are 2 problems with your answer",
         type: "error",
-        "titleTag": "h1"
+        "titleTag": "h1",
+        "DSExample": true
     })
 %}
 

--- a/src/patterns/feedback/examples/feedback-form-validation/index.njk
+++ b/src/patterns/feedback/examples/feedback-form-validation/index.njk
@@ -41,7 +41,8 @@ layout: none
     {% call
         onsPanel({
             title: "There are 2 problems with this page",
-            type: "error"
+            type: "error",
+            "DSExample": true
         })
     %}
         {% from "components/lists/_macro.njk" import onsList %}
@@ -77,7 +78,8 @@ layout: none
                 "name": "feedback-type",
                 "error": {
                     "id": "feedback-type",
-                    "text": "Select what your feedback is about"
+                    "text": "Select what your feedback is about",
+                    "DSExample": true
                 },
                 "radios": [
                     {
@@ -170,7 +172,8 @@ layout: none
                 },
                 "error": {
                     "id": "feedback-content",
-                    "text": "Enter your feedback"
+                    "text": "Enter your feedback",
+                    "DSExample": true
                 }
             })
         }}


### PR DESCRIPTION
### What is the context of this PR?
This is to stop error panels focusing on page load in Design System examples. Fixes: #995 

### How to review 
- Check errors do focus on page load if `DSExample` isnt set
- Check that DS pages with error panels on no longer focus on page load