### PR TITLE
Changed new set to filter

### DIFF
--- a/src/components/input/autosuggest/autosuggest.ui.js
+++ b/src/components/input/autosuggest/autosuggest.ui.js
@@ -515,7 +515,10 @@ export default class AutosuggestUI {
       this.allSelections = this.currentSelections;
     }
     this.allSelections.push(value);
-    this.allSelections = [...new Set(this.allSelections)];
+
+    this.allSelections = this.allSelections.filter(function(value, index, array) {
+      return array.indexOf(value) == index;
+    });
 
     return this.allSelections.join(', ');
   }


### PR DESCRIPTION
### What is the context of this PR?
A bug in ie11 caused suggested addresses to throw an error when selected when using the multi select variant of the autosuggestion component. This fixes it.

### How to review 
Check it works in ie11