### PR TITLE
Fix param name in section nav docs

### DIFF
--- a/src/components/section-navigation/_macro-options.md
+++ b/src/components/section-navigation/_macro-options.md
@@ -10,5 +10,5 @@
 | Name    | Type   | Required | Description                                               |
 | ------- | ------ | -------- | --------------------------------------------------------- |
 | classes | string | false    | Additional css classes for the section navigation element |
-| path    | string | true     | The path to the linked page                               |
+| url     | string | true     | The URL to the linked page                                |
 | title   | string | true     | The text for the link                                     |


### PR DESCRIPTION
### What is the context of this PR?
Fix param name `path` and change it to `url` to match the correct name used in section navigation macro.

Fixes: #1520 

### How to review
Doc make sense
