### PR TITLE
1025 skip link tabindex

### DIFF
--- a/src/components/skip-to-content/skip-to-content.js
+++ b/src/components/skip-to-content/skip-to-content.js
@@ -2,7 +2,7 @@ export default function skipToMain(link) {
   const id = link.getAttribute('href').replace('#', '');
   link.addEventListener('click', event => {
     event.preventDefault();
-    document.getElementById(id).tabIndex = 0;
+    document.getElementById(id).tabIndex = -1;
     document.getElementById(id).style.outline = 'none';
     document.getElementById(id).focus();
   });

--- a/src/styles/page-template/examples/custom/index.njk
+++ b/src/styles/page-template/examples/custom/index.njk
@@ -81,7 +81,7 @@ layout: none
         }
     }
 } %}
-{% block bodyStart %}
+{% block preHeader %}
 {% from "components/phase-banner/_macro.njk" import onsPhaseBanner %}
 {{
     onsPhaseBanner({

--- a/src/styles/page-template/examples/rtl/index.njk
+++ b/src/styles/page-template/examples/rtl/index.njk
@@ -130,6 +130,10 @@ layout: none
     {{ onsTableOfContents({
         "title": 'محتويات',
         "ariaLabel": 'Pages in this guide',
+        "skipLink": {
+            "url": "#section-content",
+            "text": "Skip to guide content"
+        },
         "itemsList": [
             {
                 "url": '#0',
@@ -147,7 +151,7 @@ layout: none
         ]
     }) }}
 
-    <div class="page__body">
+    <div id="section-content" class="page__body">
 
         <h2>ما هو التعداد السكاني؟</h2>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3368,10 +3368,17 @@ debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^3.2.6:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
 
@@ -4487,6 +4494,13 @@ faye-websocket@^0.11.3:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
   integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
+  dependencies:
+    websocket-driver ">=0.5.1"
+
+faye-websocket@~0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
+  integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
   dependencies:
     websocket-driver ">=0.5.1"
 


### PR DESCRIPTION
### What is the context of this PR?
The js solution for the skip to content link, preventing the need to append `#main-content` to the url (which persists when moving to next page in eQ), was adding `tabindex="0"` to the `<main>` element, which meant it was then part of the tab order.  So when the user tabs back up to the header, the focus indicator is lost when `<main>` is in focus.

#### Changes:

- Changed js `tabindex` value to `-1` so it's focusable by JS, but not put in tab order
- Updated custom page template example, moving phase banner to a different block, to ensure skip links are in the correct position
- Add TOC to RTL page template guide

### How to review 
Check skip to content link works as expected, and user can tab back up without losing focus indicator