### PR TITLE
Fix error panels being focusable and tabbable

### DIFF
--- a/src/components/panel/examples/error-header/index.njk
+++ b/src/components/panel/examples/error-header/index.njk
@@ -7,7 +7,6 @@
         "type": "error",
         "dsExample": isPatternLib
 }) %}
-
     {{
         onsList({
             "element": "ol",

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1,4 +1,3 @@
 export default function errorPanel(panel) {
-  panel.setAttribute('tabIndex', -1);
-  panel.focus();
+  panel.scrollIntoView();
 }

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1,4 +1,4 @@
 export default function errorPanel(panel) {
-  panel.setAttribute('tabIndex', 0);
+  panel.setAttribute('tabIndex', -1);
   panel.focus();
 }


### PR DESCRIPTION
### What is the context of this PR?
DAC issue: make error summary panels be focusable but not tabbable

### How to review 
Check that error summary panels are focused on page load but not tabbable