### PR TITLE
Fixed bug with joined class names. Modified whtespace between classes

### DIFF
--- a/src/components/lists/_macro.njk
+++ b/src/components/lists/_macro.njk
@@ -17,7 +17,7 @@
         {% set listEl = 'ul' %}
     {% endif %}
 
-    <{{listEl}} {% if params.id is defined and params.id %}id="{{ params.id }} "{% endif %}class="list {{ params.classes -}} {{- otherClasses -}}">
+    <{{listEl}} {% if params.id is defined and params.id %}id="{{ params.id }} "{% endif %}class="list{% if params.classes is defined %} {{ params.classes -}}{% endif %}{% if otherClasses %} {{ otherClasses -}}{% endif %}">
         {%- for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) -%}
             <li class="list__item {{ item.listclass }}"{% if item.current is defined and item.current %} aria-current="true"{% endif %}>
                


### PR DESCRIPTION
Fixed bug with how social icons are rendered due to no space between class names

**Bug**
<img width="662" alt="Screenshot 2021-01-06 at 15 15 56" src="https://user-images.githubusercontent.com/4989027/103784655-1f617680-5032-11eb-94ce-b775d45fe9b9.png">

**Fixed**
<img width="725" alt="Screenshot 2021-01-06 at 15 16 07" src="https://user-images.githubusercontent.com/4989027/103784670-24bec100-5032-11eb-8fd0-fd310bbc2532.png">

Altered the macro to ensure correct spaces are used for each type. See output for each list type used.