### PR TITLE
Added an alternative version for call to actions 'Announcement'

### DIFF
--- a/src/components/call-to-action/_call-to-action.scss
+++ b/src/components/call-to-action/_call-to-action.scss
@@ -1,8 +1,57 @@
 .call-to-action {
+  background-color: $cta-bg;
   padding: 0.85rem 0;
-  background: $cta-bg;
 
   &__heading {
     padding-right: 0.2rem;
+  }
+}
+
+// Announcement
+.call-to-action--announcement {
+  background-color: $color-black;
+  color: $color-white;
+  padding: 2rem 0;
+
+  & .call-to-action__list {
+    margin-bottom: 0;
+    padding-left: 0;
+  }
+
+  & .call-to-action__item {
+    align-items: flex-start;
+    display: flex;
+  }
+
+  & .call-to-action__seperator {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+
+  & .call-to-action__item:last-child {
+    margin-bottom: 0;
+  }
+
+  & .svg-icon {
+    fill: $color-white;
+    flex-shrink: 0;
+    margin-left: -4px; // Adjustment flush left
+    margin-right: 0.5rem;
+    margin-top: 2px; // Alignment tweak
+  }
+
+  & a {
+    color: inherit;
+    font-weight: bold;
+    position: relative;
+
+    &:hover {
+      text-decoration-color: $color-white;
+      text-decoration-thickness: 2px;
+    }
+
+    &:focus {
+      box-shadow: 0 -2px #fd0, 0 4px #fd0 !important; // Override focus style because the black border is not visible on a black background
+    }
   }
 }

--- a/src/components/call-to-action/_macro.njk
+++ b/src/components/call-to-action/_macro.njk
@@ -1,7 +1,35 @@
 {% macro onsCallToAction(params) %}
-    {% from "components/button/_macro.njk" import onsButton %}
-    <div class="call-to-action">
+{% from "components/button/_macro.njk" import onsButton %}
+{% from "components/icons/_macro.njk" import onsIcon %}  
+
+    <div class="call-to-action{% if params.type == 'announcement' %} call-to-action--announcement{% endif %}{{ ' ' + params.classes if params.classes else '' }}">
+
         <div class="container">
+
+            {% if params is defined and params and params.type == "announcement" %}
+
+                <ul class="call-to-action__list">
+
+                    {% for announcements in (params.announcements if params.announcements is iterable else params.announcements.items()) %}
+                    
+                    <li class="call-to-action__item">
+                        {{
+                            onsIcon({
+                                "icon": 'arrow-forward',
+                                "iconSize": 'l'
+                            })
+                        }}
+                        <div class="call-to-action__contents">
+                            <a href="{{ announcements.url }}">{{ announcements.title }}</a><span class="call-to-action__seperator" aria-hidden="true">|</span>{{ announcements.text }}
+                        </div>
+                    </li>
+
+                    {% endfor %}
+
+                </ul>
+
+            {% else %}
+
             <div class="grid grid--flex grid--vertical-center grid--no-wrap@s">
                 <div class="grid__col col-auto u-flex-shrink@s">
                     <h2 class="call-to-action__heading u-fs-r--b u-di">{{ params.headingText }}</h2>
@@ -11,11 +39,16 @@
                     {{ onsButton({
                         "text": params.button.text,
                         "url": params.button.url,
-                        "classes": "btn--small",
-                        "innerClasses": "icon--chevron-right-white"
+                        "classes": 'btn--small',
+                        "innerClasses": 'icon--chevron-right-white'
                     })}}
                 </div>
             </div>
+
+            {% endif %}
+
         </div>
+
     </div>
+
 {% endmacro %}

--- a/src/components/call-to-action/examples/call-to-action-announcement/index.njk
+++ b/src/components/call-to-action/examples/call-to-action-announcement/index.njk
@@ -1,0 +1,22 @@
+---
+"theme": census
+"fullWidth": true
+---
+{% from "components/call-to-action/_macro.njk" import onsCallToAction %}
+{{-
+    onsCallToAction({
+        "type": 'announcement',
+        "announcements": [
+            {
+                "url": '#0',
+                "title": 'Coronavirus (COVID-19)',
+                "text": 'National lockdown: stay at home'
+            },
+            {
+                "url": '#0',
+                "title": 'Brexit',
+                "text": 'Check what you need to do'
+            }
+        ]
+    })
+}}

--- a/src/components/call-to-action/index.njk
+++ b/src/components/call-to-action/index.njk
@@ -22,6 +22,12 @@ A persistent call to action to start census.
     patternlibExample({"path": "components/call-to-action/examples/call-to-action-census/index.njk"})
 }}
 
+## Announcement
+An important announcement or group of announcements with clear call to actions.
+{{
+    patternlibExample({"path": "components/call-to-action/examples/call-to-action-announcement/index.njk"})
+}}
+
 ## Research on this component
 {% call onsPanel() %}
     If you have conducted any user research using this component, please feed back your findings via the

--- a/src/components/icons/_macro.njk
+++ b/src/components/icons/_macro.njk
@@ -156,6 +156,11 @@
         <svg class="footer__ogl-img" xmlns="http://www.w3.org/2000/svg" width="60px" height="24px" viewBox="0 0 60 24" focusable="false" aria-hidden="true">
             <path d="M51.7,17.5V0l-6.2,4v19.8h13.8v-6.2H51.7z M36.7,16.3c-1,0.9-2.4,1.4-3.8,1.4c-3.2,0-5.8-2.6-5.8-5.8s2.6-5.8,5.8-5.8c2,0,3.9,1.1,4.9,2.7L43,5.6C40.9,2.2,37.1,0,32.9,0c-4.5,0-8.4,2.5-10.4,6.1C20.4,2.5,16.5,0,12,0C5.4,0,0,5.4,0,12s5.4,12,12,12c4.5,0,8.4-2.5,10.4-6.1c2.1,3.6,6,6.1,10.4,6.1c3,0,5.8-1.1,7.9-3l2.4,2.7h0.4V13h-9.8L36.7,16.3zM12,17.8c-3.2,0-5.8-2.6-5.8-5.8S8.8,6.2,12,6.2s5.8,2.6,5.8,5.8S15.2,17.8,12,17.8" fill="#595959"></path>
         </svg>
+
+    {% elif params.icon == "arrow-forward" %}
+        <svg class="{% if params.iconSize %}svg-icon svg-icon--{{ params.iconSize }}{% else %}svg-icon{% endif %}" xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+            <path d="M5,13h11.2l-4.9,4.9c-0.4,0.4-0.4,1,0,1.4c0.4,0.4,1,0.4,1.4,0l6.6-6.6c0.4-0.4,0.4-1,0-1.4l-6.6-6.6c-0.4-0.4-1-0.4-1.4,0c-0.4,0.4-0.4,1,0,1.4l4.9,4.9H5c-0.6,0-1,0.4-1,1S4.4,13,5,13z" fill="currentColor"></path>
+        </svg>
      {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
Call to action component has been extended to allow for single or multiple announcement.

![BlackBanner](https://user-images.githubusercontent.com/4989027/110814082-0323c500-8281-11eb-8b0d-20e75c801ce3.png)

**This pattern is pretty much identical to what GDS have done for GOV.UK that can be seen here:** 
https://www.gov.uk

**Trello card can be found here:**
https://trello.com/c/Z2LaG5a3/47-blackbanner