### PR TITLE
Fixed margin-bottom as a result of introducing the strong tag to the …

### DIFF
--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -50,10 +50,13 @@
 
   &__body {
     padding: 1rem;
+
     // Removes inherited bottom margin to make whitespace inside panel equal
-    > *:last-child {
+    > *:last-child,
+    strong > *:last-child {
       margin-bottom: 0;
     }
+
     &.svg-icon-margin--xxl {
       padding-left: 3.3rem !important;
     }

--- a/src/styles/typography/icons/_icons.scss
+++ b/src/styles/typography/icons/_icons.scss
@@ -1,5 +1,4 @@
 .svg-icon {
-  fill: currentColor;
   width: 1rem;
   height: 1rem;
   vertical-align: middle;


### PR DESCRIPTION
Fixed additional panel as a result of introducing the strong tag. Last child was not working as a result of this addition.

Also fixed the incorrect colour being used for the success panel

**Before**
<img width="571" alt="Screenshot 2021-02-04 at 11 15 15" src="https://user-images.githubusercontent.com/4989027/106885386-6c407780-66da-11eb-9df3-1632b763e8cd.png">
<img width="944" alt="Screenshot 2021-02-04 at 11 15 10" src="https://user-images.githubusercontent.com/4989027/106885396-6e0a3b00-66da-11eb-91b1-fbe8b865de5f.png">

**After**
<img width="527" alt="Screenshot 2021-02-04 at 11 14 51" src="https://user-images.githubusercontent.com/4989027/106885431-78c4d000-66da-11eb-897e-a0cafb2ecb53.png">

<img width="871" alt="Screenshot 2021-02-04 at 11 15 03" src="https://user-images.githubusercontent.com/4989027/106885418-76627600-66da-11eb-91aa-b9d1c6297930.png">
