### PR TITLE
Address autosuggest - Updated query params for country boosts

### DIFF
--- a/src/components/input/autosuggest/autosuggest.address.js
+++ b/src/components/input/autosuggest/autosuggest.address.js
@@ -330,9 +330,10 @@ export default class AutosuggestAddress {
       addressType;
 
     const classificationFilterParam = '&classificationfilter=',
-      ewboostParam = '&fromsource=ewboost',
-      niboostParam = '&fromsource=niboost',
-      nionlyParam = '&fromsource=nionly',
+      eboostParam = '&eboost=10',
+      wboostParam = '&wboost=10',
+      niboostParam = '&eboost=0&sboost=0&wboost=0',
+      nionlyParam = '&niboost=10',
       favourwelshParam = '&favourwelsh=true',
       addresstypeParam = '?addresstype=',
       epochParam = '&epoch=72';
@@ -350,8 +351,12 @@ export default class AutosuggestAddress {
         fullURL = fullURL + classificationFilterParam + this.classificationFilter;
       }
 
-      if ((this.regionCode === 'gb-eng' || this.regionCode === 'gb-wls') && this.classificationFilter === 'workplace') {
-        fullURL = fullURL + ewboostParam;
+      if (this.classificationFilter === 'workplace') {
+        if (this.regionCode === 'gb-eng') {
+          fullURL = fullURL + eboostParam;
+        } else if (this.regionCode === 'gb-wls') {
+          fullURL = fullURL + wboostParam;
+        }
       }
 
       if (this.regionCode === 'gb-nir') {

--- a/src/tests/spec/autosuggest/autosuggest.address.spec.js
+++ b/src/tests/spec/autosuggest/autosuggest.address.spec.js
@@ -819,7 +819,7 @@ describe('Autosuggest.address component', function() {
       it('then the fetch url should contain the correct parameters', function() {
         this.limit = 10;
         expect(this.autosuggestAddress.fetch.url).to.equal(
-          '/addresses/eq?input=195 colle&limit=10&classificationfilter=educational&fromsource=nionly',
+          '/addresses/eq?input=195 colle&limit=10&classificationfilter=educational&niboost=10',
         );
       });
     });
@@ -865,7 +865,7 @@ describe('Autosuggest.address component', function() {
       it('then the fetch url should contain the correct parameters', function() {
         this.limit = 10;
         expect(this.autosuggestAddress.fetch.url).to.equal(
-          '/addresses/eq?input=195 colle&limit=10&classificationfilter=workplace&fromsource=niboost',
+          '/addresses/eq?input=195 colle&limit=10&classificationfilter=workplace&eboost=0&sboost=0&wboost=0',
         );
       });
     });
@@ -922,7 +922,7 @@ describe('Autosuggest.address component', function() {
       it('then the fetch url should contain the correct parameters', function() {
         this.limit = 10;
         expect(this.autosuggestAddress.fetch.url).to.equal(
-          '/addresses/eq?input=195 colle&limit=10&classificationfilter=workplace&fromsource=ewboost&favourwelsh=true',
+          '/addresses/eq?input=195 colle&limit=10&classificationfilter=workplace&=wboost=10&favourwelsh=true',
         );
       });
     });

--- a/src/tests/spec/autosuggest/autosuggest.address.spec.js
+++ b/src/tests/spec/autosuggest/autosuggest.address.spec.js
@@ -922,7 +922,7 @@ describe('Autosuggest.address component', function() {
       it('then the fetch url should contain the correct parameters', function() {
         this.limit = 10;
         expect(this.autosuggestAddress.fetch.url).to.equal(
-          '/addresses/eq?input=195 colle&limit=10&classificationfilter=workplace&=wboost=10&favourwelsh=true',
+          '/addresses/eq?input=195 colle&limit=10&classificationfilter=workplace&wboost=10&favourwelsh=true',
         );
       });
     });


### PR DESCRIPTION
### What is the context of this PR?
AIMS have updated the parameters for country boosts so the component has been updated to reflect this.

### How to review 
Update the component example in components/address/examples/address/ and use a variety of `options` combinations...

```
                "options": {
                    "regionCode": "gb-nir/gb-wls/gb-en",
                    "addressType": "residential/workplace/educational"
                }
```

Check the suggestions that are retrieved.
