### PR TITLE
Added new component for related content

### DIFF
--- a/src/components/related-content/_macro.njk
+++ b/src/components/related-content/_macro.njk
@@ -1,0 +1,17 @@
+{% macro onsRelatedContent(params) %}
+
+{% if params is defined and params and params.classes is defined and params.classes %}
+    {% set classes = ' ' + params.classes %}
+{% endif %}
+
+  <div class="related-content{{ classes }}">
+    
+    <h2 class="related-content__title u-fs-r--b u-mb-xs">{{ params.title }}</h2>
+
+    <div class="related-content__body">
+        {{ (params.body if params else "") | safe }}{{ caller() if caller }}
+    </div>
+
+  </div>
+
+{% endmacro %}

--- a/src/components/related-content/_related-content.scss
+++ b/src/components/related-content/_related-content.scss
@@ -1,0 +1,5 @@
+.related-content {
+  @extend .u-mt-m;
+  border-top: 5px solid $color-branded;
+  padding: 1rem 0;
+}

--- a/src/components/related-content/examples/related-content-branded/index.njk
+++ b/src/components/related-content/examples/related-content-branded/index.njk
@@ -1,0 +1,32 @@
+---
+"theme": census
+---
+
+{% from "components/related-content/_macro.njk" import onsRelatedContent %}
+{% from "components/lists/_macro.njk" import onsList %}
+
+{% call onsRelatedContent({
+        "title": 'Free language helpline'
+    })
+%}
+
+    <p class="u-mb-xs">Telephone: 0800 587 2021</p>
+
+    {{
+        onsList({
+            "classes": 'list--bare u-mb-no',
+            "itemsList": [
+                {
+                    "text": 'Monday to Friday, 8am to 8pm'
+                },
+                {
+                    "text": 'Saturday, 8am to 1pm'
+                },
+                {
+                    "text": 'Census weekend 20 – 21 March, 8am to 8pm'
+                }
+            ]
+        })
+    }}
+
+{% endcall %}

--- a/src/components/related-content/examples/related-content/index.njk
+++ b/src/components/related-content/examples/related-content/index.njk
@@ -1,0 +1,28 @@
+{% from "components/related-content/_macro.njk" import onsRelatedContent %}
+{% from "components/lists/_macro.njk" import onsList %}
+
+{% call onsRelatedContent({
+        "title": 'Free language helpline'
+    })
+%}
+
+    <p class="u-mb-xs">Telephone: 0800 587 2021</p>
+
+    {{
+        onsList({
+            "classes": 'list--bare u-mb-no',
+            "itemsList": [
+                {
+                    "text": 'Monday to Friday, 8am to 8pm'
+                },
+                {
+                    "text": 'Saturday, 8am to 1pm'
+                },
+                {
+                    "text": 'Census weekend 20 – 21 March, 8am to 8pm'
+                }
+            ]
+        })
+    }}
+
+{% endcall %}

--- a/src/components/related-content/index.njk
+++ b/src/components/related-content/index.njk
@@ -1,0 +1,39 @@
+---
+title: Related content
+---
+{% from "views/partials/example/_macro.njk" import patternlibExample %}
+{% from "components/external-link/_macro.njk" import onsExternalLink %}
+{% from "components/panel/_macro.njk" import onsPanel %}
+
+Related content is used to provide additional information for the user.
+
+## Related content
+Contact details to support languages.
+{{
+    patternlibExample({"path": "components/related-content/examples/related-content/index.njk"})
+}}
+
+## Related content with Census branding
+Contact details to support languages.
+{{
+    patternlibExample({"path": "components/related-content/examples/related-content-branded/index.njk"})
+}}
+
+## Research on this component
+{% call onsPanel() %}
+    If you have conducted any user research using this component, please feed back your findings via the
+    {{
+        onsExternalLink({
+            "url": "https://github.com/ONSdigital/design-system/discussions/1283",
+            "linkText": "Design System forum"
+        })
+    }}
+{% endcall %}
+
+## Design System forum
+{{
+    onsExternalLink({
+        "url": "https://github.com/ONSdigital/design-system/discussions/1283",
+        "linkText": "Discuss ‘Related content’ on GitHub"
+    })
+}}


### PR DESCRIPTION
Added new component for ‘Related content’.

I think at some point, we could combine related links with related content. I will look into this as an enhancement.

Currently we are using this pattern here: https://census-website-respond.netlify.app/end-to-end/language-help

<img width="673" alt="Screenshot 2021-01-11 at 15 39 13" src="https://user-images.githubusercontent.com/4989027/104202711-2c5fda80-5423-11eb-97b6-ae78b83d9c1f.png">


