### PR TITLE
Remove duplicate strong tags from UAC example

### DIFF
--- a/src/components/collapsible/examples/collapsible-with-warning/index.njk
+++ b/src/components/collapsible/examples/collapsible-with-warning/index.njk
@@ -24,5 +24,4 @@
         Someone in your household must still complete a census using a household access code
     {% endcall %}
 
-    
 {% endcall %}

--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -2,7 +2,6 @@
   {% from "components/button/_macro.njk" import onsButton %}
 
   {% set title_tag = "h1" if params.tilteAsH1 else "div" %}
-
   {% set currentLanguageISOCode = "en" %}
 
   {% if params.language is defined and params.language and params.language.languages is defined and params.language.languages %}

--- a/src/components/panel/_macro.njk
+++ b/src/components/panel/_macro.njk
@@ -74,7 +74,6 @@
                 {% if params is defined and params and params.type == "warn" or params.type == "warn-branded" %}
                     </strong>
                 {% endif %}
-
             </div>
 
         </div>

--- a/src/components/uac/examples/uac-census/index.njk
+++ b/src/components/uac/examples/uac-census/index.njk
@@ -47,7 +47,6 @@ layout: none
 } %}
 
 {% block preMain %}
-
     {{
         onsBreadcrumb({
             "ariaLabel": 'Breadcrumb',
@@ -64,7 +63,6 @@ layout: none
             ]
         })
     }}
-
 {% endblock %}
 
 {% block main %}
@@ -99,7 +97,7 @@ layout: none
                 classes: "u-mt-l u-mb-l"
             })
         %}
-        <p><strong>Someone in your household must still complete a census using a household access code</strong></p>
+            Someone in your household must still complete a census using a household access code
         {% endcall %}
     {% endset %}
 


### PR DESCRIPTION
### What is the context of this PR?
This is just a small PR to remove the duplicate strong tags from the UAC census example. Plus a bit of a code tidy removing some whitespace.

Fixes: #1361 

### How to review 
Only one strong tag now appears in example