### PR TITLE
Left align for image and caption. Updated docs and macro options

### DIFF
--- a/src/components/images/_images.scss
+++ b/src/components/images/_images.scss
@@ -1,17 +1,15 @@
 .figure {
   margin: 0;
-  text-align: center;
   @extend .u-mb-m;
 
   &__image {
-    display: inline-block;
+    display: block;
     max-width: 100%;
   }
 
   &__caption {
     display: block;
     font-size: 0.8rem;
-    text-align: center;
     padding: 0.5rem 0 0;
   }
 }

--- a/src/components/images/_macro-options.md
+++ b/src/components/images/_macro-options.md
@@ -2,7 +2,7 @@
 | ------- | ------- | -------------------------------- | --------------------------------------------------------------- |
 | url     | string  | true (false if `Image` provided) | The complete image path including filename and extension        |
 | image   | `Image` | false (true if url not provided) | An object containing path and filename attributes for the image |
-| alt     | string  | true                             | Alt tag to explain the appearance and function of the image     |
+| alt     | string  | false                            | Alt tag to explain the appearance and function of the image     |
 | caption | string  | false                            | A short caption describing the contents                         |
 
 ## Image

--- a/src/components/images/examples/new/index.njk
+++ b/src/components/images/examples/new/index.njk
@@ -5,7 +5,6 @@
             smallSrc: '/img/small/woman-in-purple-dress-shirt.jpg',
             largeSrc: '/img/large/woman-in-purple-dress-shirt.jpg'
         },
-        alt: 'Woman in a purple dress shirt using a laptop',
         caption: 'Image 1 - Woman in a purple dress shirt using a laptop'
     })
 }}

--- a/src/styles/images/index.njk
+++ b/src/styles/images/index.njk
@@ -13,6 +13,8 @@ Uses two versions of the image, one for standard screens and the other for retin
 
 We specify a folder path for both small and large images which is defined in the macro as `smallSrc` and `largeSrc`. The filename is expected to be the same for both.
 
+If the image is decorative and does not convey important information, do not add an alt tag. This will then be hidden from screen reader users.
+
 {{
     patternlibExample({"path": 'components/images/examples/new/index.njk'})
 }}


### PR DESCRIPTION
Image and caption is now left aligned.

Added some information about when not to add an alt tag (decorative image).

Alt tag is not required.