### PR TITLE
Allow setting of grid col number

### DIFF
--- a/src/styles/page-template/_template.njk
+++ b/src/styles/page-template/_template.njk
@@ -11,7 +11,7 @@
     {% set otherLanguageISOCode = otherLanguage.ISOCode %}
 {% endif %}
 
-{% set pageColNumber = "8" %}
+{% set pageColNumber = pageConfig.pageColNumber | default("8") %}
 
 {% if pageConfig.cdn is defined and pageConfig.cdn or release_version is defined and release_version %}
     {# Production #}

--- a/src/styles/page-template/_template.njk
+++ b/src/styles/page-template/_template.njk
@@ -11,6 +11,9 @@
     {% set otherLanguageISOCode = otherLanguage.ISOCode %}
 {% endif %}
 
+
+{% set pageColNumber = pageConfig.pageColNumber if pageConfig.pageColNumber is defined and pageConfig.pageColNumber else "8" %}
+
 {% if pageConfig.cdn is defined and pageConfig.cdn or release_version is defined and release_version %}
     {# Production #}
     {% set cdn_url = (pageConfig.cdn.url if pageConfig.cdn is defined and pageConfig.cdn) or "https://cdn.ons.gov.uk/sdc/design-system" %}
@@ -135,7 +138,7 @@
                             {% endif %}
                             {% block preMain %}{% endblock %}
                             <div class="grid">
-                                <div class="grid__col col-8@m">
+                                <div class="grid__col col-{{ pageColNumber }}@m">
                                     <main id="main-content" class="page__main {{ pageClasses }}">
                                         {% block main %}{% endblock %}
                                     </main>

--- a/src/styles/page-template/_template.njk
+++ b/src/styles/page-template/_template.njk
@@ -11,8 +11,7 @@
     {% set otherLanguageISOCode = otherLanguage.ISOCode %}
 {% endif %}
 
-
-{% set pageColNumber = pageConfig.pageColNumber if pageConfig.pageColNumber is defined and pageConfig.pageColNumber else "8" %}
+{% set pageColNumber = "8" %}
 
 {% if pageConfig.cdn is defined and pageConfig.cdn or release_version is defined and release_version %}
     {# Production #}

--- a/src/styles/page-template/index.njk
+++ b/src/styles/page-template/index.njk
@@ -138,6 +138,7 @@ Variables can be set with:
 | phase         | `PhaseBanner` [_(ref)_](/components/phase-banner)   | false                             | Settings for the Phase banner                                                                |
 | serviceLinks  | `Array<Navigation>` [_(ref)_](/components/header)   | false                             | An array to render the service links list                                                    |
 | footer        | `PageFooter` [_(ref)_](#pagefooter)                 | true                              | Configuration for the page footer                                                            |
+| pageColNumber | string                                              | false                             | sets the number of grid columns for the page (defaults to 8)                                 |
 {% endmd %}
 
 ###### PageHeader

--- a/src/styles/page-template/index.njk
+++ b/src/styles/page-template/index.njk
@@ -126,7 +126,7 @@ Variables can be set with:
 | assetsURL     | string                                              | false                             | The base url where to find CSS/JS/images etc. e.g. `http://localhost:3030`                   |
 | theme         | string                                              | false                             | The name of the css file e.g. "census" if using a theme. Defaults to "main".                 |
 | title         | string                                              | true                              | The contents for the `<title>` element                                                       |
-| cspNonce      | string                                              | false                             | The Content Security Policy (CSP) nonce value                                                      |
+| cspNonce      | string                                              | false                             | The Content Security Policy (CSP) nonce value                                                |
 | headMeta      | `HeadMeta` [_(ref)_](#headmeta)                     | false                             | Configuration for `<meta>` information in the document `<head>`                              |
 | breadcrumbs   | `Breadcrumbs` [_(ref)_](/components/breadcrumb)     | false                             | Configuration for the breadcrumbs or back link                                               |
 | bodyClasses   | string                                              | false                             | Classes to add to the `<body>` element                                                       |
@@ -138,6 +138,7 @@ Variables can be set with:
 | phase         | `PhaseBanner` [_(ref)_](/components/phase-banner)   | false                             | Settings for the Phase banner                                                                |
 | serviceLinks  | `Array<Navigation>` [_(ref)_](/components/header)   | false                             | An array to render the service links list                                                    |
 | footer        | `PageFooter` [_(ref)_](#pagefooter)                 | true                              | Configuration for the page footer                                                            |
+| pageColNumber | string                                              | false                             | sets the number of grid columns for the page (defaults to 8)                                 |
 {% endmd %}
 
 ###### PageHeader

--- a/src/styles/page-template/index.njk
+++ b/src/styles/page-template/index.njk
@@ -138,7 +138,6 @@ Variables can be set with:
 | phase         | `PhaseBanner` [_(ref)_](/components/phase-banner)   | false                             | Settings for the Phase banner                                                                |
 | serviceLinks  | `Array<Navigation>` [_(ref)_](/components/header)   | false                             | An array to render the service links list                                                    |
 | footer        | `PageFooter` [_(ref)_](#pagefooter)                 | true                              | Configuration for the page footer                                                            |
-| pageColNumber | string                                              | false                             | sets the number of grid columns for the page (defaults to 8)                                 |
 {% endmd %}
 
 ###### PageHeader


### PR DESCRIPTION
### What is the context of this PR?
Allow setting of grid col number in the pageConfig. This change was due to it needing to be able to be overwritten for the census website

### How to review 
Check `pageColNumber` can be set and it defaults to 8 if not set