### PR TITLE
Cookies - fix return link on cookies settings confirmation message - census

### DIFF
--- a/src/js/cookies-settings.js
+++ b/src/js/cookies-settings.js
@@ -8,6 +8,7 @@ export default class CookiesSettings {
     this.cookiesBanner = document.querySelector('.cookies-banner');
 
     this.component.addEventListener('submit', this.submitSettingsForm.bind(this));
+    this.returnLink.addEventListener('click', this.goBackToPrevPage.bind(this));
 
     this.setInitialFormValues();
   }
@@ -87,13 +88,16 @@ export default class CookiesSettings {
 
   setConfirmationMessageAttributes() {
     this.confirmationMessage.setAttribute('role', 'alert');
-    if (document.referrer) {
+    if (document.referrer != '') {
       this.confirmationMessage.setAttribute('autofocus', 'autofocus');
       this.confirmationMessage.setAttribute('tabindex', '-1');
       this.confirmationMessage.focus();
-      this.returnLink.href = document.referrer;
     } else {
       this.returnLink.style.display = 'none';
     }
+  }
+
+  goBackToPrevPage() {
+    window.history.back();
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
The link displayed to return to previous page when cookies settings updated used `document.referrer` that doesn't work across domains, it will only link to the root domain. 

Have updated so that the code checks for a referrer but then uses `history.back()` to successfully resolve the full url of the previous page.

### How to review 
Test the return link sends you to the correct page.

https://trello.com/c/Ovny0yY6