### PR TITLE
Design System - add all scss to npm package

### DIFF
--- a/ci/common.js
+++ b/ci/common.js
@@ -20,7 +20,7 @@ async function copyComponent(componentName, componentsPath, newComponentsPath) {
 
     const items = await fs
       .readdirSync(componentPath)
-      .filter(path => path.includes('.njk') && path.includes('_') && !path.includes('_test-'));
+      .filter(path => path.includes('_') && !path.includes('.md') && !path.includes('_test-'));
 
     if (items.length) {
       await createFolder(newComponentPath);

--- a/ci/generate-npm-package.js
+++ b/ci/generate-npm-package.js
@@ -50,8 +50,7 @@ async function copyAssets() {
 
 async function copyBaseSass() {
   await createFolder(newSassPath);
-  await copyDir(`${sourcePath}/scss/helpers`, `${newSassPath}/helpers`);
-  await copyDir(`${sourcePath}/scss/vars`, `${newSassPath}/vars`);
+  await copyDir(`${sourcePath}/scss`, `${newSassPath}`);
 }
 
 async function run() {

--- a/src/scss/base/_index.scss
+++ b/src/scss/base/_index.scss
@@ -1,0 +1,4 @@
+@import './fonts';
+@import './forms';
+@import './global';
+@import './typography';

--- a/src/scss/helpers/_index.scss
+++ b/src/scss/helpers/_index.scss
@@ -1,0 +1,3 @@
+@import './functions';
+@import './mixins';
+@import './mq';

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -3,13 +3,13 @@
 @include normalize();
 
 @import 'vars/index';
-@import 'helpers/*.scss';
-@import 'base/*.scss';
-@import 'objects/*.scss';
+@import 'helpers/index';
+@import 'base/index';
+@import 'objects/index';
 @import '../components/**/*.scss';
 @import '../patterns/**/*.scss';
 @import '../styles/**/*.scss';
-@import 'utilities/*.scss';
+@import 'utilities/index';
 
 // Right to left
 @import 'rtl.scss';

--- a/src/scss/objects/_index.scss
+++ b/src/scss/objects/_index.scss
@@ -1,0 +1,3 @@
+@import './container';
+@import './page';
+@import './spacing';

--- a/src/scss/utilities/_index.scss
+++ b/src/scss/utilities/_index.scss
@@ -1,0 +1,10 @@
+@import './border';
+@import './colors';
+@import './display';
+@import './float';
+@import './grid';
+@import './margin';
+@import './pad';
+@import './typography';
+@import './utilities';
+@import './visibility';


### PR DESCRIPTION
### What is the context of this PR?
To provide more flexibility for services to consume the DS we will now publish all scss files to our npm package.

This will allow services to handpick the css they will need within their own build system.

### How to review
Release the ds
Create a protoype and @import scss 