### PR TITLE
Convert footer language items to list

### DIFF
--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -104,7 +104,7 @@
                         {% set currentLanguage = params.language.languages | selectattr("current") | first %}
                         {% set languageNumber = params.language.languages | length %}
                         <div class="grid__col {% if languageNumber and languageNumber != 2 %} u-d-no@m{% elif languageNumber %} u-d-no{% endif %}">
-                            {% set languageItems = params.language.languages | rejectattr("current") %}
+                            {% set languageItems = params.language.languages | rejectattr("current") | list %}
                             {% if currentLanguage.allLanguages is defined and currentLanguage.allLanguages and params.language.allLanguagesUrl is defined and params.language.allLanguagesUrl %}
                                 {% set languageItems = (languageItems.push({
                                     "url": params.language.allLanguagesUrl,


### PR DESCRIPTION
### What is the context of this PR?
There is an error in Runner when using footers that has come from the changes to the list component in #1538. Because we now calculate the length of the list and Runner passes in a generator object into the languages list in footers, this is to convert it back to a list before the list component is called. This is because generator objects aren't compatible with `| length`

### How to review
- Check that tests pass
- Check that lists and footers still work correctly
