### PR TITLE
Added placeholder images if none defined

### DIFF
--- a/src/components/articles/_articles.scss
+++ b/src/components/articles/_articles.scss
@@ -4,28 +4,6 @@
     display: flex;
   }
 
-  // Featured
-  &--featured {
-    background-color: $color-grey-5;
-    border-top: 0;
-    padding-bottom: 0;
-    padding-top: 0;
-
-    & .article__image {
-      margin-right: 0;
-      margin-bottom: 1.5rem;
-
-      @include mq(m) {
-        margin-right: 1.5rem;
-        margin-bottom: 0;
-      }
-    }
-
-    & .article__image img {
-      width: 100%;
-    }
-  }
-
   & + & {
     border-top: 1px solid $color-grey-4;
     margin: 1.5rem 0 0;
@@ -39,6 +17,7 @@
   &__image {
     flex-shrink: 0;
     margin-bottom: 1rem;
+    max-width: 140px;
 
     @include mq(s) {
       display: flex;
@@ -78,6 +57,29 @@
       &:hover {
         color: $color-black;
       }
+    }
+  }
+
+  // Featured
+  &--featured {
+    background-color: $color-grey-5;
+    border-top: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+
+    & .article__image {
+      margin-right: 0;
+      margin-bottom: 1.5rem;
+      max-width: 379px;
+
+      @include mq(m) {
+        margin-right: 1.5rem;
+        margin-bottom: 0;
+      }
+    }
+
+    & .article__image img {
+      width: 100%;
     }
   }
 }

--- a/src/components/articles/_macro.njk
+++ b/src/components/articles/_macro.njk
@@ -25,7 +25,7 @@
 
                             {% else %}
 
-                                {% if article.image is defined and article.image and article.image.filename %}
+                                {% if article.image is defined and article.image and article.image.filename is defined and article.image.filename %}
                                     <img height="92" width="140" srcset="{{ article.image.smallSrc }}{{ article.image.filename }} 1x, {{ article.image.largeSrc }}{{ article.image.filename }} 2x" src="{{ article.image.smallSrc }}{{ article.image.filename }}" alt="{{ article.image.alt }}" loading="lazy">
                                 {% else %}
                                     <img height="92" width="140" srcset="{{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/small/placeholder-news.png 1x, {{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/large/placeholder-news.png 2x" src="{{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/small/placeholder-news.png" alt="Image placeholder" loading="lazy">

--- a/src/components/articles/_macro.njk
+++ b/src/components/articles/_macro.njk
@@ -1,5 +1,6 @@
 {% macro onsArticles(params) %}
 
+
     {% for article in (params.articles if params.articles is iterable else params.articles.items()) %}
     <article class="article{% if article.featured %} article--featured {% endif %}{{ ' ' + params.classes if params.classes else '' }}">
 
@@ -10,19 +11,36 @@
                 <div class="grid__col col-5@m">
                 {% endif %}
 
-
                     <div class="article__image" aria-hidden="true">
-                        <a class="article__image-link" href="{{ article.url }}" tabindex="-1">
-                            <img srcset="{{ article.image.smallSrc }}{{ article.image.filename }} 1x, {{ article.image.largeSrc }}{{ article.image.filename }} 2x" src="{{ article.image.smallSrc }}{{ article.image.filename }}" alt="{{ article.image.alt }}">
-                        </a>
-                    </div>
 
+                        <a class="article__image-link" href="{{ article.url }}" tabindex="-1">
+
+                            {% if article.featured is defined and article.featured %}
+
+                                {% if article.image is defined and article.image and article.image.filename %}
+                                    <img height="248" width="379" srcset="{{ article.image.smallSrc }}{{ article.image.filename }} 1x, {{ article.image.largeSrc }}{{ article.image.filename }} 2x" src="{{ article.image.smallSrc }}{{ article.image.filename }}" alt="{{ article.image.alt }}" loading="lazy">
+                                {% else %}
+                                    <img height="248" width="379" srcset="{{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/small/placeholder-news-medium.png 1x, {{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/large/placeholder-news-medium.png 2x" src="{{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/small/placeholder-news-medium.png" alt="Image placeholder" loading="lazy">
+                                {% endif %}
+
+                            {% else %}
+
+                                {% if article.image is defined and article.image and article.image.filename %}
+                                    <img height="92" width="140" srcset="{{ article.image.smallSrc }}{{ article.image.filename }} 1x, {{ article.image.largeSrc }}{{ article.image.filename }} 2x" src="{{ article.image.smallSrc }}{{ article.image.filename }}" alt="{{ article.image.alt }}" loading="lazy">
+                                {% else %}
+                                    <img height="92" width="140" srcset="{{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/small/placeholder-news.png 1x, {{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/large/placeholder-news.png 2x" src="{{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/small/placeholder-news.png" alt="Image placeholder" loading="lazy">
+                                {% endif %}
+
+                            {% endif %}
+
+                        </a>
+
+                    </div>
 
                 {% if article.featured is defined and article.featured %}
                 </div>
                 <div class="grid__col col-7@m">
                 {% endif %}
-
 
                     <div class="article__content">
 
@@ -49,7 +67,6 @@
                         {% endif %}
 
                     </div>
-
 
                 {% if article.featured is defined and article.featured %}
                 </div>

--- a/src/components/articles/_macro.njk
+++ b/src/components/articles/_macro.njk
@@ -17,7 +17,7 @@
 
                             {% if article.featured is defined and article.featured %}
 
-                                {% if article.image is defined and article.image and article.image.filename %}
+                                {% if article.image is defined and article.image and article.image.filename is defined and article.image.filename %}
                                     <img height="248" width="379" srcset="{{ article.image.smallSrc }}{{ article.image.filename }} 1x, {{ article.image.largeSrc }}{{ article.image.filename }} 2x" src="{{ article.image.smallSrc }}{{ article.image.filename }}" alt="{{ article.image.alt }}" loading="lazy">
                                 {% else %}
                                     <img height="248" width="379" srcset="{{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/small/placeholder-news-medium.png 1x, {{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/large/placeholder-news-medium.png 2x" src="{{ article.placeholderURL if article.placeholderURL is defined and article.placeholderURL }}/img/small/placeholder-news-medium.png" alt="Image placeholder" loading="lazy">

--- a/src/components/articles/examples/articles-featured/index.njk
+++ b/src/components/articles/examples/articles-featured/index.njk
@@ -3,12 +3,6 @@
     "articles": [
         {
             "featured": true,
-            "image": {
-                "smallSrc": '/img/small/',
-                "largeSrc": '/img/large/',
-                "filename": 'placeholder-news-medium.png',
-                "alt": 'Census 2021 placeholer'
-            },
             "url": '#0',
             "title": 'For the first time the ONS is using administrative data to count number of rooms',
             "date": {

--- a/src/components/articles/examples/articles-multiple/index.njk
+++ b/src/components/articles/examples/articles-multiple/index.njk
@@ -2,12 +2,6 @@
 {{ onsArticles({
     "articles": [
         {
-            "image": {
-                "smallSrc": '/img/small/',
-                "largeSrc": '/img/large/',
-                "filename": 'placeholder-news.png',
-                "alt": 'Census 2021 placeholer'
-            },
             "url": '#0',
             "title": 'A new approach to counting rooms and bedrooms',
             "date": {
@@ -21,12 +15,6 @@
             "excerpt": 'As part of preparations for the 2021 Census, Andy Teague explains how ONS will be estimating the number of rooms and bedrooms at an address.'
         },
         {
-            "image": {
-                "smallSrc": '/img/small/',
-                "largeSrc": '/img/large/',
-                "filename": 'placeholder-news.png',
-                "alt": 'Census 2021 placeholer'
-            },
             "url": '#0',
             "title": 'The next steps towards the 2021 Census',
             "date": {

--- a/src/components/articles/examples/articles-single/index.njk
+++ b/src/components/articles/examples/articles-single/index.njk
@@ -2,12 +2,6 @@
 {{ onsArticles({
     "articles": [
         {
-            "image": {
-                "smallSrc": '/img/small/',
-                "largeSrc": '/img/large/',
-                "filename": 'placeholder-news.png',
-                "alt": 'Census 2021 placeholer'
-            },
             "url": '#0',
             "title": 'Find out what users told us about our plans for 2021 Census Outputs',
             "date": {


### PR DESCRIPTION
**Updated articles to include:**

- height and width property on image tag
- css max-width property on image container
- placeholder image fallbacks for featured and general articles if none specified

Image dimensions are included in the documentation and should be added into Craft as **image modifiers**. This will ensure the correct image size is used,  even if full-scale resolution images are added by the client.

**It is recommended by Google Lighthouse that image dimensions are specified on the image tag**