### PR TITLE
Fix empty label textarea bug

### DIFF
--- a/src/components/textarea/_macro.njk
+++ b/src/components/textarea/_macro.njk
@@ -8,12 +8,14 @@
     {% set field %}
         {% set textareaExlusiveClass = " ons-js-exclusive-group-item" if params.mutuallyExclusive else "" %}
 
-        {{ onsLabel({
-            "for": params.id,
-            "text": params.label.text,
-            "description": params.label.description,
-            "classes": params.label.classes
-        }) }}
+        {% if params.label is defined and params.label %}
+            {{ onsLabel({
+                "for": params.id,
+                "text": params.label.text,
+                "description": params.label.description,
+                "classes": params.label.classes
+            }) }}
+        {% endif %}
 
         <textarea
             id="{{ params.id }}"


### PR DESCRIPTION
### What is the context of this PR?
Currently if no label for a textarea is defined an empty one is created. This has caused an issue in runner where the js will fall over if a textarea without a label is used with a mutually exclusive checkbox. This is because the js is looking to trim the label if one exists, which it is unable to do on "".

This PR fixes this by only adding a label if one is defined.

### How to review
- Tests pass
- Changes make sense
- Textarea works as expected with and without label
