### PR TITLE
Fix autosuggest address results handling

### DIFF
--- a/src/components/input/autosuggest/autosuggest.ui.js
+++ b/src/components/input/autosuggest/autosuggest.ui.js
@@ -380,7 +380,13 @@ export default class AutosuggestUI {
       this.setHighlightedResult(null);
 
       this.input.setAttribute('aria-expanded', !!this.numberOfResults);
-      this.context.classList[!!this.numberOfResults ? 'add' : 'remove'](classAutosuggestHasResults);
+
+      if (!!this.numberOfResults && this.sanitisedQuery.length >= this.minChars) {
+        this.context.classList.add(classAutosuggestHasResults);
+      } else {
+        this.context.classList.remove(classAutosuggestHasResults);
+        this.clearListbox();
+      }
     }
 
     if (this.numberOfResults === 0 && this.noResults) {

--- a/src/get-started/browser-compatibility/index.njk
+++ b/src/get-started/browser-compatibility/index.njk
@@ -31,7 +31,7 @@ You should test your component or pattern in these browsers:
 | _macOS_          | Safari            | 12 and later      |
 |                  | Chrome            | Latest 2 versions |
 |                  | Firefox           | Latest 2 versions |
-| _iOS_            | Safari            | 10.3 and later    |
+| _iOS_            | Safari            | 12.1 and later    |
 |                  | Chrome            | Latest 2 versions |
 | _Android_        | Chrome            | Latest 2 versions |
 |                  | Samsung Internet  | Latest 2 versions |


### PR DESCRIPTION
## What is the context of this PR?
To replicate issue go to https://ons-design-system.netlify.app/components/address/examples/address/
Type in cf14 and see suggestions.
Quickly delete so only c is displayed
Observe results displayed with broken formatting of code.

This is due to an underlying call being made to the uprn endpoint when dealing with partial postcode groupings that only have 1 in the group. This 2nd call is not dealt with when the minimum characters are not being met with the current query.

## How to review
Go to /components/address/examples/address/ on the preview build and other autosuggest examples and ensure everything works ok.