### PR TITLE
Download component - Correctly place comma if required and updates to styling when used inside page__body

### DIFF
--- a/src/components/downloads/_macro.njk
+++ b/src/components/downloads/_macro.njk
@@ -1,5 +1,7 @@
 {% macro onsDownloads(params) %}
+
     {% for download in (params.downloads if params.downloads is iterable else params.downloads.items()) %}
+
     <div class="download{{ ' ' + params.classes if params.classes else '' }}">
 
         <div class="download__image" aria-hidden="true">
@@ -13,13 +15,43 @@
         </div>
 
         <div class="download__content">
-            <h3 class="u-fs-m u-mb-xs">
-                <a href="{{ download.url }}">{{ download.title }}{% if download.meta is defined and download.meta %}<span class="u-vh">, {% if download.meta.fileType is defined and download.meta.fileType %}{{ download.meta.fileType }} document download, {% endif %}{% if download.meta.fileSize is defined and download.meta.fileSize %}{{ download.meta.fileSize }}, {% endif %}{% if download.meta.filePages is defined and download.meta.filePages %}{{ download.meta.filePages }}{% endif %}</span>{% endif %}</a>
-            </h3>
+                
+                <h3 class="u-fs-m u-mt-no u-mb-xs">
+                    <a href="{{ download.url }}">{{ download.title }}<span class="u-vh">, 
+                    
+                    {%- if download.meta is defined and download.meta %}
+                
+                        {% set metaItems = [] %}
+
+                        {% if download.meta.fileType is defined and download.meta.fileType %}{% set metaItems = (metaItems.push(download.meta.fileType + ' document download'), metaItems) %}{% endif %}
+                        {% if download.meta.fileSize is defined and download.meta.fileSize %}{% set metaItems = (metaItems.push(download.meta.fileSize), metaItems) %}{% endif %}
+                        {% if download.meta.filePages is defined and download.meta.filePages %}{% set metaItems = (metaItems.push(download.meta.filePages), metaItems) %}{% endif %}
+
+                        {{ metaItems|join(', ') }}
+
+                    {% endif -%}
+                    
+                    </span></a>
+                </h3>
 
             <span class="u-fs-s u-mb-xs download__meta" aria-hidden="true">
-                {%- if download.type is defined and download.type %}{{ download.type }}{% endif %}
-                {%- if download.meta is defined and download.meta %}, {% if download.meta.fileType is defined and download.meta.fileType %}{{ download.meta.fileType }}, {% endif %}{% if download.meta.fileSize is defined and download.meta.fileSize %}{{ download.meta.fileSize }}, {% endif %}{% if download.meta.filePages is defined and download.meta.filePages %}{{ download.meta.filePages }}{% endif %}{% endif %}
+
+                {%- if download.type is defined and download.type %}
+                    {{ download.type }}
+                {% endif %}
+
+                {%- if download.meta is defined and download.meta %}
+
+                    {% set metaItems = [] %}
+
+                    {% if download.meta.fileType is defined and download.meta.fileType %}{% set metaItems = (metaItems.push(download.meta.fileType), metaItems) %}{% endif %}
+                    {% if download.meta.fileSize is defined and download.meta.fileSize %}{% set metaItems = (metaItems.push(download.meta.fileSize), metaItems) %}{% endif %}
+                    {% if download.meta.filePages is defined and download.meta.filePages %}{% set metaItems = (metaItems.push(download.meta.filePages), metaItems) %}{% endif %}
+
+                    {{ metaItems|join(', ') }}
+
+                {% endif -%}
+            
             </span>
             
             {% if download.excerpt is defined and download.excerpt %}

--- a/src/components/downloads/examples/downloads-multiple/index.njk
+++ b/src/components/downloads/examples/downloads-multiple/index.njk
@@ -3,67 +3,67 @@
     "downloads": [
         {
             "thumbnail": {
-                "smallSrc": "/patternlib-img/download-resources/img/small/census-2021-matters-to-everyone.png",
-                "largeSrc": "/patternlib-img/download-resources/img/large/census-2021-matters-to-everyone.png",
-                "alt": "Census 2021 matters to everyone document thumbnail"
+                "smallSrc": '/patternlib-img/download-resources/img/small/census-2021-matters-to-everyone.png',
+                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-matters-to-everyone.png',
+                "alt": 'Census 2021 matters to everyone document thumbnail'
             },
-            "url": "/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf",
-            "title": "Census 2021 matters to everyone",
-            "type": "Poster",
+            "url": '/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf',
+            "title": 'Census 2021 matters to everyone',
+            "type": 'Poster',
             "meta": {
-                "fileType": "PDF",
-                "fileSize": "866KB",
-                "filePages": "1 page"
+                "fileType": 'PDF',
+                "fileSize": '866KB',
+                "filePages": '1 page'
             },
-            "excerpt": "By taking part and encouraging others to do the same, you’ll make sure your community gets the services it needs."
+            "excerpt": 'By taking part and encouraging others to do the same, you’ll make sure your community gets the services it needs.'
         },
         {
             "thumbnail": {
-                "smallSrc": "/patternlib-img/download-resources/img/small/including-everyone-in-census-2021-v2.png",
-                "largeSrc": "/patternlib-img/download-resources/img/large/including-everyone-in-census-2021-v2.png",
-                "alt": "Including everyone in Census 2021 document thumbnail"
+                "smallSrc": '/patternlib-img/download-resources/img/small/including-everyone-in-census-2021-v2.png',
+                "largeSrc": '/patternlib-img/download-resources/img/large/including-everyone-in-census-2021-v2.png',
+                "alt": 'Including everyone in Census 2021 document thumbnail'
             },
-            "url": "/patternlib-img/download-resources/documents/Print-Ready-A4EB1-2021-v1-0-120620.pdf",            
-            "title": "Including everyone in Census 2021",
-            "type": "Poster",
+            "url": '/patternlib-img/download-resources/documents/Print-Ready-A4EB1-2021-v1-0-120620.pdf',            
+            "title": 'Including everyone in Census 2021',
+            "type": 'Poster',
             "meta": {
-                "fileType": "PDF",
-                "fileSize": "499KB",
-                "filePages": "1 page"
+                "fileType": 'PDF',
+                "fileSize": '499KB',
+                "filePages": '1 page'
             },
-            "excerpt": "Empty belly poster, aimed at advertising census events."
+            "excerpt": 'Empty belly poster, aimed at advertising census events.'
         },
         {
             "thumbnail": {
-                "smallSrc": "/patternlib-img/download-resources/img/small/including-everyone-in-census-2021.png",
-                "largeSrc": "/patternlib-img/download-resources/img/large/including-everyone-in-census-2021.png",
-                "alt": "Including everyone in Census 2021 document thumbnail"
+                "smallSrc": '/patternlib-img/download-resources/img/small/including-everyone-in-census-2021.png',
+                "largeSrc": '/patternlib-img/download-resources/img/large/including-everyone-in-census-2021.png',
+                "alt": 'Including everyone in Census 2021 document thumbnail'
             },
-            "url": "/patternlib-img/download-resources/documents/A6PCA1-v1-0-Print-Ready-Pack1.pdf",            
-            "title": "Including everyone in Census 2021",
-            "type": "Poster",
+            "url": '/patternlib-img/download-resources/documents/A6PCA1-v1-0-Print-Ready-Pack1.pdf',            
+            "title": 'Including everyone in Census 2021',
+            "type": 'Poster',
             "meta": {
-                "fileType": "PDF",
-                "fileSize": "499KB",
-                "filePages": "1 page"
+                "fileType": 'PDF',
+                "fileSize": '499KB',
+                "filePages": '1 page'
             },
-            "excerpt": "Generic poster advertising census 2021."
+            "excerpt": 'Generic poster advertising census 2021.'
         },
         {
             "thumbnail": {
-                "smallSrc": "/patternlib-img/download-resources/img/small/census-2021-community-handbook.png",
-                "largeSrc": "/patternlib-img/download-resources/img/large/census-2021-community-handbook.png",
-                "alt": "Community handbook for Census 2021 document thumbnail"
+                "smallSrc": '/patternlib-img/download-resources/img/small/census-2021-community-handbook.png',
+                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-community-handbook.png',
+                "alt": 'Community handbook for Census 2021 document thumbnail'
             },
-            "url": "/patternlib-img/download-resources/documents/CHDE1-Community-Handbook-v0.6.pdf",            
-            "title": "Community handbook for Census 2021",
-            "type": "Booklet",
+            "url": '/patternlib-img/download-resources/documents/CHDE1-Community-Handbook-v0.6.pdf',            
+            "title": 'Community handbook for Census 2021',
+            "type": 'Booklet',
             "meta": {
-                "fileType": "PDF",
-                "fileSize": "3.3MB",
-                "filePages": "16 pages"
+                "fileType": 'PDF',
+                "fileSize": '3.3MB',
+                "filePages": '16 pages'
             },
-            "excerpt": "This handbook explains what the census is, why it matters to everyone and how we can work together to spread the word within your community."
+            "excerpt": 'This handbook explains what the census is, why it matters to everyone and how we can work together to spread the word within your community.'
         }
     ]
 }) }}

--- a/src/components/downloads/examples/downloads-single-noimage/index.njk
+++ b/src/components/downloads/examples/downloads-single-noimage/index.njk
@@ -2,15 +2,15 @@
 {{ onsDownloads({
     "downloads": [
         {
-            "url": "/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf",
-            "title": "Census 2021 matters to everyone",
-            "type": "Poster",
+            "url": '/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf',
+            "title": 'Census 2021 matters to everyone',
+            "type": 'Poster',
             "meta": {
-                "fileType": "PDF",
-                "fileSize": "866KB",
-                "filePages": "1 page"
+                "fileType": 'PDF',
+                "fileSize": '866KB',
+                "filePages": '1 page'
             },
-            "excerpt": "By taking part and encouraging others to do the same, you’ll make sure your community gets the services it needs."
+            "excerpt": 'By taking part and encouraging others to do the same, you’ll make sure your community gets the services it needs.'
         }
     ]
 }) }}

--- a/src/components/downloads/examples/downloads-single/index.njk
+++ b/src/components/downloads/examples/downloads-single/index.njk
@@ -3,19 +3,19 @@
     "downloads": [
         {
             "thumbnail": {
-                "smallSrc": "/patternlib-img/download-resources/img/small/census-2021-matters-to-everyone.png",
-                "largeSrc": "/patternlib-img/download-resources/img/large/census-2021-matters-to-everyone.png",
-                "alt": "Census 2021 matters to everyone document thumbnail"
+                "smallSrc": '/patternlib-img/download-resources/img/small/census-2021-matters-to-everyone.png',
+                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-matters-to-everyone.png',
+                "alt": 'Census 2021 matters to everyone document thumbnail'
             },
-            "url": "/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf",
-            "title": "Census 2021 matters to everyone",
-            "type": "Poster",
+            "url": '/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf',
+            "title": 'Census 2021 matters to everyone',
+            "type": 'Poster',
             "meta": {
-                "fileType": "PDF",
-                "fileSize": "866KB",
-                "filePages": "1 page"
+                "fileType": 'PDF',
+                "fileSize": '866KB',
+                "filePages": '1 page'
             },
-            "excerpt": "By taking part and encouraging others to do the same, you’ll make sure your community gets the services it needs."
+            "excerpt": 'By taking part and encouraging others to do the same, you’ll make sure your community gets the services it needs.'
         }
     ]
 }) }}


### PR DESCRIPTION
Updated download component to reset the heading margin top due to being used inside `page__body`.

This fixes #1291

**Enhancements added**

If some meta tags don’t exist, we see comma’s being used incorrectly. This fixes that problem. I have also added this pattern to the visually hidden text in the heading.

I have tested in various scenarios and it works fine. I have also added some consistency tweaks to the examples.