### PR TITLE
Fix mutually exclusive textarea label bug

### DIFF
--- a/src/components/mutually-exclusive/mutually-exclusive.js
+++ b/src/components/mutually-exclusive/mutually-exclusive.js
@@ -103,12 +103,14 @@ export default class MutuallyExclusive {
     // This filter is used to strip out any text that is in 'ons-u-vh' elements for accessibility
     let labelText;
 
-    if (label.classList.contains(inputAbbrClass)) {
-      labelText = label.getAttribute('title');
-    } else if (label.classList.contains(inputLegendClass) && label.querySelector('h1')) {
-      labelText = label.querySelector('h1').innerText;
-    } else {
-      labelText = [...label.childNodes].filter(node => node.nodeType === 3 && node.textContent.trim())[0].textContent.trim();
+    if (label) {
+      if (label.classList.contains(inputAbbrClass)) {
+        labelText = label.getAttribute('title');
+      } else if (label.classList.contains(inputLegendClass) && label.querySelector('h1')) {
+        labelText = label.querySelector('h1').innerText;
+      } else {
+        labelText = [...label.childNodes].filter(node => node.nodeType === 3 && node.textContent.trim())[0].textContent.trim();
+      }
     }
 
     return labelText;


### PR DESCRIPTION
### What is the context of this PR?
When a textarea without a label is used with a mutually exclusive checkbox there is a bug that makes the js fall over. Because label doesn't exist. This is because this line

```
if (!label) {
      label = this.context.querySelector(`.${inputLegendClass}`);
    }
```
Doesn't find the legend because it is just outside of the context.

By putting an if around the part where it falls over this will prevent this error happening in future.

### How to review
- Can be tested by removing the label on the text area example on the mutually exclusive component page and comparing this branch with master
