### PR TITLE
Added 'Community backlog' page to contribute section

### DIFF
--- a/src/contribute/community-backlog/index.njk
+++ b/src/contribute/community-backlog/index.njk
@@ -7,7 +7,7 @@ sortOrder: 3
 
 The community backlog is where we log each proposal for a new feature or a change to an existing feature in the design system.
 
-The Design System Working Group has to agree to each proposal first. They are then put on the backlog in the “to do” column. Anyone in the community can pick up a proposal to develop it.
+The Design System working group has to agree to each proposal first. They are then put on the backlog in the “to do” column. Anyone in the community can pick up a proposal to develop it.
 
 Items on the {{
     onsExternalLink({

--- a/src/contribute/community-backlog/index.njk
+++ b/src/contribute/community-backlog/index.njk
@@ -1,0 +1,40 @@
+---
+title: Community backlog
+group: Our process
+sortOrder: 3
+---
+{% from "components/external-link/_macro.njk" import onsExternalLink %}
+{% from "components/lists/_macro.njk" import onsList %}
+
+The community backlog is where we log each proposal for a new feature or a change to an existing feature in the design system.
+
+The Design System Working Group first has to agree to each proposal. They are then put on the backlog in the “to do” column. Anyone in the community can pick up a proposal to develop it.
+
+Items on the {{
+    onsExternalLink({
+        "url": "https://github.com/ONSdigital/design-system/projects/1",
+        "linkText": "community backlog on GitHub"
+    })
+}} are categorised as:
+
+{{
+    onsList({
+        "itemsList": [
+          {
+            "text": '<strong>to do</strong> – anything the community has agreed should be in the design system'
+          },
+          {
+              "text": '<strong>in progress</strong> – is being developed'
+          },
+          {
+              "text": '<strong>in review</strong> – needs to be reviewed before publishing'
+          },
+          {
+              "text": '<strong>published</strong> – is live in the design system'
+          },
+          {
+              "text": '<strong>not doing</strong> – any proposal we have decided not to include in the design system'
+          }
+        ]
+    })
+}}

--- a/src/contribute/community-backlog/index.njk
+++ b/src/contribute/community-backlog/index.njk
@@ -7,7 +7,7 @@ sortOrder: 3
 
 The community backlog is where we log each proposal for a new feature or a change to an existing feature in the design system.
 
-The Design System Working Group first has to agree to each proposal. They are then put on the backlog in the “to do” column. Anyone in the community can pick up a proposal to develop it.
+The Design System Working Group has to agree to each proposal first. They are then put on the backlog in the “to do” column. Anyone in the community can pick up a proposal to develop it.
 
 Items on the {{
     onsExternalLink({

--- a/src/contribute/community-backlog/index.njk
+++ b/src/contribute/community-backlog/index.njk
@@ -1,6 +1,5 @@
 ---
 title: Community backlog
-group: Our process
 sortOrder: 3
 ---
 {% from "components/external-link/_macro.njk" import onsExternalLink %}

--- a/src/contribute/index.njk
+++ b/src/contribute/index.njk
@@ -6,4 +6,4 @@ A community of designers, developers and researchers from across the ONS develop
 
 You are welcome to make a contribution to the design system. You can [propose a new feature](/contribute/propose-a-new-feature) or [suggest a change to an existing feature](/contribute/propose-a-change) or its documentation.
 
-The Design System Working Group will consider each proposal and decide if your evidence is strong enough for it to be put on the [community backlog](/contribute/community-backlog).
+The Design System working group will consider each proposal and decide if your evidence is strong enough for it to be put on the [community backlog](/contribute/community-backlog).

--- a/src/contribute/index.njk
+++ b/src/contribute/index.njk
@@ -6,4 +6,4 @@ A community of designers, developers and researchers from across the ONS develop
 
 You are welcome to make a contribution to the design system. You can [propose a new feature](/contribute/propose-a-new-feature) or [suggest a change to an existing feature](/contribute/propose-a-change) or its documentation.
 
-The community will consider each proposal and decide if your evidence is strong enough for it to go ahead.
+The Design System Working Group will consider each proposal and decide if your evidence is strong enough for it to be put on the [community backlog](/contribute/community-backlog).

--- a/src/contribute/propose-a-change/index.njk
+++ b/src/contribute/propose-a-change/index.njk
@@ -1,6 +1,5 @@
 ---
 title: Propose a change
-group: How to...
 sortOrder: 2
 ---
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
@@ -9,7 +8,7 @@ sortOrder: 2
 Follow these steps if you need to make a change to a feature in the design system.
 
 ## 1. Check if the change has already been proposed
-Check the [community backlog](community-backlog) to see if someone has already proposed changes to this component, pattern or style.
+Check the [community backlog](/contribute/community-backlog) to see if someone has already proposed changes to this component, pattern or style.
 
 If you decide to go ahead, you need to provide evidence that the change will:
 {{
@@ -38,19 +37,19 @@ You need to explain what change you want to make and why. Comment using the GitH
 }}
 
 ## 3. Present your proposal
-We will then invite you to demonstrate your change proposal at a Design System Working Group meeting, and present your evidence to support it. When you complete the issue template, you need to let us know who else to invite to the meeting. 
+We will then invite you to demonstrate your change proposal at a Design System Working Group meeting, and present your evidence to support it. When you complete the issue template, you need to let us know who else to invite to the meeting.
 
 ## 4. Get approval for the proposal
 The group will discuss the change and your evidence. It will decide if the change is needed. The working group may suggest an alternative or reject the proposal if the evidence is not strong enough.
 
 ## 5. Add it to the backlog
-If the group approves the change, it will add the proposal to the [community backlog](community-backlog).
+If the group approves the change, it will add the proposal to the [community backlog](/contribute/community-backlog).
 
 ## 6. Decide who will develop it
 You may not be in a position to work on the change yourself. If you want or need someone else to develop it, the working group meeting is the place to discuss this. The group can help find a suitable developer.
 
 ## Get help with your proposal
-If you need further help with your proposal, or have any questions, you can email the Design System Working Group at {{ 
+If you need further help with your proposal, or have any questions, you can email the Design System Working Group at {{
 onsExternalLink({
     "url": "mailto:ONS.Design.System@ons.gov.uk?subject=Help with a Design System proposal",
     "linkText": "ONS.Design.System@ons.gov.uk"

--- a/src/contribute/propose-a-change/index.njk
+++ b/src/contribute/propose-a-change/index.njk
@@ -37,7 +37,7 @@ You need to explain what change you want to make and why. Comment using the GitH
 }}
 
 ## 3. Present your proposal
-We will then invite you to demonstrate your change proposal at a Design System Working Group meeting, and present your evidence to support it. When you complete the issue template, you need to let us know who else to invite to the meeting.
+We will then invite you to demonstrate your change proposal at a Design System working group meeting, and present your evidence to support it. When you complete the issue template, you need to let us know who else to invite to the meeting.
 
 ## 4. Get approval for the proposal
 The group will discuss the change and your evidence. It will decide if the change is needed. The working group may suggest an alternative or reject the proposal if the evidence is not strong enough.
@@ -49,7 +49,7 @@ If the group approves the change, it will add the proposal to the [community bac
 You may not be in a position to work on the change yourself. If you want or need someone else to develop it, the working group meeting is the place to discuss this. The group can help find a suitable developer.
 
 ## Get help with your proposal
-If you need further help with your proposal, or have any questions, you can email the Design System Working Group at {{
+If you need further help with your proposal, or have any questions, you can email the Design System working group at {{
 onsExternalLink({
     "url": "mailto:ONS.Design.System@ons.gov.uk?subject=Help with a Design System proposal",
     "linkText": "ONS.Design.System@ons.gov.uk"

--- a/src/contribute/propose-a-change/index.njk
+++ b/src/contribute/propose-a-change/index.njk
@@ -1,5 +1,6 @@
 ---
 title: Propose a change
+group: How to...
 sortOrder: 2
 ---
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
@@ -8,12 +9,7 @@ sortOrder: 2
 Follow these steps if you need to make a change to a feature in the design system.
 
 ## 1. Check if the change has already been proposed
-Check the {{
-    onsExternalLink({
-        "url": "https://github.com/ONSdigital/design-system/projects/1",
-        "linkText": "community backlog on GitHub"
-    })
-}} to see if someone has already proposed changes to this component, pattern or style.
+Check the [community backlog](community-backlog) to see if someone has already proposed changes to this component, pattern or style.
 
 If you decide to go ahead, you need to provide evidence that the change will:
 {{
@@ -48,12 +44,7 @@ We will then invite you to demonstrate your change proposal at a Design System W
 The group will discuss the change and your evidence. It will decide if the change is needed. The working group may suggest an alternative or reject the proposal if the evidence is not strong enough.
 
 ## 5. Add it to the backlog
-If the group approves the change, it will add the proposal to the {{
-    onsExternalLink({
-        "url": "https://github.com/ONSdigital/design-system/projects/1",
-        "linkText": "community backlog on GitHub"
-    })
-}}.
+If the group approves the change, it will add the proposal to the [community backlog](community-backlog).
 
 ## 6. Decide who will develop it
 You may not be in a position to work on the change yourself. If you want or need someone else to develop it, the working group meeting is the place to discuss this. The group can help find a suitable developer.

--- a/src/contribute/propose-a-new-feature/index.njk
+++ b/src/contribute/propose-a-new-feature/index.njk
@@ -1,6 +1,5 @@
 ---
 title: Propose a new feature
-group: How to...
 sortOrder: 1
 ---
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
@@ -19,7 +18,7 @@ First, check if the feature is already:
                 "text": 'in the ONS Design system'
             },
             {
-                "text": 'being developed – you can check this on the <a class="external-link" target="_blank" rel="noopener" href="https://github.com/ONSdigital/design-system/projects/1">community backlog on GitHub<span class="external-link__icon">&nbsp;<svg class="svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false"><path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)"/><path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)"/></svg></span></a>'
+                "text": 'being developed – you can check this on the <a href="/contribute/community-backlog">community backlog</a>'
             }
         ]
     })
@@ -57,13 +56,13 @@ We will then invite you to demonstrate your proposal at a Design System Working 
 The group will discuss the feature and your evidence. It will decide if the feature is needed in the design system. The working group may suggest a variant of an existing feature or reject the proposal if the evidence is not strong enough.
 
 ## 5. Add it to the backlog
-If the group approves the new feature, it will add the proposal to the ONS Design System [community backlog](community-backlog).
+If the group approves the new feature, it will add the proposal to the ONS Design System [community backlog](/contribute/community-backlog).
 
 ## 6. Decide who will develop it
 You may not be in a position to create the new feature yourself. If you want or need someone else to develop it, the working group meeting is the place to discuss this. The group can help find a suitable developer.
 
 ## Get help with your proposal
-If you need further help with your proposal, or have any questions, you can email the Design System Working Group at {{ 
+If you need further help with your proposal, or have any questions, you can email the Design System Working Group at {{
 onsExternalLink({
     "url": "mailto:ONS.Design.System@ons.gov.uk?subject=Help with a Design System proposal",
     "linkText": "ONS.Design.System@ons.gov.uk"

--- a/src/contribute/propose-a-new-feature/index.njk
+++ b/src/contribute/propose-a-new-feature/index.njk
@@ -50,7 +50,7 @@ First, {{
 }}. Just replace the content in the template with details about your proposal.
 
 ## 3. Present your proposal
-We will then invite you to demonstrate your proposal at a Design System Working Group meeting, and present your evidence to support it.  When you complete the issue template, you need to let us know who else to invite to the meeting.
+We will then invite you to demonstrate your proposal at a Design System working group meeting, and present your evidence to support it.  When you complete the issue template, you need to let us know who else to invite to the meeting.
 
 ## 4. Get approval for the proposal
 The group will discuss the feature and your evidence. It will decide if the feature is needed in the design system. The working group may suggest a variant of an existing feature or reject the proposal if the evidence is not strong enough.
@@ -62,7 +62,7 @@ If the group approves the new feature, it will add the proposal to the ONS Desig
 You may not be in a position to create the new feature yourself. If you want or need someone else to develop it, the working group meeting is the place to discuss this. The group can help find a suitable developer.
 
 ## Get help with your proposal
-If you need further help with your proposal, or have any questions, you can email the Design System Working Group at {{
+If you need further help with your proposal, or have any questions, you can email the Design System working group at {{
 onsExternalLink({
     "url": "mailto:ONS.Design.System@ons.gov.uk?subject=Help with a Design System proposal",
     "linkText": "ONS.Design.System@ons.gov.uk"

--- a/src/contribute/propose-a-new-feature/index.njk
+++ b/src/contribute/propose-a-new-feature/index.njk
@@ -1,5 +1,6 @@
 ---
 title: Propose a new feature
+group: How to...
 sortOrder: 1
 ---
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
@@ -56,12 +57,7 @@ We will then invite you to demonstrate your proposal at a Design System Working 
 The group will discuss the feature and your evidence. It will decide if the feature is needed in the design system. The working group may suggest a variant of an existing feature or reject the proposal if the evidence is not strong enough.
 
 ## 5. Add it to the backlog
-If the group approves the new feature, it will add the proposal to the ONS Design System {{
-    onsExternalLink({
-        "url": "https://github.com/ONSdigital/design-system/projects/1",
-        "linkText": "community backlog on GitHub"
-    })
-}}.
+If the group approves the new feature, it will add the proposal to the ONS Design System [community backlog](community-backlog).
 
 ## 6. Decide who will develop it
 You may not be in a position to create the new feature yourself. If you want or need someone else to develop it, the working group meeting is the place to discuss this. The group can help find a suitable developer.

--- a/src/index.njk
+++ b/src/index.njk
@@ -68,7 +68,7 @@ sortOrder: 1
                 })
             }}</p>
 
-            <p>If you need further help, or have any questions, you can email the Design System Working Group at {{ 
+            <p>If you need further help, or have any questions, you can email the Design System working group at {{ 
             onsExternalLink({
                 "url": "mailto:ONS.Design.System@ons.gov.uk?subject=Help using the Design System",
                 "linkText": "ONS.Design.System@ons.gov.uk"


### PR DESCRIPTION
### What is the context of this PR?
- New page under 'contribute' to describe the DS community backlog and link to it.

### How to review
- Check page
- Check links to this new page in "propose a..." pages
