### PR TITLE
Fix Jinja caller issue in question macro

### DIFF
--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -28,6 +28,10 @@
     >
         {% if params.legendIsQuestionTitle %}
             {% from "components/fieldset/_macro.njk" import onsFieldset %}
+
+            {# Resolves caller issue in jijna: https://github.com/pallets/jinja/issues/371 #}
+            {% set content = caller() %}
+            
             {% call onsFieldset({
                 "legendIsQuestionTitle": params.legendIsQuestionTitle,
                 "legend": titleHtml,
@@ -40,7 +44,7 @@
                     {{- instHtml -}}
                 {% endif %}
 
-                {{ caller () }}
+                {{ content }}
             {% endcall %}
 
         {% else %}


### PR DESCRIPTION
### What is the context of this PR?
The question macro doesn't work in Jinja as `{{ caller() }}` can't be used within a `{% call %}` block - https://github.com/pallets/jinja/issues/371

The fix captures the return value of `caller()` outside of the `{% call %}` block in a variable, and uses the variable in the call block.

The fix is the same as how it is done in the mutually exclusive component - https://github.com/ONSdigital/design-system/pull/544