### PR TITLE
Added property to all SVGs (IE bug fix DAC)

### DIFF
--- a/src/components/icons/_macro.njk
+++ b/src/components/icons/_macro.njk
@@ -1,62 +1,62 @@
 {% macro onsIcon(params) %}
     {% if params.icon == "check" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path d="M14.35,3.9l-.71-.71a.5.5,0,0,0-.71,0h0L5.79,10.34,3.07,7.61a.51.51,0,0,0-.71,0l-.71.71a.51.51,0,0,0,0,.71l3.78,3.78a.5.5,0,0,0,.71,0h0L14.35,4.6A.5.5,0,0,0,14.35,3.9Z" transform="translate(-1.51 -3.04)"/>
         </svg>
     {% elif params.icon == "chevron" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 7.5 12.85" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 7.5 12.85" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z" transform="translate(-5.02 -1.59)"/>
         </svg>
     {% elif params.icon == "exit" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path d="M13.85,7.65l-2.5-2.5a.5.5,0,0,0-.71,0,.48.48,0,0,0-.15.36V7h-3a.5.5,0,0,0-.5.5v1a.5.5,0,0,0,.5.5h3v1.5A.49.49,0,0,0,11,11a.48.48,0,0,0,.34-.14l2.51-2.5a.49.49,0,0,0,0-.68Z" transform="translate(-2 -2)"/>
             <path d="M8.5,14h-6a.5.5,0,0,1-.5-.5V2.5A.5.5,0,0,1,2.5,2h6a.5.5,0,0,1,.5.5V3a.5.5,0,0,1-.5.5h-5v9h5A.5.5,0,0,1,9,13v.5A.5.5,0,0,1,8.5,14Z" transform="translate(-2 -2)"/>
         </svg>
     {% elif params.icon == "quote" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 14 10" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 14 10" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path d="M13.44.77h-3l-2 4v6h6v-6h-3l2-4zm-8 0h-3l-2 4v6h6v-6h-3l2-4z" transform="translate(-0.44 -0.77)"/>
         </svg>
     {% elif params.icon == "lock" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 10 13" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 10 13" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path d="M12.25,6h-.72V4.49a3.5,3.5,0,0,0-7,0V6H3.75A.77.77,0,0,0,3,6.75v6.5a.77.77,0,0,0,.75.75h8.5a.77.77,0,0,0,.75-.75V6.75A.77.77,0,0,0,12.25,6ZM5.54,4.49a2.5,2.5,0,1,1,5,0V6h-5ZM9,11.66a.3.3,0,0,1-.26.34H7.29A.29.29,0,0,1,7,11.69v0l.39-1.82a1,1,0,1,1,1.4-.18.77.77,0,0,1-.18.18Z" transform="translate(-3 -0.99)"/>
         </svg>
     {% elif params.icon == "external-link" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)"/>
             <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)"/>
         </svg>
     {% elif params.icon == "sort-sprite" %}
-        <svg id="sort-sprite{% if params.id is defined and params.id %}-{{ params.id | lower }}{% endif %}" class="svg-icon" viewBox="0 0 12 18.6" xmlns="http://www.w3.org/2000/svg">
+        <svg id="sort-sprite{% if params.id is defined and params.id %}-{{ params.id | lower }}{% endif %}" class="svg-icon" viewBox="0 0 12 18.6" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path class="topTriangle"  d="M6 0l6 7.2H0L6 0zm0 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z"/>
             <path class="bottomTriangle" d="M6 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z"/>
         </svg>
     {% elif params.icon == "print" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 20 16" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 20 16" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path d="M17 4H3C1.3 4 0 5.2 0 6.8v5.5h4V16h12v-3.7h4V6.8C20 5.2 18.7 4 17 4zm-3 10H6V9h8v5zm3-6a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm-1-8H4v3h12V0z"/>
         </svg>
     {% elif params.icon == "person" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false">
             <path d="M7,9H9a5,5,0,0,1,5,5H2A5,5,0,0,1,7,9Z" transform="translate(-2 -2)"/>
             <circle cx="6" cy="3" r="3"/>
         </svg>
     {% elif params.icon == "facebook" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" id="icon-facebook" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" id="icon-facebook" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
             <path d="M32,16.0986285 C32.0009185,7.5342974 25.337417,0.468462963 16.8372092,0.0203294753 C8.33700136,-0.427804013 0.97607758,5.89865855 0.0874346352,14.4161886 C-0.801208309,22.9337186 5.09355054,30.6602611 13.5009524,31.9979281 L13.5009524,20.7518951 L9.44,20.7518951 L9.44,16.0986285 L13.5009524,16.0986285 L13.5009524,12.549267 C13.5009524,8.5169471 15.8857143,6.28613892 19.5428571,6.28613892 C20.742535,6.30277426 21.9393895,6.40782423 23.1238095,6.60044523 L23.1238095,10.5637711 L21.1047619,10.5637711 C19.1161905,10.5637711 18.4990476,11.8056643 18.4990476,13.0782216 L18.4990476,16.0986285 L22.9409524,16.0986285 L22.2247619,20.7518951 L18.4990476,20.7518951 L18.4990476,31.9979281 C26.2735701,30.760956 31.9991507,24.0182672 32,16.0986285 L32,16.0986285 Z"/>
         </svg>
     {% elif params.icon == "twitter" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" id="icon-twitter" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" id="icon-twitter" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
             <path d="M24.04,12.95c0,0.17,0,0.33,0,0.5c0.01,4.01-2.17,7.71-5.69,9.64c-3.52,1.93-7.81,1.78-11.19-0.38c0.31,0.04,0.61,0.05,0.92,0.05c1.73,0,3.42-0.58,4.78-1.65c-1.65-0.04-3.09-1.11-3.6-2.68c0.25,0.05,0.51,0.07,0.76,0.07c0.34,0,0.68-0.05,1.01-0.14C9.23,18,7.93,16.4,7.95,14.55v-0.05c0.54,0.29,1.13,0.46,1.74,0.48c-1.66-1.12-2.2-3.33-1.23-5.08c1.96,2.41,4.85,3.87,7.95,4.03c-0.07-0.29-0.1-0.58-0.1-0.88c0-1.58,0.97-3,2.44-3.59c1.47-0.58,3.15-0.21,4.23,0.94c0.86-0.17,1.69-0.49,2.45-0.94c-0.28,0.9-0.88,1.65-1.69,2.13c0.76-0.09,1.51-0.29,2.21-0.6C25.43,11.76,24.79,12.42,24.04,12.95zM16,0C7.16,0,0,7.16,0,16s7.16,16,16,16s16-7.16,16-16c0-4.24-1.69-8.31-4.69-11.31S20.24,0,16,0z"/>
         </svg>
     {% elif params.icon == "instagram" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" id="icon-instagram" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" id="icon-instagram" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
             <path d="M21.34,9.46c0.66,0,1.2,0.54,1.2,1.2c0,0.66-0.54,1.2-1.2,1.2c-0.66,0-1.2-0.54-1.2-1.2C20.14,10,20.68,9.46,21.34,9.46z M16,12.67c-1.84,0-3.33,1.49-3.33,3.33c0,1.84,1.49,3.33,3.33,3.33c1.84,0,3.33-1.49,3.33-3.33C19.33,14.16,17.84,12.67,16,12.67z M16,10.86c2.84,0,5.14,2.3,5.14,5.14c0,2.84-2.3,5.14-5.14,5.14c-2.84,0-5.14-2.3-5.14-5.14C10.86,13.16,13.16,10.86,16,10.86z M16.56,7.8h-1.11c-2.17,0-2.51,0.01-3.49,0.06c-0.97,0.04-1.5,0.21-1.86,0.34C9.64,8.39,9.3,8.6,8.95,8.95C8.6,9.3,8.39,9.64,8.2,10.1c-0.14,0.35-0.3,0.88-0.34,1.86c-0.04,0.98-0.06,1.32-0.06,3.49v1.11c0,2.17,0.01,2.51,0.06,3.49c0.04,0.97,0.21,1.5,0.34,1.86c0.18,0.47,0.4,0.8,0.75,1.15c0.35,0.35,0.68,0.57,1.15,0.75c0.35,0.14,0.88,0.3,1.86,0.34c0.94,0.04,1.29,0.06,3.23,0.06h1.61c1.94,0,2.3-0.02,3.23-0.06c0.97-0.04,1.5-0.21,1.86-0.34c0.47-0.18,0.8-0.4,1.15-0.75c0.35-0.35,0.57-0.68,0.75-1.15c0.14-0.35,0.3-0.88,0.34-1.86c0.04-0.94,0.06-1.29,0.06-3.23v-1.61c0-1.94-0.02-2.3-0.06-3.23c-0.04-0.97-0.21-1.5-0.34-1.86c-0.18-0.47-0.4-0.8-0.75-1.15C22.7,8.6,22.36,8.39,21.9,8.2c-0.35-0.14-0.88-0.3-1.86-0.34C19.06,7.82,18.72,7.8,16.56,7.8z M17.03,6c1.8,0,2.18,0.02,3.1,0.06c1.06,0.05,1.79,0.22,2.43,0.46c0.66,0.26,1.22,0.6,1.77,1.15c0.56,0.56,0.9,1.11,1.15,1.77c0.25,0.64,0.42,1.36,0.46,2.43c0.05,0.99,0.06,1.35,0.06,3.58v1.09c0,2.22-0.01,2.59-0.06,3.58c-0.05,1.06-0.22,1.79-0.46,2.43c-0.26,0.66-0.6,1.22-1.15,1.77c-0.56,0.56-1.11,0.9-1.77,1.15c-0.64,0.25-1.36,0.42-2.43,0.46C19.13,25.99,18.77,26,16.55,26h-1.09c-2.22,0-2.59-0.01-3.58-0.06c-1.06-0.05-1.79-0.22-2.43-0.46c-0.66-0.26-1.22-0.6-1.77-1.15c-0.56-0.56-0.9-1.11-1.15-1.77c-0.25-0.64-0.42-1.36-0.46-2.43C6.02,19.21,6,18.83,6,17.03v-2.06c0-1.8,0.02-2.18,0.06-3.1c0.05-1.06,0.22-1.79,0.46-2.43c0.26-0.66,0.6-1.22,1.15-1.77c0.56-0.56,1.11-0.9,1.77-1.15c0.64-0.25,1.36-0.42,2.43-0.46C12.79,6.02,13.17,6,14.97,6H17.03z M16,0C7.16,0,0,7.16,0,16s7.16,16,16,16s16-7.16,16-16c0-4.24-1.69-8.31-4.69-11.31S20.24,0,16,0z"/>
         </svg>
     {% elif params.icon == "linkedin" %}
-        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" id="icon-linkedin" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" id="icon-linkedin" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
             <path d="M16,-3.41060513e-13 C20.2434638,-3.41060513e-13 24.3131264,1.68570945 27.3137085,4.6862915 C30.3142906,7.68687356 32,11.7565362 32,16 C32,24.836556 24.836556,32 16,32 C7.163444,32 0,24.836556 0,16 C0,7.163444 7.163444,-3.41060513e-13 16,-3.41060513e-13 Z M11.3505859,12.4641113 L7.45385744,12.4641113 L7.45385744,24.1875 L11.3505859,24.1875 L11.3505859,12.4641113 Z M20.9152832,12.1889649 C18.8479004,12.1889649 17.9213867,13.3251953 17.4035644,14.1240234 L17.4035644,14.1240234 L17.4035644,12.4641113 L13.5070801,12.4641113 C13.5212538,12.7696262 13.5275532,13.809993 13.5292593,15.1533871 L13.5293118,16.8832762 C13.5292156,16.9843911 13.5291048,17.0860852 13.5289803,17.1882303 L13.5280782,17.8054916 L13.5280782,17.8054916 L13.5268961,18.427439 C13.5216699,20.9164121 13.5108442,23.3704557 13.5078578,24.0208157 L13.5070801,24.1875 L17.4035644,24.1875 L17.4035644,17.640625 C17.4035644,17.2902832 17.4287109,16.9401856 17.5317382,16.6896972 C17.8134766,15.9897461 18.4545899,15.2646484 19.5310059,15.2646484 C20.940918,15.2646484 21.5051269,16.3395996 21.5051269,17.9157715 L21.5051269,17.9157715 L21.5051269,24.1875 L25.4013672,24.1875 L25.4013672,17.465332 C25.4013672,13.8645019 23.4790039,12.1889649 20.9152832,12.1889649 Z M9.42822263,6.8125 C8.09521488,6.8125 7.22363281,7.68774412 7.22363281,8.83813475 C7.22363281,9.96313475 8.06933594,10.8632812 9.37695313,10.8632812 L9.37695313,10.8632812 L9.40234375,10.8632812 C10.7612305,10.8632812 11.6069336,9.96313475 11.6069336,8.83813475 C11.581543,7.68774412 10.7612305,6.8125 9.42822263,6.8125 Z"/>
         </svg>
     {% elif params.icon == "loader" %}
-        <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" class="uil-default">
+        <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" focusable="false" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" class="uil-default">
             <rect x="0" y="0" width="100" height="100" fill="none" class="bk"></rect>
             <rect x='46.5' y='40' width='7' height='20' rx='5' ry='5' transform='rotate(0 50 50) translate(0 -30)'>
                 <animate attributeName='opacity' from='1' to='0' dur='1s' begin='0s' repeatCount='indefinite'/>
@@ -96,7 +96,7 @@
             </rect>
         </svg>
     {% elif params.icon == "census-logo-cy" %}
-        <svg class="header__svg-logo" xmlns="http://www.w3.org/2000/svg" width="242" height="44" viewBox="0 0 242 44" role="img" aria-labelledby="census-logo-cy-alt">
+        <svg class="header__svg-logo" xmlns="http://www.w3.org/2000/svg" focusable="false" width="242" height="44" viewBox="0 0 242 44" role="img" aria-labelledby="census-logo-cy-alt">
             <title id="census-logo-cy-alt">{{ params.altText }}</title>
             <path style="opacity:0.7" d="M623.06,494.45H611.47a4.82,4.82,0,0,1,.14-1c.61-2.44,3.08-3.71,6.08-5.05,3.46-1.59,6.72-3.22,6.72-7.32s-3-6.82-8-6.82a9.6,9.6,0,0,0-6.15,2,5.11,5.11,0,0,0-2.08,3.75c0,1.9,2.4,1.87,2.4,1.76a5.42,5.42,0,0,1,5.58-4.38c2.94,0,4.67,1.41,4.67,3.78s-2.69,3.61-5.69,5.09c-3.43,1.7-7.07,3.78-7.07,8.48v.88c0,1.45.67,2,2.26,2h12.72c1.2,0,1.73-.53,1.73-1.48v-.21C624.79,495,624.26,494.45,623.06,494.45Z" transform="translate(-401.34 -464)"/>
             <path style="opacity:0.7" d="M595.5,474.24c-5.86,0-9.5,4.14-9.5,10.74v2.34c0,6.6,3.57,10.7,9.5,10.7s9.54-4.17,9.54-10.78V485C605,478.34,601.44,474.24,595.5,474.24Zm5.9,13.18c0,4.81-2.12,7.53-5.9,7.53s-5.83-2.76-5.83-7.56v-2.58c0-4.81,2.12-7.56,5.83-7.56s5.9,2.82,5.9,7.63Z" transform="translate(-401.34 -464)"/>
@@ -115,7 +115,7 @@
             <path d="M497.71,464.12a11.86,11.86,0,0,0-8.51,11.37V495a2.69,2.69,0,0,0,5.38,0V481.65h2a2.7,2.7,0,1,0,0-5.39h-2v-.77a6.48,6.48,0,0,1,4.6-6.19l.07,0a2.7,2.7,0,0,0,1.8-3.36A2.67,2.67,0,0,0,497.71,464.12Z" transform="translate(-401.34 -464)"/>
         </svg>
     {% elif params.icon == "census-logo-en" %}
-        <svg class="header__svg-logo" xmlns="http://www.w3.org/2000/svg" width="228" height="44" viewBox="0 0 228 44" role="img" aria-labelledby="census-logo-en-alt">
+        <svg class="header__svg-logo" xmlns="http://www.w3.org/2000/svg" focusable="false" width="228" height="44" viewBox="0 0 228 44" role="img" aria-labelledby="census-logo-en-alt">
             <title id="census-logo-en-alt">{{ params.altText }}</title>
             <path d="M35.85,10a12,12,0,0,0,0,24,2.73,2.73,0,0,0,0-5.45,6.57,6.57,0,0,1-6-3.82H45.12A2.73,2.73,0,0,0,47.85,22,12,12,0,0,0,35.85,10Zm-6,9.27a6.55,6.55,0,0,1,11.91,0Z"/>
             <path d="M62.42,10a12,12,0,0,0-12,12v9.12a2.73,2.73,0,0,0,5.45,0V22A6.55,6.55,0,1,1,69,22v9.12a2.73,2.73,0,0,0,5.45,0V22A12,12,0,0,0,62.42,10Z"/>


### PR DESCRIPTION
## DAC Accessibility finding

Added `focusable="false"` to all SVGs. In Internet Explorer all SVGs are focusable. This property ensures they are not in the tab sequence.

I have added `aria-hidden` property for the social icons specifically. Other icons require a little more thought and could include descriptive text perhaps.

Closes #1315