### PR TITLE
Added ref so github action uses the correct hash

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
### What is the context of this PR?
Github action for lighthouse ci wasn't sending the status of the job due to the hash not being correct.
