### PR TITLE
Removed alt tag property from document download thumbnail

### DIFF
--- a/src/components/downloads/_macro-options.md
+++ b/src/components/downloads/_macro-options.md
@@ -11,11 +11,10 @@
 
 ## Thumbnail
 
-| Name     | Type   | Required | Description                                                 |
-| -------- | ------ | -------- | ----------------------------------------------------------- |
-| smallSrc | string | true     | Path to the non-retina version of the image                 |
-| largeSrc | string | true     | Path to the retina version of the image                     |
-| alt      | string | true     | Alt tag to explain the appearance and function of the image |
+| Name     | Type   | Required | Description                                 |
+| -------- | ------ | -------- | ------------------------------------------- |
+| smallSrc | string | true     | Path to the non-retina version of the image |
+| largeSrc | string | true     | Path to the retina version of the image     |
 
 ## Meta
 

--- a/src/components/downloads/_macro.njk
+++ b/src/components/downloads/_macro.njk
@@ -7,9 +7,9 @@
         <div class="download__image" aria-hidden="true">
             <a class="download__image-link" href="{{ download.url }}" tabindex="-1">
                 {% if download.thumbnail is defined and download.thumbnail and download.thumbnail.smallSrc is defined and download.thumbnail.smallSrc and download.thumbnail.largeSrc is defined and download.thumbnail.largeSrc %}
-                    <img srcset="{{ download.thumbnail.smallSrc }} 1x, {{ download.thumbnail.largeSrc }} 2x" src="{{ download.thumbnail.smallSrc }}" alt="{{ download.thumbnail.alt }}" loading="lazy">
+                    <img srcset="{{ download.thumbnail.smallSrc }} 1x, {{ download.thumbnail.largeSrc }} 2x" src="{{ download.thumbnail.smallSrc }}" alt="" loading="lazy">
                 {% else %}
-                    <img srcset="{{ download.placeholderURL if download.placeholderURL is defined and download.placeholderURL }}/img/small/placeholder-portrait.png 1x, {{ download.placeholderURL if download.placeholderURL is defined and download.placeholderURL }}/img/large/placeholder-portrait.png 2x" src="{{ download.placeholderURL if download.placeholderURL is defined and download.placeholderURL }}/img/small/placeholder-portrait.png" alt="Image placeholder" loading="lazy">
+                    <img srcset="{{ download.placeholderURL if download.placeholderURL is defined and download.placeholderURL }}/img/small/placeholder-portrait.png 1x, {{ download.placeholderURL if download.placeholderURL is defined and download.placeholderURL }}/img/large/placeholder-portrait.png 2x" src="{{ download.placeholderURL if download.placeholderURL is defined and download.placeholderURL }}/img/small/placeholder-portrait.png" alt="" loading="lazy">
                 {% endif %}
             </a>
         </div>

--- a/src/components/downloads/examples/downloads-multiple/index.njk
+++ b/src/components/downloads/examples/downloads-multiple/index.njk
@@ -4,8 +4,7 @@
         {
             "thumbnail": {
                 "smallSrc": '/patternlib-img/download-resources/img/small/census-2021-matters-to-everyone.png',
-                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-matters-to-everyone.png',
-                "alt": 'Census 2021 matters to everyone document thumbnail'
+                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-matters-to-everyone.png'
             },
             "url": '/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf',
             "title": 'Census 2021 matters to everyone',
@@ -20,8 +19,7 @@
         {
             "thumbnail": {
                 "smallSrc": '/patternlib-img/download-resources/img/small/including-everyone-in-census-2021-v2.png',
-                "largeSrc": '/patternlib-img/download-resources/img/large/including-everyone-in-census-2021-v2.png',
-                "alt": 'Including everyone in Census 2021 document thumbnail'
+                "largeSrc": '/patternlib-img/download-resources/img/large/including-everyone-in-census-2021-v2.png'
             },
             "url": '/patternlib-img/download-resources/documents/Print-Ready-A4EB1-2021-v1-0-120620.pdf',            
             "title": 'Including everyone in Census 2021',
@@ -36,8 +34,7 @@
         {
             "thumbnail": {
                 "smallSrc": '/patternlib-img/download-resources/img/small/including-everyone-in-census-2021.png',
-                "largeSrc": '/patternlib-img/download-resources/img/large/including-everyone-in-census-2021.png',
-                "alt": 'Including everyone in Census 2021 document thumbnail'
+                "largeSrc": '/patternlib-img/download-resources/img/large/including-everyone-in-census-2021.png'
             },
             "url": '/patternlib-img/download-resources/documents/A6PCA1-v1-0-Print-Ready-Pack1.pdf',            
             "title": 'Including everyone in Census 2021',
@@ -52,8 +49,7 @@
         {
             "thumbnail": {
                 "smallSrc": '/patternlib-img/download-resources/img/small/census-2021-community-handbook.png',
-                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-community-handbook.png',
-                "alt": 'Community handbook for Census 2021 document thumbnail'
+                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-community-handbook.png'
             },
             "url": '/patternlib-img/download-resources/documents/CHDE1-Community-Handbook-v0.6.pdf',            
             "title": 'Community handbook for Census 2021',

--- a/src/components/downloads/examples/downloads-single/index.njk
+++ b/src/components/downloads/examples/downloads-single/index.njk
@@ -4,8 +4,7 @@
         {
             "thumbnail": {
                 "smallSrc": '/patternlib-img/download-resources/img/small/census-2021-matters-to-everyone.png',
-                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-matters-to-everyone.png',
-                "alt": 'Census 2021 matters to everyone document thumbnail'
+                "largeSrc": '/patternlib-img/download-resources/img/large/census-2021-matters-to-everyone.png'
             },
             "url": '/patternlib-img/download-resources/documents/Print-Ready-A4GIP1-2021-v1-0-120620.pdf',
             "title": 'Census 2021 matters to everyone',

--- a/src/components/downloads/index.njk
+++ b/src/components/downloads/index.njk
@@ -39,6 +39,8 @@ Image dimension for:
 
 We specify a folder path for both small and large images, which is defined in the macro as `smallSrc` and `largeSrc`. The filename is expected to be the same for both.
 
+The image used is considered decorative and does not convey important information, and as such should be hidden from screen readers. The image does not require an `alt` tag.
+
 ## Research on this pattern
 {% call onsPanel() %}
     If you have conducted any user research using this pattern, please feed back your findings via the


### PR DESCRIPTION
Thumbnail is decorative and does not convey important information to screen readers and has been assigned a null alt attribute to enable screen reading software to disregard it.

**Ref:** P16 in the DAC Accessibility report.