### PR TITLE
Add docker creds to release to S3 task

### DIFF
--- a/ci/concourse.yml
+++ b/ci/concourse.yml
@@ -94,6 +94,8 @@ jobs:
         type: docker-image
         source:
           repository: mesosphere/aws-cli
+          username: ((dockerhub_username))
+          password: ((dockerhub_password))
 
       inputs:
       - name: dist


### PR DESCRIPTION
### What is the context of this PR?
This PR is to add the docker credentials to the release to S3 job which was missed off the original PR

### How to review 
Release pipeline runs without error