### PR TITLE
Removed copyright link due to duplication (DAC enhancement)

### DIFF
--- a/src/components/footer/_macro-options.md
+++ b/src/components/footer/_macro-options.md
@@ -23,13 +23,10 @@
 
 ## CopyrightDeclaration
 
-| Name      | Type    | Required | Description                                                      |
-| --------- | ------- | -------- | ---------------------------------------------------------------- |
-| copyright | string  | true     | The text for the copyright declaration                           |
-| text      | string  | true     | The text that comes before the link on the copyright declaration |
-| link      | string  | true     | The text for the copyright link                                  |
-| url       | string  | true     | The url for the copyright link                                   |
-| newWindow | boolean | false    | If set to true opens the copyright link in a new tab             |
+| Name      | Type   | Required | Description                                         |
+| --------- | ------ | -------- | --------------------------------------------------- |
+| copyright | string | true     | The text for the copyright declaration              |
+| text      | string | true     | The text that comes after the copyright declaration |
 
 ## FooterCol
 

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -218,7 +218,7 @@
                     <!-- Copyright -->
                     <div class="grid"> 
                         <div class="grid__col u-mt-s">
-                            <p class="u-fs-s u-mb-no">&copy; {{ params.copyrightDeclaration.copyright }} <br> {{ params.copyrightDeclaration.text }} <a href="{{ params.copyrightDeclaration.url }}" {% if params.copyrightDeclaration.newWindow is defined and params.copyrightDeclaration.newWindow %}target="_blank" rel="noopener"{% endif %}>{{ params.copyrightDeclaration.link }}</a>.</p>
+                            <p class="u-fs-s u-mb-no">&copy; {{ params.copyrightDeclaration.copyright }} <br> {{ params.copyrightDeclaration.text }}</p>
                         </div>
                     </div>
                 {% endif %}

--- a/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
+++ b/src/components/footer/examples/footer-transactional-no-ogl-crest-copyright/index.njk
@@ -44,10 +44,7 @@
         ],
         "copyrightDeclaration": {
             "copyright": 'Crown copyright and database rights 2020 OS 100019153.',
-            "text": 'Use of address data is subject to the',
-            "link": 'terms and conditions',
-            "url": '#0',
-            "newWindow": true
+            "text": 'Use of address data is subject to the terms and conditions.'
         }
     })
 }}


### PR DESCRIPTION
Removed link in copyright declaration to fix duplicated links being used. The same link is referenced in terms and conditions.