### PR TITLE
Remove deprecated relationship params

### DIFF
--- a/src/components/relationships/_macro-options.md
+++ b/src/components/relationships/_macro-options.md
@@ -1,7 +1,5 @@
 | Name                  | Type           | Required | Description                                                                                                 |
 | --------------------- | -------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
-| legend                | string         | true     | The legend for the radios. This is visually hidden by default so should be set to match the question title  |
-| legendClasses         | string         | false    | Classes to apply to the legend element                                                                      |
 | legendIsQuestionTitle | boolean        | false    | Creates a `h1` inside the legend ([further information](/components/fieldset#legend-as-pagequestion-title)) |
 | playback              | string         | true     | Default text for the playback below the component                                                           |
 | radios                | `Array<Radio>` | true     | An array of radio options. Each option must have `data-title` and `data-playback` attributes                |


### PR DESCRIPTION
### What is the context of this PR?
`legend` and `legendClasses` are no longer used in relationships so this pr removes them from the docs

### How to review
Docs make sense
