### PR TITLE
Fix autosuggest error when there is no status code

### DIFF
--- a/src/components/input/autosuggest/autosuggest.ui.js
+++ b/src/components/input/autosuggest/autosuggest.ui.js
@@ -198,11 +198,6 @@ export default class AutosuggestUI {
     }
   }
 
-  // handleFocus() {
-  //   clearTimeout(this.blurTimeout);
-  //   this.getSuggestions(true);
-  // }
-
   handleBlur() {
     clearTimeout(this.blurTimeout);
     this.blurring = true;
@@ -401,7 +396,7 @@ export default class AutosuggestUI {
       message = this.typeMore;
       this.setAriaStatus(message);
       this.listbox.innerHTML = `<li class="${classAutosuggestOption} ${classAutosuggestOptionNoResults}">${message}</li>`;
-    } else if (status > 400) {
+    } else if (status > 400 || status === '') {
       message = this.errorAPI + (this.errorAPILinkText ? ' <a href="' + window.location.href + '">' + this.errorAPILinkText + '</a>' : '');
 
       this.input.setAttribute('disabled', true);

--- a/src/tests/spec/autosuggest/autosuggest.ui.spec.js
+++ b/src/tests/spec/autosuggest/autosuggest.ui.spec.js
@@ -1176,6 +1176,37 @@ describe('Autosuggest.ui component', function() {
           expect(this.setAriaStatusSpy).to.have.been.called();
         });
       });
+
+      describe('when there is no status code', function() {
+        beforeEach(function() {
+          this.handleNoResultsSpy = chai.spy.on(this.autosuggest, 'handleNoResults');
+          this.setAriaStatusSpy = chai.spy.on(this.autosuggest, 'setAriaStatus');
+          this.createWarningSpy = chai.spy.on(this.autosuggest, 'createWarningElement');
+          this.autosuggest.handleNoResults('');
+        });
+
+        it('then the listbox innerHTML should show the API error message', function() {
+          expect(this.autosuggest.listbox.textContent).to.equal('!' + params.autosuggest.errorMessageAPI);
+          expect(this.createWarningSpy).to.have.been.called();
+          expect(this.handleNoResultsSpy).to.have.been.called();
+        });
+
+        it('the input should be disabled', function() {
+          expect(this.input.hasAttribute('disabled')).to.be.true;
+        });
+
+        it('the input value should be empty', function() {
+          expect(this.input.value).to.equal('');
+        });
+
+        it('the label class should be added', function() {
+          expect(this.label.classList.contains('u-lighter')).to.be.true;
+        });
+
+        it('then the aria status should be set', function() {
+          expect(this.setAriaStatusSpy).to.have.been.called();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### What is the context of this PR?
The address autosuggest was showing the incorrect error when the API had been blocked due to the CORS policy. Because the CORS error contains no status code the "no results" error was being shown instead This PR will ensure it shows the correct API error and has a test added for that situation.

### How to review 
Check the correct error is shown when no status code is returned from the API