### PR TITLE
Added 'writing page titles' content guide

### DIFF
--- a/src/get-started/browser-compatibility/index.njk
+++ b/src/get-started/browser-compatibility/index.njk
@@ -1,5 +1,7 @@
 ---
-title: Browser compatibility
+title: Browser testing
+sortOrder: 1
+group: Guides
 ---
 
 {% from "components/external-link/_macro.njk" import onsExternalLink %}

--- a/src/get-started/design-assets/index.njk
+++ b/src/get-started/design-assets/index.njk
@@ -1,12 +1,11 @@
 ---
-title: Design assets
-sortOrder: 2
+title: Prototyping in Sketch
+sortOrder: 3
+group: Guides
 ---
 {% from "components/lists/_macro.njk" import onsList %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
-
-## Sketch
 
 Sketch is an application used to mock up wireframes and click through prototypes. 
 
@@ -17,7 +16,7 @@ Sketch is an application used to mock up wireframes and click through prototypes
     })
 }}
 
-### Add the ONS Sketch Library to Sketch
+## Using the ONS Design System Sketch library
 
 {{
     onsList({

--- a/src/get-started/page-titles/index.njk
+++ b/src/get-started/page-titles/index.njk
@@ -1,0 +1,44 @@
+---
+title: Writing page titles
+sortOrder: 2
+group: Guides
+---
+{% from "components/external-link/_macro.njk" import onsExternalLink %}
+{% from "components/lists/_macro.njk" import onsList %}
+
+Every page of a website or service needs a page `<title>`. A good page title helps users find what they want and recognise they are in the right place. 
+
+Page titles are the first thing read out by screen readers and the link that is shown first on search results. 
+
+Each page title needs to:
+{{
+    onsList({
+        "itemsList": [
+          {
+            "text": 'describe what’s on the page'
+          },
+          {
+              "text": 'have the most important words first'
+          },
+          {
+              "text": 'be concise'
+          },
+          {
+              "text": 'use clear, accessible language'
+          },
+          {
+              "text": 'be unique'
+          },
+          {
+              "text": 'avoid internal jargon'
+          },
+          {
+              "text": 'use consistent language, for example, if “Start survey” is used for one page title, it would be inconsistent to use “Submit form” later in the user’s journey'
+          }
+        ]
+    })
+}}
+
+Include a suffix to each page title of the site name so the user is clear about where they are. For example, “Introduction to people who live here - Census 2021” or “Births, deaths and marriages - Office for National Statistics”.
+
+For the [error state](patterns/correct-errors) version of each page, add the prefix “Error:” to each page title.

--- a/src/get-started/page-titles/index.njk
+++ b/src/get-started/page-titles/index.njk
@@ -8,7 +8,7 @@ group: Guides
 
 Every page of a website or service needs a page `<title>`. A good page title helps users find what they want and recognise they are in the right place. 
 
-Page titles are the first thing read out by screen readers and the link that is shown first on search results. 
+Page titles are the first thing read out by screen readers and the link that shows in search results.
 
 Each page title needs to:
 {{
@@ -33,12 +33,12 @@ Each page title needs to:
               "text": 'avoid internal jargon'
           },
           {
-              "text": 'use consistent language, for example, if “Start survey” is used for one page title, it would be inconsistent to use “Submit form” later in the user’s journey'
+              "text": 'use consistent language, for example, if you use “Start survey” for one page title, it would be inconsistent to use “Submit form” later in the user’s journey'
           }
         ]
     })
 }}
 
-Include a suffix to each page title of the site name so the user is clear about where they are. For example, “Introduction to people who live here - Census 2021” or “Births, deaths and marriages - Office for National Statistics”.
+Include the site name on the end of each page title so the user is clear about where they are. For example, “Introduction to people who live here – Census 2021” or “Births, deaths and marriages – Office for National Statistics”.
 
-For the [error state](patterns/correct-errors) version of each page, add the prefix “Error:” to each page title.
+For the [error state](/patterns/correct-errors) version of each page, add “Error: ” at the start of each page title.

--- a/src/get-started/svgs/index.njk
+++ b/src/get-started/svgs/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Exporting SVGs
-sortOrder: 3
+sortOrder: 4
+group: Guides
 ---
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
 


### PR DESCRIPTION
### What is the context of this PR?
- Added new page to 'get started' section about How to write page titles
- Grouped all the guides that aren't related to 'installing' into a new subgroup
- Renamed the design assets and browser compatibility page titles

### How to review
Check docs
