### PR TITLE
Added retina support and documentation to support component

### DIFF
--- a/src/components/images/_images.scss
+++ b/src/components/images/_images.scss
@@ -1,12 +1,15 @@
 .figure {
   margin: 0;
+  text-align: center;
   @extend .u-mb-m;
+
   &__image {
-    display: block;
+    display: inline-block;
     max-width: 100%;
   }
 
   &__caption {
+    display: block;
     font-size: 0.8rem;
     text-align: center;
     padding: 0.5rem 0 0;

--- a/src/components/images/_macro-options.md
+++ b/src/components/images/_macro-options.md
@@ -1,0 +1,13 @@
+| Name    | Type    | Required                         | Description                                                     |
+| ------- | ------- | -------------------------------- | --------------------------------------------------------------- |
+| url     | string  | true (false if `Image` provided) | The complete image path including filename and extension        |
+| image   | `Image` | false (true if url not provided) | An object containing path and filename attributes for the image |
+| alt     | string  | true                             | Alt tag to explain the appearance and function of the image     |
+| caption | string  | false                            | A short caption describing the contents                         |
+
+## Image
+
+| Name     | Type   | Required | Description                                 |
+| -------- | ------ | -------- | ------------------------------------------- |
+| smallSrc | string | true     | Path to the non-retina version of the image |
+| largeSrc | string | true     | Path to the retina version of the image     |

--- a/src/components/images/_macro.njk
+++ b/src/components/images/_macro.njk
@@ -1,10 +1,17 @@
 {%- macro onsImage(params) -%}
     <figure class="figure">
-        <img class="figure__image" src="{{ params.url }}" alt="{{ params.alt }}">
+        
+        {% if params.image is defined and params.image %}
+            <img class="figure__image" srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x" src="{{ params.image.smallSrc }}" alt="{{ params.alt }}">
+        {% else %}
+            <img class="figure__image" src="{{ params.url }}" alt="{{ params.alt }}">
+        {% endif %}
+
         {% if params.caption is defined and params.caption %}
             <figcaption class="figure__caption">
                 {{ params.caption }}
             </figcaption>
         {% endif %}
+        
     </figure>
 {%- endmacro -%}

--- a/src/components/images/examples/image/index.njk
+++ b/src/components/images/examples/image/index.njk
@@ -1,8 +1,0 @@
-{% from "components/images/_macro.njk" import onsImage %}
-{{
-    onsImage({
-        "url": '/patternlib-img/photo-1.jpg',
-        "alt": 'Siblings in the sun',
-        "caption": 'Image 1 - Siblings in the sun'
-    })
-}}

--- a/src/components/images/examples/new/index.njk
+++ b/src/components/images/examples/new/index.njk
@@ -1,0 +1,11 @@
+{% from "components/images/_macro.njk" import onsImage %}
+{{
+    onsImage({
+        image: {
+            smallSrc: '/img/small/woman-in-purple-dress-shirt.jpg',
+            largeSrc: '/img/large/woman-in-purple-dress-shirt.jpg'
+        },
+        alt: 'Woman in a purple dress shirt using a laptop',
+        caption: 'Image 1 - Woman in a purple dress shirt using a laptop'
+    })
+}}

--- a/src/components/images/examples/old/index.njk
+++ b/src/components/images/examples/old/index.njk
@@ -1,0 +1,8 @@
+{% from "components/images/_macro.njk" import onsImage %}
+{{
+    onsImage({
+        url: '/img/small/woman-in-purple-dress-shirt.jpg',
+        alt: 'Woman in a purple dress shirt using a laptop',
+        caption: 'Image 1 - Woman in a purple dress shirt using a laptop'
+    })
+}}

--- a/src/styles/images/index.njk
+++ b/src/styles/images/index.njk
@@ -5,20 +5,32 @@ title: Images
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 
-{{
-    onsPanel({
-        "body": "This pattern requires documentation."
-    })
-}}
+Adds an image to the page with an optional caption.
+
+## Improved approach for retina screens
+
+Uses two versions of the image, one for standard screens and the other for retina screens.
+
+We specify a folder path for both small and large images which is defined in the macro as `smallSrc` and `largeSrc`. The filename is expected to be the same for both.
 
 {{
-    patternlibExample({"path": "components/images/examples/image/index.njk"})
+    patternlibExample({"path": 'components/images/examples/new/index.njk'})
+}}
+
+## Old approach
+
+Specifies a single image that would appear blurry on retina displays.
+
+This continues to use the original macro property `url` for the image path.
+
+{{
+    patternlibExample({"path": 'components/images/examples/old/index.njk'})
 }}
 
 ## Design System forum
 {{
     onsExternalLink({
-        "url": "https://github.com/ONSdigital/design-system/discussions/713",
-        "linkText": "Discuss 'Images' on GitHub"
+        "url": 'https://github.com/ONSdigital/design-system/discussions/713',
+        "linkText": "Discuss ‘Images’ on GitHub"
     })
 }}


### PR DESCRIPTION
Updated initially for CRAFT usage with `srcSmall` and `srcLarge` properties.

Added retina flexibility for image.

It now uses the same approach as used in Article, Hero, Downloads components in providing a `smallSrc` and a `largeSrc`.

Component will fallback if none specified to the old `url` approach.

Added documentation and macro options with a few style adjustments.

See how it looks :).