### PR TITLE
Remove striptags due to runner vulnerability

### DIFF
--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -104,7 +104,7 @@
                                                         <a
                                                             href="{{ action.url }}"
                                                             class="summary__button"
-                                                            {% if action.ariaLabel is defined and action.ariaLabel %} aria-label="{{ action.ariaLabel | striptags() }}"{% endif %}
+                                                            {% if action.ariaLabel is defined and action.ariaLabel %} aria-label="{{ action.ariaLabel }}"{% endif %}
                                                             {% if action.attributes is defined and action.attributes %}{% for attribute, value in (action.attributes.items() if action.attributes is mapping and action.attributes.items else action.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
                                                         >{{ action.text }}</a>
                                                     {% endfor %}


### PR DESCRIPTION
### What is the context of this PR?
`striptags` causes a vulnerability in runner as they are already escaping tags but us calling `striptags` on it as well unescapes it. I don't think `striptags` is needed anyway because html strings shouldn't be provided in the aria label

### How to review 
Check aira-labels on summary actions work correctly without `striptags`