### PR TITLE
Add number width class to input

### DIFF
--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -57,6 +57,9 @@
 // Text input widths
 @include input-width('input--w-{x}');
 
+// Number input widths
+@include input-width('input-number--w-{x}', 0.54rem);
+
 .input--postcode {
   width: 100%;
   max-width: input-width-calc($chars: 5, $num-chars: 2, $spaces: 1);

--- a/src/components/input/examples/telephone/index.njk
+++ b/src/components/input/examples/telephone/index.njk
@@ -4,7 +4,7 @@
         "id": "telephone",
         "type": "tel",
         "autocomplete": "tel",
-        "classes": "input-number--w-5",
+        "classes": "input-number--w-15",
         "label": {
             "text": "Phone number",
             "description": "For international numbers include the country code, for example +33 1234 567 890"

--- a/src/components/input/examples/telephone/index.njk
+++ b/src/components/input/examples/telephone/index.njk
@@ -4,7 +4,7 @@
         "id": "telephone",
         "type": "tel",
         "autocomplete": "tel",
-        "classes": "input--w-9",
+        "classes": "input--w-5",
         "label": {
             "text": "Phone number",
             "description": "For international numbers include the country code, for example +33 1234 567 890"

--- a/src/components/input/examples/telephone/index.njk
+++ b/src/components/input/examples/telephone/index.njk
@@ -4,7 +4,7 @@
         "id": "telephone",
         "type": "tel",
         "autocomplete": "tel",
-        "classes": "input--w-5",
+        "classes": "input-number--w-5",
         "label": {
             "text": "Phone number",
             "description": "For international numbers include the country code, for example +33 1234 567 890"

--- a/src/components/input/examples/text-width-constrained/index.njk
+++ b/src/components/input/examples/text-width-constrained/index.njk
@@ -2,7 +2,7 @@
 {{
     onsInput({
         "id": "text-width",
-        "classes": "input--w-8",
+        "classes": "input--w-5",
         "autocomplete": "postal-code",
         "label": {
             "text": "Postcode"

--- a/src/components/input/examples/text-width-constrained/index.njk
+++ b/src/components/input/examples/text-width-constrained/index.njk
@@ -2,7 +2,7 @@
 {{
     onsInput({
         "id": "text-width",
-        "classes": "input--w-5",
+        "classes": "input--w-8",
         "autocomplete": "postal-code",
         "label": {
             "text": "Postcode"

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -44,7 +44,9 @@ An optional `label__description` can be used to display a hint to help the user 
 ### Width constrained
 Where possible, you should make the inputs the right width for the size of content they are intended for to help users understand what they should enter.  For example, UK postcodes never consist of more than 8 characters.
 
-Inputs can have their widths constrained (but not limited) to the number of expected characters using the `input--w-<number>` class. Available widths are: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50.
+Inputs can have their widths constrained (but not limited) to the number of expected characters using the `input--w-<number>` or `input-number--w-<number>` classes.
+`input--w-<number>` is based on the character width of a 'W' and is to be used on fields that will contain any text. `input-number--w-<number>` is based on the character width of '4' and is to be used on fields that only contain numbers.
+Available widths for both classes are: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50.
 {{
     patternlibExample({"path": "components/input/examples/text-width-constrained/index.njk"})
 }}

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -46,7 +46,7 @@ Where possible, you should make the inputs the right width for the size of conte
 
 Inputs can have their widths constrained (but not limited) to the number of expected characters using the `input--w-<number>` or `input-number--w-<number>` classes.
 `input--w-<number>` is based on the character width of a 'W' and is to be used on fields that will contain any text. `input-number--w-<number>` is based on the character width of '4' and is to be used on fields that only contain numbers.
-Available widths for both classes are: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50.
+Available widths for both classes are: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 50.
 {{
     patternlibExample({"path": "components/input/examples/text-width-constrained/index.njk"})
 }}

--- a/src/scss/vars/_forms.scss
+++ b/src/scss/vars/_forms.scss
@@ -5,7 +5,7 @@ $input-padding-vertical: 0.39rem;
 $input-padding-horizontal: 0.5rem;
 $input-width: 20rem;
 $input-border-width: 1px;
-$input-widths: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50;
+$input-widths: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 50;
 // Widest character (capital W) is 1.0065rem wide
 $char-max-width: 1.0065rem;
 // Widest number (4) is 0.54rem  wide

--- a/src/scss/vars/_forms.scss
+++ b/src/scss/vars/_forms.scss
@@ -7,7 +7,7 @@ $input-width: 20rem;
 $input-border-width: 1px;
 $input-widths: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 30, 40, 50;
 // Widest character (capital W) is 1.0065rem wide
-$char-max-width: 1.0065rem;
+$char-max-width: 0.9rem;
 // Widest number (4) is 0.54rem  wide
 $num-max-width: 0.54rem;
 // Not the width of a space, the width of the space between characters with no spaces between


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #1177 

### How to review 
Check text field width using both `input--w-<number>` and `input-number--w-<number>` are correct width by entering the same number of characters into the field. Using '4's for the number one and 'W's for the character one.