### PR TITLE
Create share component

### DIFF
--- a/src/components/share/_macro-options.md
+++ b/src/components/share/_macro-options.md
@@ -1,0 +1,9 @@
+| Name      | Type    | Required | Description                                                      |
+| --------- | ------- | -------- | ---------------------------------------------------------------- |
+| titleTag  | string  | false    | The HTML tag that is used the title e.g. `h2`. Defaults to `h2`  |
+| title     | string  | true     | Heading for the share component                                  |
+| pageTitle | string  | true     | Page title for the page to be shared                             |
+| pageURL   | string  | true     | Absolute URL of the page to be shared                            |
+| facebook  | boolean | false    | Display a Facebook icon/link to allow sharing to Facebook        |
+| twitter   | boolean | false    | Display a Twitter icon/link to allow sharing to Twitter          |
+| iconSize  | string  | false    | Icon size can be set to `m`, `l`, `xl`, `xxl`. Defaults to `xxl` |

--- a/src/components/share/_macro.njk
+++ b/src/components/share/_macro.njk
@@ -1,4 +1,4 @@
-{% macro onsShareContent(params) %}
+{% macro onsSharePage(params) %}
     {% from "components/lists/_macro.njk" import onsList %}
 
     {% set titleTag = params.titleTag | default("h2") %}

--- a/src/components/share/_macro.njk
+++ b/src/components/share/_macro.njk
@@ -1,0 +1,44 @@
+{% macro onsShareContent(params) %}
+    {% from "components/lists/_macro.njk" import onsList %}
+
+    {% set titleTag = params.titleTag | default("h2") %}
+    <{{ titleTag }} class="u-fs-r--b u-mb-xs">{{ params.title }}</{{ titleTag }}>
+
+    {% set list = [] %}
+    {% if params.facebook is defined and params.facebook and params.facebook === true %}
+        {% set facebook =
+            {
+                "url": 'https://www.facebook.com/sharer/sharer.php?u=' ~ params.pageURL,
+                "text": 'Facebook',
+                "prefixIcon": 'facebook',
+                "iconSize": params.iconSize | default("xxl"),
+                "rel": 'noreferrer external',
+                "target": '_blank'
+            }
+         %}
+
+        {% set list = (list.push(facebook), list) %}
+    {% endif %}
+    {% if params.twitter is defined and params.twitter and params.twitter === true %}
+        {% set twitter =
+            {
+                "url": 'https://twitter.com/intent/tweet?original_referer&text=' ~ params.pageTitle ~ '&url=' ~ params.pageURL,
+                "text": 'Twitter',
+                "prefixIcon": 'twitter',
+                "iconSize": params.iconSize | default("xxl"),
+                "rel": 'noreferrer external',
+                "target": '_blank'
+            }
+         %}
+
+        {% set list = (list.push(twitter), list) %}
+
+    {% endif %}
+
+    {{
+        onsList({
+            "classes": 'list--bare list--inline list--icons',
+            "itemsList": list
+        })
+    }}
+{% endmacro %}

--- a/src/components/share/examples/share/index.njk
+++ b/src/components/share/examples/share/index.njk
@@ -1,0 +1,11 @@
+{% from "components/share/_macro.njk" import onsShareContent %}
+
+{{
+    onsShareContent({
+        "title": "Share this post",
+        "pageTitle": "A page to share",
+        "pageURL": "https://example.com/a-page-to-share",
+        "facebook": true,
+        "twitter": true
+    })
+}}

--- a/src/components/share/examples/share/index.njk
+++ b/src/components/share/examples/share/index.njk
@@ -1,7 +1,7 @@
-{% from "components/share/_macro.njk" import onsShareContent %}
+{% from "components/share/_macro.njk" import onsSharePage %}
 
 {{
-    onsShareContent({
+    onsSharePage({
         "title": "Share this post",
         "pageTitle": "A page to share",
         "pageURL": "https://example.com/a-page-to-share",

--- a/src/components/share/index.njk
+++ b/src/components/share/index.njk
@@ -1,0 +1,33 @@
+---
+title: Share page
+experimental: true
+---
+{% from "views/partials/example/_macro.njk" import patternlibExample %}
+{% from "components/external-link/_macro.njk" import onsExternalLink %}
+{% from "components/panel/_macro.njk" import onsPanel %}
+
+Use the 'Share page' component to allow site visitors to share a page on Twitter and/or Facebook.
+
+# Example
+{{
+    patternlibExample({"path": "components/share/examples/share/index.njk"})
+}}
+
+## Research on this component
+{% call onsPanel() %}
+    If you have conducted any user research using this component, please feed back your findings via the
+    {{
+        onsExternalLink({
+            "url": "https://github.com/ONSdigital/design-system/issues/1190",
+            "linkText": "Design System forum"
+        })
+    }}
+{% endcall %}
+
+## Design System forum
+{{
+    onsExternalLink({
+        "url": "https://github.com/ONSdigital/design-system/issues/1190",
+        "linkText": "Discuss 'Share page' on GitHub"
+    })
+}}


### PR DESCRIPTION
### What is the context of this PR?
New share page component. Currently allows for sharing a page to twitter and facebook as per requirements for census website news articles.