### PR TITLE
Autosuggest - Additional aria-label on results <ul>

### DIFF
--- a/src/components/address/_macro.njk
+++ b/src/components/address/_macro.njk
@@ -106,6 +106,7 @@
                                 "isEditable": params.autosuggest.isEditable,
                                 "ariaYouHaveSelected": params.autosuggest.ariaYouHaveSelected,
                                 "ariaMinChars": params.autosuggest.ariaMinChars,
+                                "ariaResultsLabel": params.autosuggest.ariaResultsLabel,
                                 "ariaOneResult": params.autosuggest.ariaOneResult,
                                 "ariaNResults": params.autosuggest.ariaNResults,
                                 "ariaLimitedResults": params.autosuggest.ariaLimitedResults,

--- a/src/components/address/examples/address/index.njk
+++ b/src/components/address/examples/address/index.njk
@@ -30,6 +30,7 @@ layout: none
                 "instructions": "Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.",
                 "ariaYouHaveSelected": "You have selected",
                 "ariaMinChars": "Enter 3 or more characters for suggestions.",
+                "ariaResultsLabel": "Address suggestions",
                 "ariaOneResult": "There is one suggestion available.",
                 "ariaNResults": "There are {n} suggestions available.",
                 "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search",

--- a/src/components/autosuggest/_macro-options.md
+++ b/src/components/autosuggest/_macro-options.md
@@ -7,6 +7,7 @@
 | instructions            | string            | true     | Instructions on how to use the autosuggest that will be read out by screenreaders                                                                  |
 | ariaYouHaveSelected     | string            | true     | Aria message to tell the user that they have selected an answer                                                                                    |
 | ariaMinChars            | string            | true     | Aria message to tell the user how many charecters they need to enter before autosuggest will start                                                 |
+| ariaResultsLabel        | string            | true     | Aria message to tell the user that suggestions are available                                                                                       |
 | ariaOneResult           | string            | true     | Aria message to tell the user there is only one suggestion left                                                                                    |
 | ariaNResults            | string            | true     | Aria message to tell the user how many suggestions are left                                                                                        |
 | ariaLimitedResults      | string            | true     | Aria message to tell the user if the results have been limited and what they are limited to                                                        |

--- a/src/components/autosuggest/examples/autosuggest-address/index.njk
+++ b/src/components/autosuggest/examples/autosuggest-address/index.njk
@@ -15,6 +15,7 @@
                 "instructions": "Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.",
                 "ariaYouHaveSelected": "You have selected",
                 "ariaMinChars": "Enter 3 or more characters for suggestions.",
+                "ariaResultsLabel": "Address suggestions",
                 "ariaOneResult": "There is one suggestion available.",
                 "ariaNResults": "There are {n} suggestions available.",
                 "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search",

--- a/src/components/autosuggest/examples/autosuggest-country-multiple/index.njk
+++ b/src/components/autosuggest/examples/autosuggest-country-multiple/index.njk
@@ -14,6 +14,7 @@
                 "instructions": "Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.",
                 "ariaYouHaveSelected": "You have selected",
                 "ariaMinChars": "Enter 3 or more characters for suggestions.",
+                "ariaResultsLabel": "Passport suggestions",
                 "ariaOneResult": "There is one suggestion available.",
                 "ariaNResults": "There are {n} suggestions available.",
                 "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search",

--- a/src/components/autosuggest/examples/autosuggest-country/index.njk
+++ b/src/components/autosuggest/examples/autosuggest-country/index.njk
@@ -14,6 +14,7 @@
                 "instructions": "Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.",
                 "ariaYouHaveSelected": "You have selected",
                 "ariaMinChars": "Enter 3 or more characters for suggestions.",
+                "ariaResultsLabel": "Country suggestions",
                 "ariaOneResult": "There is one suggestion available.",
                 "ariaNResults": "There are {n} suggestions available.",
                 "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search",

--- a/src/components/input/_autosuggest-macro.njk
+++ b/src/components/input/_autosuggest-macro.njk
@@ -34,7 +34,7 @@
         {{ content | safe }}
         <div class="autosuggest-input__results js-autosuggest-results">
             <header class="autosuggest-input__results-title u-fs-s">{{ params.resultsTitle }}</header>
-            <ul class="autosuggest-input__listbox js-autosuggest-listbox" role="listbox" id="{{ params.id }}-listbox" tabindex="-1"></ul>
+            <ul class="autosuggest-input__listbox js-autosuggest-listbox" role="listbox" id="{{ params.id }}-listbox" aria-label="{{ params.ariaResultsLabel }}" tabindex="-1"></ul>
         </div>
         <div class="autosuggest-input__instructions u-vh js-autosuggest-instructions" id="{{ params.id }}-instructions" tabindex="-1">{{ params.instructions }}</div>
         <div class="autosuggest-input__status u-vh js-autosuggest-aria-status" aria-live="assertive" role="status" tabindex="-1"></div> 

--- a/src/components/input/_macro-options.md
+++ b/src/components/input/_macro-options.md
@@ -47,6 +47,7 @@
 | instructions            | string            | true     | Instructions on how to use the autosuggest that will be read out by screenreaders                                                                  |
 | ariaYouHaveSelected     | string            | true     | Aria message to tell the user that they have selected an answer                                                                                    |
 | ariaMinChars            | string            | true     | Aria message to tell the user how many charecters they need to enter before autosuggest will start                                                 |
+| ariaResultsLabel        | string            | true     | Aria message to tell the user that suggestions are available                                                                                       |
 | ariaOneResult           | string            | true     | Aria message to tell the user there is only one suggestion left                                                                                    |
 | ariaNResults            | string            | true     | Aria message to tell the user how many suggestions are left                                                                                        |
 | ariaLimitedResults      | string            | true     | Aria message to tell the user if the results have been limited and what they are limited to                                                        |

--- a/src/components/input/_macro.njk
+++ b/src/components/input/_macro.njk
@@ -108,6 +108,7 @@
                 "instructions": params.autosuggest.instructions,
                 "ariaYouHaveSelected": params.autosuggest.ariaYouHaveSelected,
                 "ariaMinChars": params.autosuggest.ariaMinChars,
+                "ariaResultsLabel": params.autosuggest.ariaResultsLabel,
                 "ariaOneResult": params.autosuggest.ariaOneResult,
                 "ariaNResults": params.autosuggest.ariaNResults,
                 "ariaLimitedResults": params.autosuggest.ariaLimitedResults,

--- a/src/components/input/autosuggest/autosuggest.ui.js
+++ b/src/components/input/autosuggest/autosuggest.ui.js
@@ -109,7 +109,7 @@ export default class AutosuggestUI {
     this.input.setAttribute('aria-autocomplete', 'list');
     this.input.setAttribute('aria-controls', this.listbox.getAttribute('id'));
     this.input.setAttribute('aria-describedby', this.instructions.getAttribute('id'));
-    this.input.setAttribute('aria-has-popup', true);
+    this.input.setAttribute('aria-haspopup', true);
     this.input.setAttribute('aria-owns', this.listbox.getAttribute('id'));
     this.input.setAttribute('aria-expanded', false);
     this.input.setAttribute('autocomplete', this.input.getAttribute('autocomplete') || 'zz');

--- a/src/tests/spec/autosuggest/autosuggest.ui.spec.js
+++ b/src/tests/spec/autosuggest/autosuggest.ui.spec.js
@@ -107,7 +107,7 @@ describe('Autosuggest.ui component', function() {
       expect(this.input.getAttribute('aria-autocomplete')).to.equal('list');
       expect(this.input.getAttribute('aria-controls')).to.equal(this.listbox.getAttribute('id'));
       expect(this.input.getAttribute('aria-describedby')).to.equal(this.instructions.getAttribute('id'));
-      expect(this.input.getAttribute('aria-has-popup')).to.equal('true');
+      expect(this.input.getAttribute('aria-haspopup')).to.equal('true');
       expect(this.input.getAttribute('aria-owns')).to.equal(this.listbox.getAttribute('id'));
       expect(this.input.getAttribute('aria-expanded')).to.equal('false');
       expect(this.input.getAttribute('role')).to.equal('combobox');


### PR DESCRIPTION
### What is the context of this PR?
DAC review suggested an additional `aria-label` is required on the autosuggest results `<ul>` element.

BREAKING CHANGE - A new parameter `ariaResultsLabel` needs to be added to `onsAutosuggest` implementations. The value should be a string that is contextual to the current scenario i.e.  `'ariaResultsLabel': 'Passport suggestions'`.

### How to review 
Check the parameter is rendered as an `aria-label` html attribute.