### PR TITLE
Revert static base URL and have karma use proxy to serve fonts.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,12 +38,17 @@ export default function(config) {
 
     files: [
       { pattern: 'src/components/**/*.njk', included: false },
+      { pattern: 'src/static/fonts/*', included: false },
       'src/scss/main.scss',
       { pattern: 'src/js/polyfills.js', included: process.env.TEST_MODE === 'nomodule' },
       'src/tests/spec/**/*.spec.js',
     ],
 
     exclude: [],
+
+    proxies: {
+      '/base/src/fonts/': '/base/src/static/fonts/',
+    },
 
     preprocessors: {
       'src/scss/main.scss': ['scss'],

--- a/src/scss/vars/_vars.scss
+++ b/src/scss/vars/_vars.scss
@@ -1,1 +1,1 @@
-$static: '';
+$static: '..';


### PR DESCRIPTION
### What is the context of this PR?
Alternative fix for broken font URLs in test runner which should also work for CDN builds.

### How to review
- Test locally.
- Create a release to verify that font URLs work properly from the CDN.