### PR TITLE
Fix error style on selects in radios

### DIFF
--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -75,7 +75,10 @@
                                             "classes": 'u-fs-s--b'
                                         },
                                         "dontWrap": true,
-                                        "value": radio.other.value
+                                        "value": radio.other.value,
+                                        "select": {
+                                            "error": params.error
+                                        }
                                     })
                                 }}
                             {% endif %}

--- a/src/components/select/_macro.njk
+++ b/src/components/select/_macro.njk
@@ -21,7 +21,7 @@
         <select
             id="{{ params.id }}"
             name="{{ params.name }}"
-            class="input input--select {{ params.classes }}"
+            class="input input--select{% if params.classes %} {{ params.classes }}{% endif %}{% if params.select.error %} input--error{% endif %}"
             {% if params.value is defined and params.value %}value="{{ params.value}}" {% endif %}
             {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
         >

--- a/src/patterns/error-validation/examples/errors-proto/errors/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/errors/index.njk
@@ -333,6 +333,7 @@ layout: none
                         "label": {
                             "text": "Pepperoni"
                         },
+                        "checked": true,
                         "value": "pepperoni",
                         "other": {
                             "otherType": "select",
@@ -345,8 +346,7 @@ layout: none
                                 {
                                     "value": "",
                                     "text": "Select heat level",
-                                    "disabled": true,
-                                    "selected": true
+                                    "disabled": true
                                 },
                                 {
                                     "value": "mild",

--- a/src/patterns/error-validation/examples/errors-proto/errors/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/errors/index.njk
@@ -42,7 +42,7 @@ layout: none
 
 {% block main %}
     {% call onsPanel({
-            "title": "There are 7 problems with your answer",
+            "title": "There are 8 problems with your answer",
             "type": "error",
             "classes": "question__errors"
         })
@@ -84,6 +84,11 @@ layout: none
                     {
                         "text": "Enter an email address in a valid format, for example, name@example.com",
                         "url": "#email-error",
+                        "classes": "js-inpagelink"
+                    },
+                    {
+                        "text": "Please specify heat level if pepperoni selected",
+                        "url": "#select-other-error",
                         "classes": "js-inpagelink"
                     }
                 ]
@@ -297,6 +302,72 @@ layout: none
                         }
                     }
                 }
+            })
+        }}
+
+        {{
+            onsRadios({
+                "legend": "Select your favourite toppings",
+                "name": "food-other",
+                "error": {
+                    "text": "Please specify heat level if pepperoni selected",
+                    "id": "select-other-error"
+                },
+                "radios": [
+                    {
+                        "id": "bacon-other",
+                        "label": {
+                            "text": "Bacon"
+                        },
+                        "value": "bacon"
+                    },
+                    {
+                        "id": "olives-other",
+                        "label": {
+                            "text": "Olives"
+                        },
+                        "value": "olives"
+                    },
+                    {
+                        "id": "pepperoni-other",
+                        "label": {
+                            "text": "Pepperoni"
+                        },
+                        "value": "pepperoni",
+                        "other": {
+                            "otherType": "select",
+                            "id": "pepperoni-heat-level",
+                            "name": "pepperoni-heat-level",
+                            "label": {
+                                "text": "Please specify heat level"
+                            },
+                            "options": [
+                                {
+                                    "value": "",
+                                    "text": "Select heat level",
+                                    "disabled": true,
+                                    "selected": true
+                                },
+                                {
+                                    "value": "mild",
+                                    "text": "Mild"
+                                },
+                                {
+                                    "value": "medium",
+                                    "text": "Medium"
+                                },
+                                {
+                                    "value": "hot",
+                                    "text": "Hot"
+                                },
+                                {
+                                    "value": "extra hot",
+                                    "text": "Extra Hot"
+                                }
+                            ]
+                        }
+                    }
+                ]
             })
         }}
     {% endcall %}

--- a/src/patterns/error-validation/examples/errors-proto/errors/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/errors/index.njk
@@ -346,7 +346,8 @@ layout: none
                                 {
                                     "value": "",
                                     "text": "Select heat level",
-                                    "disabled": true
+                                    "disabled": true,
+                                    "selected": true
                                 },
                                 {
                                     "value": "mild",

--- a/src/patterns/error-validation/examples/errors-proto/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/index.njk
@@ -262,7 +262,8 @@ layout: none
                                 {
                                     "value": "",
                                     "text": "Select heat level",
-                                    "disabled": true
+                                    "disabled": true,
+                                    "selected": true
                                 },
                                 {
                                     "value": "mild",

--- a/src/patterns/error-validation/examples/errors-proto/index.njk
+++ b/src/patterns/error-validation/examples/errors-proto/index.njk
@@ -224,6 +224,68 @@ layout: none
                 }
             })
         }}
+
+        {{
+            onsRadios({
+                "legend": "Select your favourite toppings",
+                "name": "food-other",
+                "radios": [
+                    {
+                        "id": "bacon-other",
+                        "label": {
+                            "text": "Bacon"
+                        },
+                        "value": "bacon"
+                    },
+                    {
+                        "id": "olives-other",
+                        "label": {
+                            "text": "Olives"
+                        },
+                        "value": "olives"
+                    },
+                    {
+                        "id": "pepperoni-other",
+                        "label": {
+                            "text": "Pepperoni"
+                        },
+                        "checked": true,
+                        "value": "pepperoni",
+                        "other": {
+                            "otherType": "select",
+                            "id": "pepperoni-heat-level",
+                            "name": "pepperoni-heat-level",
+                            "label": {
+                                "text": "Please specify heat level"
+                            },
+                            "options": [
+                                {
+                                    "value": "",
+                                    "text": "Select heat level",
+                                    "disabled": true
+                                },
+                                {
+                                    "value": "mild",
+                                    "text": "Mild"
+                                },
+                                {
+                                    "value": "medium",
+                                    "text": "Medium"
+                                },
+                                {
+                                    "value": "hot",
+                                    "text": "Hot"
+                                },
+                                {
+                                    "value": "extra hot",
+                                    "text": "Extra Hot"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            })
+        }}
     {% endcall%}
 
     {{


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #1561
Also fixes whitespace in select class list when classes added with `params.classes`

### How to review
Check errors prototype and select the pepperoni radio to see the select has a red border
