### PR TITLE
Design System - move code highlighter css to ds css file

### DIFF
--- a/src/components/code-highlight/_code-highlight.scss
+++ b/src/components/code-highlight/_code-highlight.scss
@@ -1,1 +1,0 @@
-@import '~prismjs/themes/prism-tomorrow';

--- a/src/scss/patternlib.scss
+++ b/src/scss/patternlib.scss
@@ -3,6 +3,7 @@
 @import '../views/partials/**/*.scss';
 @import '../styles/page-template/examples/block-areas/block-areas';
 @import '../patterns/question/examples/question-anatomy/pl-question-anatomy';
+@import '~prismjs/themes/prism-tomorrow';
 
 .patternlib-page {
   height: 100vh;


### PR DESCRIPTION
### What is the context of this PR?
Code highlighting css was being bundled with our main css which is not required and adds unwanted bloat.

Moved the scss into the patternLib css file so it stays within the DS build.

### How to review
Check code hightlighting works as usual.