### PR TITLE
Autosuggest - change boolean type for allowMultiple property

### DIFF
--- a/src/components/autosuggest/_macro.njk
+++ b/src/components/autosuggest/_macro.njk
@@ -15,7 +15,7 @@
         data-type-more="{{ params.typeMore }}"
         {% if params.APIDomain is defined and params.APIDomain %}data-api-domain="{{ params.APIDomain }}"{% endif %}
         {% if params.APIDomainBearerToken is defined and params.APIDomainBearerToken %}data-authorization-token="{{ params.APIDomainBearerToken }}"{% endif %}
-        {% if params.allowMultiple is defined and params.allowMultiple %}data-allow-multiple="{{ params.allowMultiple }}"{% endif %}
+        {% if params.allowMultiple is defined and params.allowMultiple == true %}data-allow-multiple="true"{% endif %}
         {% if params.autosuggestData is defined and params.autosuggestData %}data-autosuggest-data="{{ params.autosuggestData }}"{% endif %}
         {% if params.errorTitle is defined and params.errorTitle %}data-error-title="{{ params.errorTitle }}"{% endif %}
         {% if params.errorMessageEnter is defined and params.errorMessageEnter %}data-error-enter="{{ params.errorMessageEnter }}"{% endif %}
@@ -50,6 +50,7 @@
                 "id": params.label.id,
                 "classes": params.label.classes
             },
+            "autocomplete": params.autocomplete,
             "legend": params.legend,
             "legendClasses": params.legendClasses,
             "value": params.value,

--- a/src/components/autosuggest/examples/autosuggest-country-multiple/index.njk
+++ b/src/components/autosuggest/examples/autosuggest-country-multiple/index.njk
@@ -20,7 +20,7 @@
             "ariaLimitedResults": "Results have been limited to 10 suggestions. Type more characters to improve your search",
             "moreResults": "Continue entering to improve suggestions",
             "resultsTitle": "Suggestions",
-            "allowMultiple": "true",
+            "allowMultiple": true,
             "autosuggestData": "https://gist.githubusercontent.com/rmccar/c123023fa6bd1b137d7f960c3ffa1fed/raw/4dede1d6e757cf0bb836228600676c62ceb4f86c/country-of-birth.json",
             "noResults": "No suggestions found. You can enter your own answer",
             "typeMore": "Continue entering to get suggestions"

--- a/src/tests/spec/autosuggest/autosuggest.ui.spec.js
+++ b/src/tests/spec/autosuggest/autosuggest.ui.spec.js
@@ -1306,7 +1306,7 @@ describe('Autosuggest.ui component', function() {
         classes: 'js-autosuggest-label',
       },
       autocomplete: 'off',
-      allowMultiple: 'true',
+      allowMultiple: true,
       instructions:
         'Use up and down keys to navigate suggestions once youve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.',
       ariaYouHaveSelected: 'You have selected',


### PR DESCRIPTION
### What is the context of this PR?

The `allowMultiple` property on the autosuggest component required the boolean value to be a string. This is inconsistent and created problems in other services. 

This PR changes the macro to allow the value to be `true` or `false`.

### How to review
Test that the multiple selection example works as expected.