### PR TITLE
added additional is defined param to list macro

### DIFF
--- a/src/components/lists/_macro.njk
+++ b/src/components/lists/_macro.njk
@@ -1,11 +1,11 @@
 {% macro onsList(params) %}
     {% set classes = params.classes | lower %}
     
-    {% if params.itemsList[0].prefix %}
+    {% if params.itemsList[0] is defined and params.itemsList[0].prefix %}
         {% set otherClasses = 'list--bare list--prefix' %}
-    {% elif params.itemsList[0].suffix %}
+    {% elif params.itemsList[0] is defined and params.itemsList[0].suffix %}
         {% set otherClasses = 'list--bare list--suffix' %}
-    {% elif params.itemsList[0].prefixIcon or params.itemsList[0].suffixIcon %}
+    {% elif params.itemsList[0] is defined and (params.itemsList[0].prefixIcon or params.itemsList[0].suffixIcon) %}
         {% set otherClasses = 'list--bare list--icons' %}
     {% else %}
         {% set otherClasses = '' %}


### PR DESCRIPTION
### What is the context of this PR?
Issue with the way we run a condition for a parameter. Works ok with nunjucks but when brought into a python app with jinja2 it throws an error. Requires an additional `is defined`.

https://trello.com/c/OEa7M5LI
