### PR TITLE
Add service links to example and fix style

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -136,6 +136,9 @@
     }
     &-service-nav__link {
       color: $color-white;
+      &:hover {
+        text-decoration: underline solid $color-white 3px;
+      }
     }
   }
 

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -134,6 +134,9 @@
     &__grid-top {
       min-height: 36px;
     }
+    &-service-nav__link {
+      color: $color-white;
+    }
   }
 
   .ons-svg-logo,

--- a/src/components/header/_macro-options.md
+++ b/src/components/header/_macro-options.md
@@ -43,3 +43,4 @@
 | classes | string | false    | Additional css classes for the navigation element |
 | path    | string | true     | The path to the linked page                       |
 | title   | string | true     | The text for the link                             |
+| id      | string | false    | The id for the link                               |

--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -60,7 +60,7 @@
                                                         href="{{ item.url }}"
                                                         class="header-service-nav__link"
                                                         {% if item.id is defined and item.id %} id="{{ item.id }}"{% endif %}
-                                                    >{{ item.text }}</a>
+                                                    >{{ item.title }}</a>
                                                 </li>
                                             {% endfor %}
                                         </ul>

--- a/src/components/header/examples/census-nisra/index.njk
+++ b/src/components/header/examples/census-nisra/index.njk
@@ -19,11 +19,11 @@ layout: none
     "navigation": {
         "id": 'main-nav',
         "ariaLabel": 'Main menu',
-        "currentPath": '/get-started',
+        "currentPath": '#home',
         "itemsList": [
             {
                 "title": 'Home',
-                "url": '#0'
+                "url": '#home'
             },
             {
                 "title": 'About the census',

--- a/src/components/header/examples/census/index.njk
+++ b/src/components/header/examples/census/index.njk
@@ -55,11 +55,11 @@ layout: none
         "id": 'main-nav',
         "ariaLabel": 'Main menu',
         "ariraListLabel": 'Navigation menu',
-        "currentPath": '/get-started',
+        "currentPath": '#home',
         "itemsList": [
             {
                 "title": 'Home',
-                "url": '#0'
+                "url": '#home'
             },
             {
                 "title": 'About the census',

--- a/src/components/header/examples/internal-basic/index.njk
+++ b/src/components/header/examples/internal-basic/index.njk
@@ -21,7 +21,7 @@
                     "url": "#0"
                 },
                 {
-                    "title": "Styles",
+                    "title": "Sign out",
                     "url": "#0"
                 }
             ]

--- a/src/components/header/examples/internal-basic/index.njk
+++ b/src/components/header/examples/internal-basic/index.njk
@@ -9,6 +9,22 @@
         "logoHref": '#0',
         "classes": 'header--internal',
         "mobileLogo": 'ons-logo-stacked-en',
-        "titleLogoHref": '#0'
+        "titleLogoHref": '#0',
+        "serviceLinks": {
+            "itemsList": [
+                {
+                    "title": "Help",
+                    "url": "#0"
+                },
+                {
+                    "title": "My Account",
+                    "url": "#0"
+                },
+                {
+                    "title": "Styles",
+                    "url": "#0"
+                }
+            ]
+        }
     })
 }}

--- a/src/styles/page-template/examples/block-areas/index.njk
+++ b/src/styles/page-template/examples/block-areas/index.njk
@@ -47,11 +47,11 @@ layout: example
                     "id": "main-nav",
                     "ariaLabel": "Main menu",
                     "ariraListLabel": "Navigation menu",
-                    "currentPath": "/get-started",
+                    "currentPath": "#get-started",
                     "itemsList": [
                         {
                             "title": "Get started",
-                            "path": "/get-started"
+                            "path": "#get-started"
                         },
                         {
                             "title": "Components",


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #1577
Also updated docs and header title param to conform with navigation links

**(BREAKING CHANGE)**
When using header service links the the text for the link is now set with `item.title` not `item.text` as before

### How to review
Example now looks as expected
