### PR TITLE
Changed border colour between downloads to align

### DIFF
--- a/src/components/downloads/_downloads.scss
+++ b/src/components/downloads/_downloads.scss
@@ -4,7 +4,7 @@
   & + & {
     margin: 1.5rem 0 0;
     padding: 1.5em 0 0;
-    border-top: 1px solid $color-grey-4;
+    border-top: 1px solid $color-grey-2;
   }
 
   &__image {


### PR DESCRIPTION
Changed border colour between items to align with general border colour.

I personally think the borders are too dark. However the dark border seems to be what we are using everywhere, so have updated download borders to match.