### PR TITLE
Address autosuggest - fix niboost typo

### DIFF
--- a/src/components/input/autosuggest/autosuggest.address.js
+++ b/src/components/input/autosuggest/autosuggest.address.js
@@ -340,7 +340,7 @@ export default class AutosuggestAddress {
       eboostParam = '&eboost=10',
       wboostParam = '&wboost=10',
       nionlyParam = '&eboost=0&sboost=0&wboost=0',
-      niboostParam = '&niboost=10',
+      niboostParam = '&nboost=10',
       favourwelshParam = '&favourwelsh=true',
       addresstypeParam = '?addresstype=',
       epochParam = '&epoch=75';

--- a/src/tests/spec/autosuggest/autosuggest.address.spec.js
+++ b/src/tests/spec/autosuggest/autosuggest.address.spec.js
@@ -876,7 +876,7 @@ describe('Autosuggest.address component', function() {
       it('then the fetch url should contain the correct parameters', function() {
         this.limit = 10;
         expect(this.autosuggestAddress.fetch.url).to.equal(
-          'https://whitelodge-ai-api.census-gcp.onsdigital.uk/addresses/eq?input=195 colle&limit=10&classificationfilter=workplace&niboost=10',
+          'https://whitelodge-ai-api.census-gcp.onsdigital.uk/addresses/eq?input=195 colle&limit=10&classificationfilter=workplace&nboost=10',
         );
       });
     });


### PR DESCRIPTION
Update `niboost` param to `nboost`

https://trello.com/c/nZrE1sqQ