### PR TITLE
Autosuggest - Use addressType from query response

### DIFF
--- a/src/components/input/autosuggest/autosuggest.ui.js
+++ b/src/components/input/autosuggest/autosuggest.ui.js
@@ -276,6 +276,7 @@ export default class AutosuggestUI {
             .then(this.handleResults.bind(this))
             .catch(error => {
               if (error.name !== 'AbortError') {
+                console.log('error:', error);
                 this.handleNoResults(500);
               }
             });

--- a/src/tests/spec/autosuggest/autosuggest.address.spec.js
+++ b/src/tests/spec/autosuggest/autosuggest.address.spec.js
@@ -889,7 +889,7 @@ describe('Autosuggest.address component', function() {
 
       it('then the retrieve url should contain the correct parameters', function() {
         expect(this.autosuggestAddress.fetch.url).to.equal(
-          'https://whitelodge-ai-api.census-gcp.onsdigital.uk/addresses/eq/uprn/11000000?addresstype=nisra',
+          'https://whitelodge-ai-api.census-gcp.onsdigital.uk/addresses/eq/uprn/11000000?addresstype=paf',
         );
       });
     });
@@ -949,7 +949,7 @@ describe('Autosuggest.address component', function() {
 
       it('then the retrieve url should contain the correct parameters', function() {
         expect(this.autosuggestAddress.fetch.url).to.equal(
-          'https://whitelodge-ai-api.census-gcp.onsdigital.uk/addresses/eq/uprn/11000000?addresstype=welshpaf',
+          'https://whitelodge-ai-api.census-gcp.onsdigital.uk/addresses/eq/uprn/11000000?addresstype=paf',
         );
       });
     });


### PR DESCRIPTION
### What is the context of this PR?
If a user entered a welsh language address (when viewing the site in english) upon selecting the welsh language suggestion the address fields would fetch the english version. This is because the address type logic didn't use the `addressType` from the initial response (it generated the address type param based on region code). 

### How to review 
Type an address in welsh such as "195 college road caerdydd" see the welsh suggestion, select it and confirm the address fields populate with the correct welsh address.

View the example => /components/address/examples/address