### PR TITLE
Remove extra underline in external links

### DIFF
--- a/src/components/external-link/_external-link.scss
+++ b/src/components/external-link/_external-link.scss
@@ -7,7 +7,7 @@
     fill: $color-grey-100;
     margin: 0 0 0 0.25rem;
     padding-bottom: 0.1rem;
-    visibility: visible !important;
+    visibility: visible;
   }
   &:focus {
     .svg-icon {

--- a/src/components/external-link/_external-link.scss
+++ b/src/components/external-link/_external-link.scss
@@ -1,11 +1,13 @@
 .external-link {
   &__icon {
+    visibility: hidden;
     white-space: nowrap;
   }
   .svg-icon {
     fill: $color-grey-100;
     margin: 0 0 0 0.25rem;
     padding-bottom: 0.1rem;
+    visibility: visible !important;
   }
   &:focus {
     .svg-icon {


### PR DESCRIPTION
### What is the context of this PR?
External links are rendering an extra space underlined at the end of the text
![image](https://user-images.githubusercontent.com/42928680/125810095-648afb6c-dee9-4b33-a23a-ea40dc8308b6.png)
This PR will remove that extra underlined bit
![image](https://user-images.githubusercontent.com/42928680/125810243-72400f2d-97d2-49e1-9047-019793ab1b54.png)

### How to review
All external links now display correctly
