### PR TITLE
Time pattern has been updated to reflect content changes

### DIFF
--- a/src/patterns/find-a-support-centre/examples/results/index.njk
+++ b/src/patterns/find-a-support-centre/examples/results/index.njk
@@ -88,7 +88,24 @@ layout: none
 
         <h3 class="u-fs-r--b u-mb-xs">Opening times</h3>
 
-        <p>9am to 4pm - Monday to Friday <br> 9am to 5pm - Saturday to Sunday (Census weekend)</p>
+        {{
+            onsList({
+                "itemsList": [
+                    {
+                        "text": 'Monday to Friday, 9am to 4pm'
+                    },
+                    {
+                        "text": 'Saturday, 9am to 5pm'
+                    },
+                    {
+                        "text": 'Sunday, 9am to 5pm'
+                    },
+                    {
+                        "text": 'Census weekend (20 – 21 March), 9am to 5pm'
+                    }
+                ]
+            })
+        }}
         
         <h3 class="u-fs-r--b u-mb-xs">Centre facilities</h3>
 
@@ -156,7 +173,7 @@ layout: none
 
         <h3 class="u-fs-r--b u-mb-xs">Opening times</h3>
 
-        <p>8am to 6pm - Monday to Friday</p>
+        <p>Monday to Friday, 8am to 6pm</p>
         
         <h3 class="u-fs-r--b u-mb-xs">Centre facilities</h3>
 


### PR DESCRIPTION
Format of time has been changed. We start with the day followed by the time. We also use a comma instead of a dash.

**Example:**

<img width="676" alt="Screenshot 2020-12-23 at 12 55 54" src="https://user-images.githubusercontent.com/4989027/102998066-5017bb00-451e-11eb-9fe9-5799f4b904cf.png">
