### PR TITLE
Fix favicon and manifest paths for runner

### DIFF
--- a/src/styles/page-template/_template.njk
+++ b/src/styles/page-template/_template.njk
@@ -14,6 +14,8 @@
 {# Meta icons #}
 {% if pageConfig is defined and pageConfig and pageConfig.theme is defined and pageConfig.theme %}
     {% set metaicons = pageConfig.theme + "/" + currentLanguageISOCode + "/" %}
+{% else %}
+    {% set metaicons = "" %}
 {% endif %}
 
 {% set pageColNumber = pageConfig.pageColNumber | default("8") %}


### PR DESCRIPTION
### What is the context of this PR?
The path to favicons and manifest in runner was wrong when not using the census theme. It was looking for a `main/[language code]` folder so this PR fixes the paths to them by removing the folders from the path if not using a theme.

### How to review
Tests pass
