### PR TITLE
Address autosuggest - Added error handling for uprn endpoint failures

### DIFF
--- a/src/components/input/autosuggest/autosuggest.address.js
+++ b/src/components/input/autosuggest/autosuggest.address.js
@@ -280,15 +280,15 @@ export default class AutosuggestAddress {
       if (selectedResult.uprn) {
         this.retrieveAddress(selectedResult.uprn, selectedResult.type)
           .then(data => {
-            if (data.status.code >= 403) {
-              this.autosuggest.handleNoResults(403);
-            } else {
-              if (this.isEditable) {
+            if (this.isEditable) {
+              if (data.status.code >= 403) {
+                this.autosuggest.handleNoResults(403);
+              } else {
                 this.addressSetter.setAddress(this.createAddressLines(data, resolve));
                 this.addressSelected = true;
-              } else {
-                this.autosuggest.input.value = selectedResult.displayText;
               }
+            } else {
+              this.autosuggest.input.value = selectedResult.displayText;
             }
           })
           .catch(error => {

--- a/src/components/input/autosuggest/autosuggest.address.js
+++ b/src/components/input/autosuggest/autosuggest.address.js
@@ -280,11 +280,15 @@ export default class AutosuggestAddress {
       if (selectedResult.uprn) {
         this.retrieveAddress(selectedResult.uprn, selectedResult.type)
           .then(data => {
-            if (this.isEditable) {
-              this.addressSetter.setAddress(this.createAddressLines(data, resolve));
-              this.addressSelected = true;
+            if (data.status.code >= 403) {
+              this.autosuggest.handleNoResults(403);
             } else {
-              this.autosuggest.input.value = selectedResult.displayText;
+              if (this.isEditable) {
+                this.addressSetter.setAddress(this.createAddressLines(data, resolve));
+                this.addressSelected = true;
+              } else {
+                this.autosuggest.input.value = selectedResult.displayText;
+              }
             }
           })
           .catch(error => {


### PR DESCRIPTION
### What is the context of this PR?
We didn't handle errors from failed uprn queries. This will almost always be caused by a bug in the AIMS api but we still need to handle to not interrupt the users journey.

If a query to the uprn endpoint fails with an error status of 403 or greater we will display the same message as when the partial endpoint errors.

### How to review 

- To fully test add to the `option` object parameter `oneYearAgo: "true"` within the `/components/address/examples/address` file. 
- Enter the following address (we know this returns a 404 when selecting the address): ROOM 23 6 THE ROCK BURY BL9 0NT
- Upon selecting the address, confirm that the error message is displayed.