### PR TITLE
Removed strong tags from warning panels

### DIFF
--- a/src/components/panel/_macro.njk
+++ b/src/components/panel/_macro.njk
@@ -67,13 +67,7 @@
             {% endif %}
 
             <div class="panel__body{% if params is defined and params and params.iconSize is defined and params.iconSize %} svg-icon-margin--{{ params.iconSize }}{% endif %}" {% if params is defined and params and params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params is defined and params and params.attributes is mapping and params.attributes.items is defined and params.attributes.items else params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}>{{ (params.body if params else "") | safe }}
-                {% if params is defined and params and params.type == "warn" or params.type == "warn-branded" %}
-                    <strong>
-                {% endif %}
                 {{ caller() if caller }}
-                {% if params is defined and params and params.type == "warn" or params.type == "warn-branded" %}
-                    </strong>
-                {% endif %}
             </div>
 
         </div>


### PR DESCRIPTION
### What is the context of this PR?
Removed strong tags from warning panels as not required as well as screenreader hidden prefix.  It's causing issues and invalid html when services pass in p tags

### How to review 
Check panels markup