### PR TITLE
Exclude page groups from urls

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -1,7 +1,7 @@
 import express from 'express';
-import fs from 'fs';
 
 import createNunjucksEnvironment from './rendering/create-nunjucks-environment.js';
+import { getSiteMap } from './rendering/helpers/site-map';
 import renderPage from './rendering/render-page.js';
 
 process.env.IS_DEV_SERVER = true;
@@ -16,19 +16,15 @@ app.use((req, res, next) => {
     rawRequestPath += '/';
   }
 
-  const requestPath = !!rawRequestPath ? `${rawRequestPath}index` : 'index';
-
-  let templatePath = `./src/pages/${requestPath}.njk`;
-  if (!fs.existsSync(templatePath)) {
-    templatePath = `./src/${requestPath}.njk`;
-  }
-
-  if (!fs.existsSync(templatePath)) {
+  const siteMap = getSiteMap();
+  const requestPath = !!rawRequestPath ? `${rawRequestPath}index.html` : 'index.html';
+  const requestEntry = siteMap.routes.get(requestPath);
+  if (!requestEntry) {
     next();
     return;
   }
 
-  const output = renderPage(templatePath, nunjucksEnvironment);
+  const output = renderPage(requestEntry.templatePath, nunjucksEnvironment);
   res.send(output);
 });
 

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -2,6 +2,7 @@ import express from 'express';
 
 import createNunjucksEnvironment from './rendering/create-nunjucks-environment.js';
 import { getSiteMap } from './rendering/helpers/site-map';
+import installRenderHelpers from './rendering/install-render-helpers';
 import renderPage from './rendering/render-page.js';
 
 process.env.IS_DEV_SERVER = true;
@@ -9,6 +10,7 @@ process.env.IS_DEV_SERVER = true;
 const app = express();
 
 const nunjucksEnvironment = createNunjucksEnvironment();
+installRenderHelpers(nunjucksEnvironment);
 
 app.use((req, res, next) => {
   let rawRequestPath = (req.path ?? '/').substr(1);

--- a/lib/rendering/create-nunjucks-environment.js
+++ b/lib/rendering/create-nunjucks-environment.js
@@ -2,9 +2,6 @@ import nunjucks from 'nunjucks';
 
 import setAttribute from './filters/set-attribute.js';
 import setAttributes from './filters/set-attributes.js';
-import generateExampleParams from './helpers/generate-example-params.js';
-import navigationHelper from './helpers/navigation-helper.js';
-import subNavigationHelper from './helpers/sub-navigation-helper.js';
 
 export default function createNunjucksEnvironment(loader) {
   const templatePaths = ['src', 'src/views'];
@@ -14,12 +11,6 @@ export default function createNunjucksEnvironment(loader) {
 
   nunjucksEnvironment.addFilter('setAttribute', setAttribute);
   nunjucksEnvironment.addFilter('setAttributes', setAttributes);
-
-  nunjucksEnvironment.addGlobal('helpers', {
-    generateExampleParams: params => generateExampleParams(params, nunjucksEnvironment),
-    navigationHelper,
-    subNavigationHelper,
-  });
 
   nunjucksEnvironment.addGlobal('isPatternLib', true);
 

--- a/lib/rendering/helpers/generate-example-params.js
+++ b/lib/rendering/helpers/generate-example-params.js
@@ -3,11 +3,13 @@ import marked from 'marked';
 
 import { formatHTML } from './format-html.js';
 import { removeFrontmatterFromString } from './remove-frontmatter-from-string.js';
+import { getPageInfo } from './site-map.js';
 
 const sourcePath = `${process.cwd()}/src`;
 
 export default function generateExampleParams(params, nunjucksEnvironment) {
-  const link = `/${params.path.replace('/index.njk', '').replace('/index.html', '')}`;
+  const entry = getPageInfo(`src/${params.path}`);
+  const link = entry.url;
   const name = link.split('/examples/')[1];
   const path = `${sourcePath}/${params.path}`;
 

--- a/lib/rendering/helpers/site-map.js
+++ b/lib/rendering/helpers/site-map.js
@@ -5,11 +5,13 @@ import lodash from 'lodash';
 import path from 'path';
 import YAML from 'yaml';
 
-let pageListingCache = null;
+const SRC_PATH = path.resolve('./src');
+
 let siteMapCache = null;
+let siteMapCacheTime = 0;
 
 function buildPageListing() {
-  return glob.sync('./src/**/[^_]*.njk').map(templatePath => {
+  const flatListing = glob.sync('./src/**/[^_]*.njk').map(templatePath => {
     templatePath = path.resolve(templatePath);
     const data = frontMatter(fs.readFileSync(templatePath, { encoding: 'utf8' }));
 
@@ -18,53 +20,117 @@ function buildPageListing() {
       segment = templatePath.match(/([^\/]+)\/index.njk/)[1];
     }
 
-    return {
+    const entry = {
       ...data.attributes,
       basePath: templatePath.replace(/\/[^/]+\.njk$/, ''),
       templatePath,
-      url: templatePath
-        .substr(5)
-        .replace(/\\/g, '/')
-        .replace(/.+\/src\//, '/')
-        .replace(/^\/pages\//, '/')
-        .replace('index.njk', '')
-        .replace('.njk', ''),
       title: data.attributes.title || segment,
       sortOrder: data.attributes.sortOrder || Infinity,
       lang: data.attributes.lang || '',
       experimental: data.attributes.experimental || '',
     };
+
+    entry.groups = discoverPageGroups(entry);
+
+    return entry;
   });
-}
 
-export function getPageListing() {
-  if (pageListingCache === null || process.env.IS_DEV_SERVER) {
-    pageListingCache = buildPageListing();
+  const lookup = new Map(flatListing.map(entry => [entry.templatePath, entry]));
+
+  for (let entry of flatListing) {
+    entry.outputPath = rewritePath(entry, lookup);
+
+    entry.url = entry.outputPath
+      .substr(5)
+      .replace(/\\/g, '/')
+      .replace(/.+\/src\//, '/')
+      .replace('index.html', '')
+      .replace('.html', '');
+
+    // Link groups to the associated entries.
+    for (let group of entry.groups) {
+      group.rootPage = lookup.get(group.rootPage);
+      group.items = group.items.map(item => lookup.get(item));
+      group.items = lodash.orderBy(group.items, ['sortOrder', 'title'], ['asc', 'asc']);
+      for (let item of group.items) {
+        item.group = group;
+      }
+    }
   }
-  return pageListingCache;
+
+  return lookup;
 }
 
-function discoverPageGroups(page) {
-  const groups = glob.sync(`${page.basePath}/*/group.yml`).map(groupDefinitionPath => {
+function discoverPageGroups(entry) {
+  const groups = glob.sync(`${entry.basePath}/*/group.yml`).map(groupDefinitionPath => {
     const groupDefinition = YAML.parse(fs.readFileSync(groupDefinitionPath, { encoding: 'utf8' }));
-    groupDefinition.rootPage = page.templatePath;
+    groupDefinition.rootPage = entry.templatePath;
     groupDefinition.slug = groupDefinitionPath.match(/\/([^\/]+)\/group\.yml/)[1];
-    groupDefinition.basePath = `${page.basePath}/${groupDefinition.slug}`;
+    groupDefinition.basePath = `${entry.basePath}/${groupDefinition.slug}`;
     groupDefinition.items = glob.sync(`${groupDefinition.basePath}/{*.njk,*/index.njk}`);
     return groupDefinition;
   });
   return lodash.orderBy(groups, ['sortOrder', 'title'], ['asc', 'asc']);
 }
 
+function rewritePath(entry, lookup) {
+  let result = entry.templatePath;
+
+  // Remove page group slugs from URLs.
+  const groupRootEntry = findGroupRoot(entry, lookup);
+  if (groupRootEntry !== null) {
+    const replacePattern = `(${groupRootEntry.basePath.replace(/[\\\/]/g, '\\/')})\/[^\/]+\/`;
+    const replacement = '$1/';
+    result = result.replace(new RegExp(replacePattern), replacement);
+  }
+
+  // Remove pages/ prefix from URLs.
+  result = result.replace(/[\\\/]src[\\\/]pages[\\\/]/, '/src/');
+
+  // Adjust file extension.
+  result = result.replace('.njk', '.html');
+
+  return result;
+}
+
+function findGroupRoot(entry, lookup) {
+  let templatePath = entry.templatePath;
+  while (!!templatePath) {
+    templatePath = getParentTemplatePath(templatePath);
+
+    const rootEntry = lookup.get(templatePath);
+    if (rootEntry?.groups.length > 0) {
+      return rootEntry;
+    }
+  }
+
+  return null;
+}
+
+function getParentTemplatePath(templatePath) {
+  const templateDirectoryPath = path.dirname(templatePath);
+
+  if (path.basename(templatePath) !== 'index.njk') {
+    return path.resolve(templateDirectoryPath, 'index.njk');
+  }
+
+  if (templateDirectoryPath === SRC_PATH) {
+    return null;
+  }
+
+  return path.resolve(path.dirname(templateDirectoryPath), 'index.njk');
+}
+
 function buildSiteMap() {
-  const pages = getPageListing();
+  const allEntries = [...buildPageListing().values()];
 
   let siteMap = {
     children: [],
     lookup: new Map(),
+    routes: new Map(allEntries.map(entry => [entry.outputPath.substr(SRC_PATH.length + 1), entry])),
   };
 
-  for (let page of pages) {
+  for (let page of allEntries) {
     let entry = siteMap;
     const segments = page.url.replace(/^\/|\/$/g, '').split('/');
     for (let i = 0; i < segments.length; ++i) {
@@ -82,21 +148,7 @@ function buildSiteMap() {
         }
         Object.assign(entry, page);
 
-        entry.groups = discoverPageGroups(page);
-
         siteMap.lookup.set(page.templatePath, entry);
-      }
-    }
-  }
-
-  // Link groups to the associated entries.
-  for (let entry of siteMap.lookup.values()) {
-    for (let group of entry.groups) {
-      group.rootPage = siteMap.lookup.get(group.rootPage);
-      group.items = group.items.map(item => siteMap.lookup.get(item));
-      group.items = lodash.orderBy(group.items, ['sortOrder', 'title'], ['asc', 'asc']);
-      for (let item of group.items) {
-        item.group = group;
       }
     }
   }
@@ -106,8 +158,9 @@ function buildSiteMap() {
 }
 
 export function getSiteMap() {
-  if (siteMapCache === null || process.env.IS_DEV_SERVER) {
+  if (siteMapCache === null || (process.env.IS_DEV_SERVER && new Date().getTime() - siteMapCacheTime > 800)) {
     siteMapCache = buildSiteMap();
+    siteMapCacheTime = new Date().getTime();
   }
   return siteMapCache;
 }

--- a/lib/rendering/helpers/site-map.js
+++ b/lib/rendering/helpers/site-map.js
@@ -153,6 +153,10 @@ function buildSiteMap() {
     }
   }
 
+  for (let entry of siteMap.lookup.values()) {
+    entry.children = lodash.orderBy(entry.children, ['sortOrder', 'title'], ['asc', 'asc']);
+  }
+
   // console.log(util.inspect(siteMap, true, 4));process.abort();
   return siteMap;
 }

--- a/lib/rendering/install-render-helpers.js
+++ b/lib/rendering/install-render-helpers.js
@@ -1,0 +1,11 @@
+import generateExampleParams from './helpers/generate-example-params.js';
+import navigationHelper from './helpers/navigation-helper.js';
+import subNavigationHelper from './helpers/sub-navigation-helper.js';
+
+export default function installRenderHelpers(nunjucksEnvironment) {
+  nunjucksEnvironment.addGlobal('helpers', {
+    generateExampleParams: params => generateExampleParams(params, nunjucksEnvironment),
+    navigationHelper,
+    subNavigationHelper,
+  });
+}

--- a/lib/rendering/nunjucks-renderer-pipe.js
+++ b/lib/rendering/nunjucks-renderer-pipe.js
@@ -2,11 +2,14 @@ import through from 'through2';
 
 import createNunjucksEnvironment from './create-nunjucks-environment.js';
 import { getPageInfo } from './helpers/site-map';
+import installRenderHelpers from './install-render-helpers';
 import renderPage from './render-page.js';
 
 export default through.obj((file, enc, cb) => {
   const pageInfo = getPageInfo(file.path);
   const nunjucksEnvironment = createNunjucksEnvironment();
+  installRenderHelpers(nunjucksEnvironment);
+
   const output = renderPage(file.path, nunjucksEnvironment);
   file.path = pageInfo.outputPath;
   file.contents = Buffer.from(output, enc);

--- a/lib/rendering/nunjucks-renderer-pipe.js
+++ b/lib/rendering/nunjucks-renderer-pipe.js
@@ -1,12 +1,14 @@
 import through from 'through2';
 
 import createNunjucksEnvironment from './create-nunjucks-environment.js';
+import { getPageInfo } from './helpers/site-map';
 import renderPage from './render-page.js';
 
 export default through.obj((file, enc, cb) => {
+  const pageInfo = getPageInfo(file.path);
   const nunjucksEnvironment = createNunjucksEnvironment();
   const output = renderPage(file.path, nunjucksEnvironment);
-  file.path = file.path.replace(/[\\\/]src[\\\/]pages[\\\/]/, '/src/').replace('.njk', '.html');
+  file.path = pageInfo.outputPath;
   file.contents = Buffer.from(output, enc);
   cb(null, file);
 });

--- a/lib/rendering/search-index-pipe.js
+++ b/lib/rendering/search-index-pipe.js
@@ -1,9 +1,9 @@
 import through from 'through2';
 
-import { getPageListing } from './helpers/site-map.js';
+import { getSiteMap } from './helpers/site-map.js';
 
 export default through.obj((file, encoding, cb) => {
-  const allPages = getPageListing();
+  const allPages = [...getSiteMap().routes.values()];
 
   const filteredPages = JSON.stringify(
     allPages.reduce(


### PR DESCRIPTION
### What is the context of this PR?
The recent addition of page groups in sub navigation introduced group slugs into URLs due to the new directory structure which caused breakage to some links. There were two approaches to resolving this issue:
- Adjusting all the links.
- Removing group slugs from generated URLs.

The preference was to remove group slugs from generated URLs.

### How to review
1. Test with `yarn start` locally.
2. Test with `yarn build && npx serve build` locally.