### PR TITLE
Workflow - add GH creds to npm publish action

### DIFF
--- a/.github/workflows/npm-bundle.yml
+++ b/.github/workflows/npm-bundle.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: 14.15.0
           registry-url: https://registry.npmjs.org/
       - run: yarn install
+      - run: git config --global user.name "${{ github.actor }}"
+      - run: git config --global user.email "github-action-${{ github.actor }}@users.noreply.github.com"
       - run: npm version ${{ github.event.release.tag_name }}
       - run: yarn npm-bundle
       - run: npm publish --access public


### PR DESCRIPTION
### What is the context of this PR?
GH creds need to be included in GH action for npm publishing (to increment the npm version).
