### PR TITLE
Add links to new team mailbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,7 +12,7 @@ assignees: ''
 
 - If you are suggesting a change to a component, pattern or style that is already in the ONS Design System, please comment on its GitHub discussion (https://github.com/ONSdigital/design-system/discussions). You can get to the discussion using the direct link at the bottom of each page in the Design System.
 
-- If you are proposing something new, check the Design System backlog (https://trello.com/b/dsgMhRlq/ons-design-system). There may already be a proposal for something similar. You can add examples of your own evidence to an existing proposal. To request access to the backlog, email jo.van.der.plank@ons.gov.uk
+- If you are proposing something new, check the Design System backlog (https://trello.com/b/dsgMhRlq/ons-design-system). There may already be a proposal for something similar. You can add examples of your own evidence to an existing proposal. To request access to the backlog, email ons.design.system@ons.gov.uk
 
 -->
 

--- a/src/contribute/propose-a-change/index.njk
+++ b/src/contribute/propose-a-change/index.njk
@@ -59,9 +59,9 @@ If the group approves the change, it will add the proposal to the {{
 You may not be in a position to work on the change yourself. If you want or need someone else to develop it, the working group meeting is the place to discuss this. The group can help find a suitable developer.
 
 ## Get help with your proposal
-If you need further help with your proposal, or have any questions, you can {{
-    onsExternalLink({
-        "url": "mailto:jo.van.der.plank@ons.gov.uk;benjamin.armstrong@ons.gov.uk?subject=Help with a Design System proposal",
-        "linkText": "contact the Design System Working Group"
+If you need further help with your proposal, or have any questions, you can email the Design System Working Group at {{ 
+onsExternalLink({
+    "url": "mailto:ONS.Design.System@ons.gov.uk?subject=Help with a Design System proposal",
+    "linkText": "ONS.Design.System@ons.gov.uk"
     })
 }}.

--- a/src/contribute/propose-a-new-feature/index.njk
+++ b/src/contribute/propose-a-new-feature/index.njk
@@ -67,9 +67,9 @@ If the group approves the new feature, it will add the proposal to the ONS Desig
 You may not be in a position to create the new feature yourself. If you want or need someone else to develop it, the working group meeting is the place to discuss this. The group can help find a suitable developer.
 
 ## Get help with your proposal
-If you need further help with your proposal, or have any questions, you can {{
-    onsExternalLink({
-        "url": "mailto:jo.van.der.plank@ons.gov.uk;benjamin.armstrong@ons.gov.uk?subject=Help with a Design System proposal",
-        "linkText": "contact the Design System Working Group"
+If you need further help with your proposal, or have any questions, you can email the Design System Working Group at {{ 
+onsExternalLink({
+    "url": "mailto:ONS.Design.System@ons.gov.uk?subject=Help with a Design System proposal",
+    "linkText": "ONS.Design.System@ons.gov.uk"
     })
 }}.

--- a/src/index.njk
+++ b/src/index.njk
@@ -57,4 +57,23 @@ sortOrder: 1
             <p>You can <a href="{{ pageInfo.rootPath }}/contribute">contribute to the design system</a> if you want to propose a new pattern or component, or want to make a change to an existing feature. </p>
         </div>
     </div>
+    <hr class="u-mt-no">
+    <div class="grid grid--gutterless u-mt-l u-mb-l">
+        <div class="grid__col col-6@m">
+            <h3 class="u-fs-l">Support</h3>
+            <p>If you have any problems using the ONS Design System, you can add a comment using the GitHub discussions link at the end of every pattern, component or style page, or find the relevant one on {{
+                onsExternalLink({
+                    "url": "https://github.com/ONSdigital/design-system/discussions",
+                    "linkText": "GitHub discussions"
+                })
+            }}</p>
+
+            <p>If you need further help, or have any questions, you can email the Design System Working Group at {{ 
+            onsExternalLink({
+                "url": "mailto:ONS.Design.System@ons.gov.uk?subject=Help using the Design System",
+                "linkText": "ONS.Design.System@ons.gov.uk"
+                })
+            }}
+        </div>
+    </div>
 </div>

--- a/src/views/layouts/_master.njk
+++ b/src/views/layouts/_master.njk
@@ -57,12 +57,16 @@
                         {
                             "itemsList": [
                                 {
-                                    "text": 'GitHub repo',
+                                    "text": 'GitHub repository',
                                     "url": 'https://github.com/ONSdigital/design-system'
                                 },
                                 {
                                     "text": 'ONS style guide',
                                     "url": 'https://style.ons.gov.uk/'
+                                },
+                                {
+                                    "text": 'ONS brand guidelines',
+                                    "url": 'https://www.notion.so/Brand-Guidelines-Office-for-National-Statistics-ONS-cf59ffee4b724fa5bc2384356c9283cf'
                                 },
                                 {
                                     "text": 'About ONS',


### PR DESCRIPTION
### What is the context of this PR?
- Updated the mailto links in the 'propose a change/new feature' pages to use the new team inbox
- Added a 'support' section to the homepage with same mailto link
- Added a link to the brand guidelines to footer
- Updated the email address in the new feature request gitHub template

### How to review
- Check the documentation and mail to links
- Check the GitHub new feature request template