### PR TITLE
Fix mutually exclusive date logic for label and legends

### DIFF
--- a/src/components/date-input/_macro.njk
+++ b/src/components/date-input/_macro.njk
@@ -87,7 +87,7 @@
         {% endset %}
     {% endif %}
 
-    {% if params.mutuallyExclusive is defined and params.mutuallyExclusive %}
+    {% if params.mutuallyExclusive is defined and params.mutuallyExclusive and numberOfFields > 1 %}
         {% call onsMutuallyExclusive({
             "id": params.id,
             "legend": params.legendOrLabel,

--- a/src/components/date-input/_macro.njk
+++ b/src/components/date-input/_macro.njk
@@ -87,14 +87,14 @@
         {% endset %}
     {% endif %}
 
-    {% if params.mutuallyExclusive is defined and params.mutuallyExclusive and numberOfFields > 1 %}
+    {% if params.mutuallyExclusive is defined and params.mutuallyExclusive %}
         {% call onsMutuallyExclusive({
             "id": params.id,
             "legend": params.legendOrLabel,
             "legendClasses": params.legendClasses,
             "description": params.description,
             "classes": params.classes,
-            "dontWrap": params.dontWrap,
+            "dontWrap": params.dontWrap if numberOfFields > 1 else true,
             "legendIsQuestionTitle": params.legendIsQuestionTitle,
             "checkbox": params.mutuallyExclusive.checkbox,
             "or": params.mutuallyExclusive.or,


### PR DESCRIPTION
### What is the context of this PR?
If there is a date with a single field that also has a mutual exclusive checkbox, the legend and label are both displayed. This will stop that and just the label will be displayed instead

![image](https://user-images.githubusercontent.com/42928680/135518336-adc10c73-c501-44c7-a71d-9056b6c1872d.png)


### How to review
- Tests pass
- Date input still works as expected
- Date input with 1 field and a mutually exclusive checkbox now only displays the label
