### PR TITLE
Fix focus state on masthead and title logos

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -7,7 +7,6 @@
   -moz-osx-font-smoothing: grayscale;
 
   & &__svg-logo {
-    display: block;
     width: 100%;
     height: auto;
     fill: $color-white;
@@ -31,7 +30,7 @@
     height: 76px;
   }
 
-  &__logo-link {
+  &__logo {
     &:focus {
       outline: 3px solid transparent;
       background-color: $color-focus;
@@ -41,7 +40,7 @@
   }
 
   &__logo {
-    display: block;
+    margin-bottom: 2px;
   }
 
   &__main {

--- a/src/components/header/_macro-options.md
+++ b/src/components/header/_macro-options.md
@@ -2,8 +2,8 @@
 | ------------- | -------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------------- |
 | phase         | `PhaseBanner` [_(ref)_](/components/phase-banner)  | false                                | Settings for the Phase banner component                                     |
 | fullWidth     | boolean                                            | false                                | Set the header to be the full width of the viewport                         |
-| logoHref      | string                                             | false                                | Path for the logo link. Defaults to "/"                                     |
-| logo          | string                                             | false                                | Path for the logo. Defaults to "ons-logo-pos"                               |
+| logoHref      | string                                             | false                                | Path for the masthead logo link. Defaults to "/"                            |
+| logo          | string                                             | false                                | Path for the masthead logo. Defaults to "ons-logo-pos"                      |
 | mobileLogo    | string                                             | false                                | Path for the mobile version of the logo. Defaults to "ons-logo-stacked-pos" |
 | language      | `Language` [_(ref)_](/patterns/language-selection) | false                                | Settings for the language selection component                               |
 | serviceLinks  | `Array<Navigation>`                                | false                                | An array to render the service links list                                   |

--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -20,10 +20,10 @@
               <div class="header__grid-top grid grid--gutterless grid--flex grid--between grid--vertical-center grid--no-wrap {{ 'header__grid-top-' + params.customHeaderLogo if params.customHeaderLogo }}">
 
                   <div class="grid__col col-auto">
-                    {% if params.logoHref is defined and params.logoHref %}<a class="header__logo-link" href="{{ params.logoHref }}">{% endif %}
+                    {% if params.logoHref is defined and params.logoHref %}<a tabindex="-1" class="header__logo-link" href="{{ params.logoHref }}">{% endif %}
                       <picture>
                         <source media="(max-width: 499px)" srcset="{{ params.assetsURL if params.assetsURL is defined and params.assetsURL }}/img/{{ params.mobileLogo | default('ons-logo-stacked-pos-' + currentLanguageISOCode) }}.svg" alt="{{ params.logoAlt | default('Office for National Statistics logo') }}">
-                        <img class="header__logo" src="{{ params.assetsURL if params.assetsURL is defined and params.assetsURL }}/img/{{ params.logo | default('ons-logo-pos-' + currentLanguageISOCode) }}.svg" alt="{{ params.logoAlt | default('Office for National Statistics logo') }}">
+                        <img tabindex="0" class="header__logo" src="{{ params.assetsURL if params.assetsURL is defined and params.assetsURL }}/img/{{ params.logo | default('ons-logo-pos-' + currentLanguageISOCode) }}.svg" alt="{{ params.logoAlt | default('Office for National Statistics logo') }}">
                       </picture>
                     {% if params.logoHref is defined and params.logoHref %}</a>{% endif %}
                   </div>


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #1198

Also fixes an issue with the focus state on the masthead Nisra logo which wasn't big enough to cover the logo

### How to review 
- Check headers with links added to them can be tabbed into
- Check Nisra masthead focus state is now big enough