### PR TITLE
Fix footer on census page template example

### DIFF
--- a/src/styles/page-template/examples/census/index.njk
+++ b/src/styles/page-template/examples/census/index.njk
@@ -86,7 +86,7 @@ layout: none
                 ]
             }
         ],
-        "rows": [
+        "legal": [
             {
                 "itemsList": [
                     {
@@ -94,7 +94,7 @@ layout: none
                         "url": '#0'
                     },
                     {
-                        "text": 'Accessibility',
+                        "text": 'Accessibility statement',
                         "url": '#0'
                     },
                     {


### PR DESCRIPTION
### What is the context of this PR?
The census page template example wasn't configuring the footer correctly which was adding an extra border. This PR fixes that.

### How to review 
Check footer looks as expected in census page template example