### PR TITLE
Remove public path override

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,12 +38,12 @@ const sassOptions = {
 
 const scripts = [
   {
-    entryPoint: ['./src/js/public-path-override.js', './src/js/main.js'],
+    entryPoint: './src/js/main.js',
     outputFile: 'main.js',
     config: babelEsmConfig,
   },
   {
-    entryPoint: ['./src/js/public-path-override.js', './src/js/polyfills.js', './src/js/main.js'],
+    entryPoint: ['./src/js/polyfills.js', './src/js/main.js'],
     outputFile: 'main.es5.js',
     config: babelNomoduleConfig,
   },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,7 +39,6 @@ export default function(config) {
     files: [
       { pattern: 'src/components/**/*.njk', included: false },
       'src/scss/main.scss',
-      'src/js/public-path-override.js',
       { pattern: 'src/js/polyfills.js', included: process.env.TEST_MODE === 'nomodule' },
       'src/tests/spec/**/*.spec.js',
     ],

--- a/src/foundations/page-template/_template.njk
+++ b/src/foundations/page-template/_template.njk
@@ -218,7 +218,6 @@
 
         <script{% if pageConfig.cspNonce is defined and pageConfig.cspNonce %} nonce="{{ pageConfig.cspNonce }}"{% elif pageConfig.cspNonce is not defined and csp_nonce is defined and csp_nonce %} nonce="{{ csp_nonce() }}"{% endif %}>
             (function() {
-                {% if assetsURL is defined and assetsURL -%}window.ONS_assets_base_URL = "{{ assetsURL }}/";{%- endif %}
                 var s = '{{ scripts | safe }}'.split(','),
                 c = document.createElement('script');
 

--- a/src/js/public-path-override.js
+++ b/src/js/public-path-override.js
@@ -1,5 +1,0 @@
-const baseURL = window.ONS_assets_base_URL;
-
-if (baseURL) {
-  __webpack_public_path__ = baseURL;
-}


### PR DESCRIPTION
### What is the context of this PR?
This PR is to remove the public path override stuff that was needed in the old build system because the js files were chunked and the path needed to be updated with the cdn_url so that they could be resolved. But after moving to Gulp we don't need this anymore because they aren't chunked anymore and keeping it in is causing a `main.js:7 Uncaught ReferenceError: __webpack_public_path__ is not defined` error in the console in the Python systems

### How to review
- Tests pass
- DS builds correctly
