### PR TITLE
Address autosuggest - allow manual query params to be dynamically added

### DIFF
--- a/src/components/address-input/_macro.njk
+++ b/src/components/address-input/_macro.njk
@@ -123,6 +123,7 @@
                             "externalInitialiser": true,
                             "APIDomain": params.APIDomain,
                             "APIDomainBearerToken": params.APIDomainBearerToken,
+                            "APIManualQueryParams": params.APIManualQueryParams,
                             "allowMultiple": params.allowMultiple,
                             "mandatory": params.mandatory,
                             "instructions": params.instructions,

--- a/src/components/address-input/autosuggest.address.js
+++ b/src/components/address-input/autosuggest.address.js
@@ -121,7 +121,7 @@ export default class AutosuggestAddress {
 
       if (this.manualQueryParams) {
         const manualQueryParams = this.container.getAttribute('data-query-params');
-        fullQueryURL = this.lookupURL + manualQueryParams;
+        fullQueryURL = this.lookupURL + text + manualQueryParams;
       } else {
         const fullPostcodeQuery = this.testFullPostcodeQuery(text);
         let limit = fullPostcodeQuery ? 100 : 10;

--- a/src/components/address-input/autosuggest.address.js
+++ b/src/components/address-input/autosuggest.address.js
@@ -66,6 +66,7 @@ export default class AutosuggestAddress {
     this.retrieveURL = `${this.APIDomain}/addresses/eq/uprn/`;
 
     // Query string options
+    this.manualQueryParams = this.container.getAttribute('data-query-params');
     this.regionCode = this.container.getAttribute('data-options-region-code');
     this.epoch = this.container.getAttribute('data-options-one-year-ago');
     this.classificationFilter = this.container.getAttribute('data-options-address-type');
@@ -117,14 +118,20 @@ export default class AutosuggestAddress {
   findAddress(text, grouped) {
     return new Promise((resolve, reject) => {
       let queryURL, fullQueryURL;
-      const testInput = this.testFullPostcodeQuery(text);
-      let limit = testInput ? 100 : 10;
 
-      queryURL = grouped ? this.lookupGroupURL + this.groupQuery : this.lookupURL + text + '&limit=' + limit;
+      if (this.manualQueryParams) {
+        const manualQueryParams = this.container.getAttribute('data-query-params');
+        fullQueryURL = this.lookupURL + manualQueryParams;
+      } else {
+        const fullPostcodeQuery = this.testFullPostcodeQuery(text);
+        let limit = fullPostcodeQuery ? 100 : 10;
 
-      fullQueryURL = this.generateURLParams(queryURL);
-      if (testInput && grouped !== false) {
-        fullQueryURL = fullQueryURL + '&groupfullpostcodes=combo';
+        queryURL = grouped ? this.lookupGroupURL + this.groupQuery : this.lookupURL + text + '&limit=' + limit;
+
+        fullQueryURL = this.generateURLParams(queryURL);
+        if (fullPostcodeQuery && grouped !== false) {
+          fullQueryURL = fullQueryURL + '&groupfullpostcodes=combo';
+        }
       }
 
       this.fetch = abortableFetch(fullQueryURL, {

--- a/src/components/autosuggest/_macro.njk
+++ b/src/components/autosuggest/_macro.njk
@@ -16,6 +16,7 @@
         data-type-more="{{ params.typeMore }}"
         {% if params.APIDomain is defined and params.APIDomain %}data-api-domain="{{ params.APIDomain }}"{% endif %}
         {% if params.APIDomainBearerToken is defined and params.APIDomainBearerToken %}data-authorization-token="{{ params.APIDomainBearerToken }}"{% endif %}
+        {% if params.APIManualQueryParams is defined and params.APIManualQueryParams %}data-query-params=""{% endif %}
         {% if params.allowMultiple is defined and params.allowMultiple == true %}data-allow-multiple="true"{% endif %}
         {% if params.autosuggestData is defined and params.autosuggestData %}data-autosuggest-data="{{ params.autosuggestData }}"{% endif %}
         {% if params.errorTitle is defined and params.errorTitle %}data-error-title="{{ params.errorTitle }}"{% endif %}

--- a/src/components/autosuggest/_macro.njk
+++ b/src/components/autosuggest/_macro.njk
@@ -16,7 +16,7 @@
         data-type-more="{{ params.typeMore }}"
         {% if params.APIDomain is defined and params.APIDomain %}data-api-domain="{{ params.APIDomain }}"{% endif %}
         {% if params.APIDomainBearerToken is defined and params.APIDomainBearerToken %}data-authorization-token="{{ params.APIDomainBearerToken }}"{% endif %}
-        {% if params.APIManualQueryParams is defined and params.APIManualQueryParams %}data-query-params=""{% endif %}
+        {% if params.APIManualQueryParams is defined and params.APIManualQueryParams == true %}data-query-params=""{% endif %}
         {% if params.allowMultiple is defined and params.allowMultiple == true %}data-allow-multiple="true"{% endif %}
         {% if params.autosuggestData is defined and params.autosuggestData %}data-autosuggest-data="{{ params.autosuggestData }}"{% endif %}
         {% if params.errorTitle is defined and params.errorTitle %}data-error-title="{{ params.errorTitle }}"{% endif %}

--- a/src/components/autosuggest/autosuggest.ui.js
+++ b/src/components/autosuggest/autosuggest.ui.js
@@ -185,11 +185,11 @@ export default class AutosuggestUI {
     this.ctrlKey = false;
   }
 
-  handleChange(alternative = false) {
-    if ((!this.blurring && this.input.value.trim()) || alternative === true) {
+  handleChange(groupResults = false) {
+    if ((!this.blurring && this.input.value.trim()) || groupResults === true) {
       this.settingResult = false;
-      if (alternative === true) {
-        this.getSuggestions(false, alternative);
+      if (groupResults === true) {
+        this.getSuggestions(false, groupResults);
       } else {
         this.getSuggestions();
       }
@@ -262,7 +262,7 @@ export default class AutosuggestUI {
     }
   }
 
-  getSuggestions(force, alternative) {
+  getSuggestions(force, groupResults) {
     if (!this.settingResult) {
       if (this.allowMultiple === 'true' && this.allSelections.length) {
         const newQuery = this.input.value.split(', ').find(item => !this.allSelections.includes(item));
@@ -278,7 +278,7 @@ export default class AutosuggestUI {
         this.unsetResults();
         this.checkCharCount();
         if (this.sanitisedQuery.length >= this.minChars) {
-          this.fetchSuggestions(this.sanitisedQuery, this.data, alternative)
+          this.fetchSuggestions(this.sanitisedQuery, this.data, groupResults)
             .then(this.handleResults.bind(this))
             .catch(error => {
               if (error.name !== 'AbortError') {


### PR DESCRIPTION
### What is the context of this PR?
This change is specific to a requirement for the AIMS team.

- A new param is available `APIManualQueryParams: true`
- If provided an empty data attribute is rendered in the html `data-query-params=""`
- This attribute can be updated via a script on the AIMS UI service using the pattern `&eboost=10&limit=200` for example
- The address autosuggest will use the value of this attribute to build the query that is sent to the AIMS api (instead of building the query params based on language and other provided options)

### How to review
Check this works in the AIMS UI service.