### PR TITLE
Fix duration mutually exclusive example

### DIFF
--- a/src/components/mutually-exclusive/examples/duration/index.njk
+++ b/src/components/mutually-exclusive/examples/duration/index.njk
@@ -12,12 +12,12 @@
         "field1": {
             "id": "address-duration-years",
             "name": "address-duration-years",
-            "label": "Years"
+            "suffix": "Years"
         },
         "field2": {
             "id": "address-duration-months",
             "name": "address-duration-months",
-            "label": "Months"
+            "suffix": "Months"
         },
         "mutuallyExclusive": {
             "or": "Or",


### PR DESCRIPTION
### What is the context of this PR?
Mutually exclusive duration example is missing suffixes

![image](https://user-images.githubusercontent.com/42928680/135521952-74f6dcdc-10f4-4759-969e-723499dc1dfe.png)

### How to review
- Mutually exclusive duration example now has suffixes
