### PR TITLE
Improve situation where right border of example iframe is sometimes obscured and cannot be seen.

### DIFF
--- a/src/scss/patternlib.scss
+++ b/src/scss/patternlib.scss
@@ -117,6 +117,10 @@
   }
 }
 
+.patternlib-example__iframe {
+  padding-right: 1px;
+}
+
 .patternlib-hero {
   background: $color-grey-5;
   padding: 2rem 0 1rem;


### PR DESCRIPTION
### What is the context of this PR?
https://trello.com/c/LgKfRwQC/1180-issue-1528-missing-right-borders-on-examples-with-grey-background

### How to review
- Start or build the website.
- View a page that has an example with a grey background.
- Verify that the dark grey border appears on the right side of the example box.
