### PR TITLE
Fix error when headMeta missing from pageConfig

### DIFF
--- a/src/styles/page-template/_template.njk
+++ b/src/styles/page-template/_template.njk
@@ -55,7 +55,7 @@
 
         {% if pageConfig.headMeta is defined and pageConfig.headMeta %}
 
-            {% if pageConfig.headMeta.description is defined and pageConfig.headMeta.description or pageConfig.description is defined and pageConfig.description %}
+            {% if pageConfig.headMeta is defined and pageConfig.headMeta and pageConfig.headMeta.description is defined and pageConfig.headMeta.description or pageConfig.description is defined and pageConfig.description %}
                 <meta name="description" content="{{ pageConfig.headMeta.description | default(pageConfig.description) }}">
             {% endif %}
 


### PR DESCRIPTION
### What is the context of this PR?
Error in Runner when headMeta object not supplied. Now checking for it when looking for headMeta.description in pageConfig

### How to review
Tests pass
