### PR TITLE
Translation support

### DIFF
--- a/src/components/lists/_list.scss
+++ b/src/components/lists/_list.scss
@@ -59,6 +59,12 @@
       margin-bottom: 0.5rem;
     }
   }
+
+  &--languages {
+    .list__link {
+      margin-right: 0;
+    }
+  }
 }
 
 @include bp-suffix('list--inline') {

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1,0 +1,19 @@
+(function() {
+  function installLanguageSelect(element) {
+    const languageSelect = element.getElementsByClassName('js-language-filter__select')[0];
+    const languageContentElements = element.getElementsByClassName('js-language-filter__content');
+
+    languageSelect.addEventListener('change', function(event) {
+      for (let languageContentElement of languageContentElements) {
+        if (languageContentElement.id === this.value) {
+          languageContentElement.classList.remove('u-hidden');
+        } else {
+          languageContentElement.classList.add('u-hidden');
+        }
+      }
+    });
+  }
+
+  let languageFilterElements = document.getElementsByClassName('js-language-filter');
+  Array.from(languageFilterElements).forEach(installLanguageSelect);
+})();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -19,4 +19,5 @@ import 'components/cookies-banner/cookies-banner.dom';
 import 'components/button/button.dom';
 import 'components/skip-to-content/skip-to-content.dom';
 import 'components/download-resources/download-resources';
+import 'components/select/select';
 import 'components/panel/panel.dom';

--- a/src/patterns/translation-support/examples/default/index.njk
+++ b/src/patterns/translation-support/examples/default/index.njk
@@ -49,6 +49,7 @@ layout: none
 
 {% block main %}
     <h1 class="u-mb-l u-fs-xxl">Languages</h1>
+    
     {{
         onsPanel({
             "classes": 'u-mb-m',
@@ -67,21 +68,22 @@ layout: none
                     <p class="u-mb-no@m">If you can’t find your language, or need more help, please call our free language helpline on <b>0800 587 2021</b>.</p>
                 </div>
 
-                <div class="grid__col col-5@md">
+                <div class="grid__col col-5@md u-db-no-js_disabled">
                     {{ onsSelect({
-                        "id": 'select',
-                        "name": 'select',
+                        "classes": 'js-language-filter__select',
+                        "id": 'language-fiter-select',
+                        "name": 'language-fiter-select',
                         "label": {
                             "text": 'Sort languages by'
                         },
                         "options": [
                             {
                                 "text": 'Native language',
-                                "value": 'native-language'
+                                "value": 'language-native'
                             },
                             {
                                 "text": 'English',
-                                "value": 'english'
+                                "value": 'language-english'
                             }
                         ]
                     }) }}
@@ -325,26 +327,217 @@ layout: none
 
         </div>
 
-        <div class="js-language-filter__content u-hidden no-js:is-hidden" id="language-english">
+        <div class="js-language-filter__content u-hidden u-db-no-js_disabled" id="language-english">
 
-            {{ onsList({
-                "classes": 'list--bare',
-                "itemsList": [
-                    {
-                        "url": '#',
-                        "text": 'Who we are',
-                        "target": '_blank'
-                    },
-                    {
-                        "url": '#',
-                        "text": 'What we do'
-                    },
-                    {
-                        "url": '#',
-                        "text": 'Where to find us'
-                    }
-                ]
-            }) }}
+            <div class="grid u-mt-m">
+
+                <div class="grid__col col-4@m">
+
+                    {{ onsList({
+                        "classes": 'list--bare list--languages',
+                        "itemsList": [
+                            {
+                                "url": '#0',
+                                "text": 'Albanian (Shqiptare)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Amharic (አማርኛ)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Arabic (عربى)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Armenian (հայերեն)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Bengali (বাংলা)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Bosnian (Bosanski)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'British Sign Language - BSL'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Bulgarian (български)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Burmese (မြန်မာဘာသာ)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Cantonese (粵語)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Czech (čeština)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Farsi (فارسی)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'French (Le français)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'German (Deutsche)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Greek (Ελληνικά)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Gujarati (ગુજરાતી)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Hebrew (עִברִית)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Hebrew (עִברִית)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Hungarian (Magyar)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Italian (Italiano)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Japanese (日本人)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Korean (한국어)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Kurdish (Kurdî)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Latvian (Latvietis)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Latvian (Latvietis)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Lithuanians (Lietuvi)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Malayalam (മലയാളം)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Mandarin (普通話)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Nepali (नेपाली)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Polish (Polskie)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Portuguese (Português)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Pothwari (پوٹھواری)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Punjabi (Gurmukhi) (ਪੰਜਾਬੀ)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Romanian (Română)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Russian (русский)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Slovak (Slovák)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Slovenian (Slovenščina)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Somali (Soomaali)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Swahili (Kiswahili)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Tagalog'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Tamil (தமிழ்)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Tetum'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Thai (ไทย)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Tigrinya (ትግርኛ)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Turkish (Türk)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Ukrainian (Український)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Urdu (اردو)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Vietnamese (Tiếng Việt)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Yiddish (יידיש)'
+                            }
+                        ]
+                    }) }}
+
+                </div>
+
+            </div>
 
         </div>
 

--- a/src/patterns/translation-support/examples/default/index.njk
+++ b/src/patterns/translation-support/examples/default/index.njk
@@ -1,0 +1,353 @@
+---
+layout: none
+---
+{% extends "styles/page-template/_template.njk" %}
+
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/select/_macro.njk" import onsSelect %}
+{% from "components/lists/_macro.njk" import onsList %}
+
+{% set pageConfig = {
+    "title": "Census 2021",
+    "theme": "census",
+    "pageColNumber": "12",
+    "absoluteUrl": pageInfo.url,
+    "headMeta": {
+        "description": "Census 2021 is a UK wide population survey."
+    },
+    "header": {
+        "logoHref": "#0",
+        "titleLogo": "census-logo-en",
+        "titleLogoHref": "#0",
+        "titleLogoAlt": "Census 2021"
+    },
+    "language": {
+        "allLanguagesUrl": "#0",
+        "languages": [
+            {
+                "url": "#0",
+                "ISOCode": "en",
+                "text": "English",
+                "buttonAriaLabel": "Language selector. Current language: English",
+                "chooseLanguage": "Choose language",
+                "allLanguages": "All languages",
+                "current": true
+            },
+            {
+                "url": "#0",
+                "ISOCode": "cy",
+                "text": "Cymraeg",
+                "buttonAriaLabel": "Dewisydd iaith. Iaith gyfredol: Cymraeg",
+                "chooseLanguage": "Dewiswch iaith",
+                "allLanguages": "Pob iaith",
+                "current": false
+            }
+        ]
+    },
+    "footer": {}
+} %}
+
+{% block main %}
+    <h1 class="u-mb-l u-fs-xxl">Languages</h1>
+    {{
+        onsPanel({
+            "classes": 'u-mb-m',
+            "body": '<p>Os oes angen y wefan hon arnoch yn Gymraeg, ewch i <a href="#0">cyfrifiad.gov.uk</a></p>'
+        })
+    }}
+
+    <div class="language-filter js-language-filter">
+
+        <div class="u-bb">
+
+            <div class="grid grid--flex grid--vertical-top grid--between u-mb-m">
+
+                <div class="grid__col col-7@m">
+                    <p>Translation support is available for the following languages.</p>
+                    <p class="u-mb-no@m">If you can’t find your language, or need more help, please call our free language helpline on <b>0800 587 2021</b>.</p>
+                </div>
+
+                <div class="grid__col col-5@md">
+                    {{ onsSelect({
+                        "id": 'select',
+                        "name": 'select',
+                        "label": {
+                            "text": 'Sort languages by'
+                        },
+                        "options": [
+                            {
+                                "text": 'Native language',
+                                "value": 'native-language'
+                            },
+                            {
+                                "text": 'English',
+                                "value": 'english'
+                            }
+                        ]
+                    }) }}
+                </div>
+
+            </div>
+
+        </div>
+
+        <div class="js-language-filter__content" id="language-native">
+
+            <div class="grid u-mt-m">
+
+                <div class="grid__col col-4@m">
+
+                    {{ onsList({
+                        "classes": 'list--bare list--languages',
+                        "itemsList": [
+                            {
+                                "url": '#0',
+                                "text": 'Bosanski (Bosnian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'British Sign Language - BSL'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'čeština (Czech)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Deutsche (German)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Italiano (Italian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Kiswahili (Swahili)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Kurdî (Kurdish)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Latvietis (Latvian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Le français (French)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Lietuvis (Lithuanian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Lingála (Lingala)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Magyar (Hungarian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Polskie (Polish)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Português (Portuguese)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Română (Romanian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Shqiptare (Albanian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Slovák (Slovak)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Slovenščina (Slovenian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Soomaali (Somali)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Tagalog'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Tetum'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Tiếng Việt (Vietnamese)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'Türk (Turkish)'
+                            }
+                        ]
+                    }) }}
+
+                </div>
+
+                <div class="grid__col col-4@m">
+
+                    {{ onsList({
+                        "classes": 'list--bare list--languages',
+                        "itemsList": [
+                            {
+                                "url": '#0',
+                                "text": 'Ελληνικά (Greek)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'български (Bulgarian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'русский (Russian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'zУкраїнський (Ukrainian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'հայերեն (Armenian)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'پوٹھواری (Pothwari)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'ትግርኛ (Tigrinya)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'አማርኛ (Amharic)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'नेपाली (Nepali)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'हिन्दी (Hindi)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'বাংলা (Bengali)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'ਪੰਜਾਬੀ (Punjabi (Gurmukhi))'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'ગુજરાતી (Gujarati)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'தமிழ் (Tamil)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'മലയാളം (Malayalam)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'ไทย (Thai)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'မြန်မာဘာသာ (Burmese)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": '한국어 (Korean)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": '日本人 (Japanese)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": '普通話 (Mandarin)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": '粵語 (Cantonese)'
+                            }
+                        ]
+                    }) }}
+
+                </div>
+
+                <div class="grid__col col-4@m">
+
+                    {{ onsList({
+                        "classes": 'list--bare list--languages u-rtl',
+                        "itemsList": [
+                            {
+                                "url": '#0',
+                                "text": 'יידיש (Yiddish)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'עִברִית (Hebrew)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'اردو (Urdu)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'عربى (Arabic)'
+                            },
+                            {
+                                "url": '#0',
+                                "text": 'فارسی (Farsi)'
+                            }
+                        ]
+                    }) }}
+
+                </div>
+
+            </div>
+
+        </div>
+
+        <div class="js-language-filter__content u-hidden no-js:is-hidden" id="language-english">
+
+            {{ onsList({
+                "classes": 'list--bare',
+                "itemsList": [
+                    {
+                        "url": '#',
+                        "text": 'Who we are',
+                        "target": '_blank'
+                    },
+                    {
+                        "url": '#',
+                        "text": 'What we do'
+                    },
+                    {
+                        "url": '#',
+                        "text": 'Where to find us'
+                    }
+                ]
+            }) }}
+
+        </div>
+
+    </div>
+
+{% endblock %}

--- a/src/patterns/translation-support/index.njk
+++ b/src/patterns/translation-support/index.njk
@@ -1,0 +1,34 @@
+---
+title: Translation support
+group: Help users to...
+experimental: true
+---
+{% from "views/partials/example/_macro.njk" import patternlibExample %}
+{% from "components/external-link/_macro.njk" import onsExternalLink %}
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/external-link/_macro.njk" import onsExternalLink %}
+
+Allow users to access support in various languages.
+
+{{
+    patternlibExample({ "path": "patterns/translation-support/examples/default/index.njk" })
+}}
+
+## Research on this pattern
+{% call onsPanel() %}
+    If you have conducted any user research using this pattern, please feed back your findings via the
+    {{
+        onsExternalLink({
+            "url": "https://github.com/ONSdigital/design-system/discussions/888",
+            "linkText": "Design System forum"
+        })
+    }}
+{% endcall %}
+
+## Design System forum
+{{
+    onsExternalLink({
+        "url": "https://github.com/ONSdigital/design-system/discussions/888",
+        "linkText": "Discuss 'Translation support' on GitHub"
+    })
+}}

--- a/src/patterns/translation-support/index.njk
+++ b/src/patterns/translation-support/index.njk
@@ -19,7 +19,7 @@ Allow users to access support in various languages.
     If you have conducted any user research using this pattern, please feed back your findings via the
     {{
         onsExternalLink({
-            "url": "https://github.com/ONSdigital/design-system/discussions/888",
+            "url": "https://github.com/ONSdigital/design-system/discussions/1249",
             "linkText": "Design System forum"
         })
     }}
@@ -28,7 +28,7 @@ Allow users to access support in various languages.
 ## Design System forum
 {{
     onsExternalLink({
-        "url": "https://github.com/ONSdigital/design-system/discussions/888",
+        "url": "https://github.com/ONSdigital/design-system/discussions/1249",
         "linkText": "Discuss 'Translation support' on GitHub"
     })
 }}

--- a/src/scss/utilities/_utilities.scss
+++ b/src/scss/utilities/_utilities.scss
@@ -20,6 +20,11 @@
   white-space: nowrap;
 }
 
+// Utility class to set direction right to left
+.u-rtl {
+  direction: rtl;
+}
+
 // Set an element's width to be auto at specified breakpoint
 @include bp-suffix(u-wa--) {
   width: auto;


### PR DESCRIPTION
I have added a new pattern for 'Translation support'. I have tagged it as an experimental pattern. 

Some work still needs to be done. We could make the select filtering more generic and usable. The select component needs some more work.

We need this pattern in Craft now. We can improve at a later date.

**Notes:**
- An additional utility class was added to allow for right to left
- If JavaScript is disabled, both the select component and the english language block is hidden (progressive enhancement)

**Example**

<img width="1379" alt="Screenshot 2020-12-16 at 17 29 15" src="https://user-images.githubusercontent.com/4989027/102384235-61177800-3fc4-11eb-97fc-3d5bf942de0f.png">
