### PR TITLE
Added a modification in scale for the pre-title on mobile devices

### DIFF
--- a/src/components/hero/_hero.scss
+++ b/src/components/hero/_hero.scss
@@ -8,6 +8,14 @@
   }
 }
 
+.hero__pre-title {
+  margin-bottom: 0.5rem;
+
+  @include mq(xs, m) {
+    max-width: 145px;
+  }
+}
+
 .hero__title {
   font-size: 2.3rem;
   line-height: 1.2;

--- a/src/components/hero/_macro.njk
+++ b/src/components/hero/_macro.njk
@@ -10,7 +10,7 @@
             <header>
                 {% if params.preTitleImage is defined and params.preTitleImage %}
                     {% set preTitleImageWithModifier = params.preTitleImage.name|replace(r/(\.[^\.]+)$/, "--" + skinName + "$1") %}
-                    <img class="u-mb-xs" src="{{ params.placeholderURL }}/img/{{ preTitleImageWithModifier }}" alt="{{ params.preTitleImage.alt }}">
+                    <img class="hero__pre-title" src="{{ params.placeholderURL }}/img/{{ preTitleImageWithModifier }}" alt="{{ params.preTitleImage.alt }}">
                 {% endif %}            
                 {% if params.censusTheme is defined and params.censusTheme %}
                     <h1 class="u-fs-xxxl">{{ params.title }}</h1>


### PR DESCRIPTION
Added pre-title scale modifications to match that of the census logo.

Looks good on mobile and desktop.

See examples:

<img width="403" alt="Screenshot 2021-01-18 at 11 42 59" src="https://user-images.githubusercontent.com/4989027/104911702-2e75ec00-5983-11eb-8fde-cf770557eb7a.png">

<img width="374" alt="Screenshot 2021-01-18 at 11 43 44" src="https://user-images.githubusercontent.com/4989027/104911751-3df53500-5983-11eb-9be9-a375215641c7.png">


