### PR TITLE
Fix jinja bug with selects

### DIFF
--- a/src/components/select/_macro.njk
+++ b/src/components/select/_macro.njk
@@ -21,7 +21,7 @@
         <select
             id="{{ params.id }}"
             name="{{ params.name }}"
-            class="input input--select{% if params.classes %} {{ params.classes }}{% endif %}{% if params.select.error %} input--error{% endif %}"
+            class="input input--select{% if params.classes %} {{ params.classes }}{% endif %}{% if params.select and params.select.error %} input--error{% endif %}"
             {% if params.value is defined and params.value %}value="{{ params.value}}" {% endif %}
             {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
         >


### PR DESCRIPTION
### What is the context of this PR?
Bug when using jinja where it is erroring when looking for `params.select.error` if `params.select` doesn't exist. So Ive added an if to stop this.

### How to review
- Selects still work as expected
- Tests pass
