### PR TITLE
Allow input width setting in checkbox answer

### DIFF
--- a/src/components/checkboxes/_checkbox-macro.njk
+++ b/src/components/checkboxes/_checkbox-macro.njk
@@ -35,7 +35,7 @@
                         "type": params.other.type,
                         "required": params.other.required,
                         "classes": params.other.classes | default(''),
-                        "width": "auto",
+                        "width": params.other.width | default('auto'),
                         "attributes": params.other.attributes,
                         "label": {
                             "id": params.other.id + "-label",

--- a/src/components/checkboxes/_macro.njk
+++ b/src/components/checkboxes/_macro.njk
@@ -40,6 +40,7 @@
                                 "type": checkbox.other.type,
                                 "otherType": checkbox.other.otherType,
                                 "options": checkbox.other.options,
+                                "width": checkbox.other.width,
                                 "classes": checkbox.other.classes | default('') + exclusiveClass | default(''),
                                 "attributes": checkbox.other.attributes,
                                 "label": {

--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -52,7 +52,7 @@
                                         "type": radio.other.type,
                                         "required": radio.other.required,
                                         "classes": radio.other.classes | default(''),
-                                        "width": "auto",
+                                        "width": radio.other.width | default('auto'),
                                         "attributes": radio.other.attributes,
                                         "label": {
                                             "id": radio.other.id + "-label",


### PR DESCRIPTION
### What is the context of this PR?
The width of checkbox inputs is hardcoded to auto, this PR will allow the setting of input widths on checkboxes but keep the default to `auto`.

### How to review
- Setting the width on checkbox inputs works
