### PR TITLE
DS - fix example iframe height

### DIFF
--- a/src/js/patternlib/iframe-resize.js
+++ b/src/js/patternlib/iframe-resize.js
@@ -1,12 +1,19 @@
 import { iframeResizer } from 'iframe-resizer';
 import domReady from 'js/domready';
 
-domReady(() => {
+function resize() {
   iframeResizer(
     {
+      autoResize: true,
       heightCalculationMethod: 'max',
       scrolling: 'omit',
     },
     '.patternlib-example__iframe',
   );
+}
+
+domReady(() => {
+  setTimeout(function() {
+    resize();
+  }, 1000);
 });


### PR DESCRIPTION
### What is the context of this PR?

Fixes https://github.com/ONSdigital/design-system/issues/1225

The dynamic iframe resizer would not render the iframe size correctly on full page examples that contained content hiding components such as accordions. 

This PR fixes the onload issue so that the iframe size is now correct when the page first renders. When an accordion is toggled to open, the page will resize ok but when toggled to close the iframe does not resize.

### How to review
Check the cookies settings pattern page ->  /patterns/cookies-settings