### PR TITLE
Fix anchor links in sub navigation helper.

### DIFF
--- a/lib/rendering/helpers/sub-navigation-helper.js
+++ b/lib/rendering/helpers/sub-navigation-helper.js
@@ -1,13 +1,12 @@
 import * as fs from 'fs';
 
 export default function subNavigationHelper({ pageInfo, anchorLinks }) {
-  const rootPage = pageInfo.depth === 0 ? pageInfo : pageInfo.parent;
-
-  const items = rootPage.children.filter(item => !!item.templatePath).map(item => ({ ...item }));
+  const itemGroups = getNavigationItemGroups(pageInfo);
+  const pageItems = itemGroups.flatMap(groups => groups.items);
 
   if (anchorLinks) {
     if (fs.existsSync(pageInfo.templatePath)) {
-      const item = items.find(item => item.url === pageInfo.url);
+      const item = pageItems.find(item => item.url === pageInfo.url);
       const raw = fs.readFileSync(pageInfo.templatePath, 'utf8');
 
       const matches = raw
@@ -38,15 +37,27 @@ export default function subNavigationHelper({ pageInfo, anchorLinks }) {
     }
   }
 
+  return itemGroups;
+}
+
+function getNavigationItemGroups(pageInfo) {
+  const rootPage = pageInfo.depth === 0 ? pageInfo : pageInfo.parent;
+
+  let groups;
   if (pageInfo.group) {
-    return pageInfo.group.rootPage.groups;
+    groups = pageInfo.group.rootPage.groups;
   } else if (pageInfo.groups.length !== 0) {
-    return pageInfo.groups;
+    groups = pageInfo.groups;
   } else {
-    return [
+    groups = [
       {
-        items,
+        items: rootPage.children.filter(item => !!item.templatePath),
       },
     ];
   }
+
+  return groups.map(group => ({
+    ...group,
+    items: group.items.map(item => ({ ...item })),
+  }));
 }


### PR DESCRIPTION
### What is the context of this PR?
The changes made to introduce grouping of pages indirectly broke the anchor links that are shown in the sub navigation. The problem occurred because items need to be copied to avoid mutation of cached page meta information since that would have undesirable side effects.

### How to review
1. Test locally with `yarn start`.
2. Open a page that has anchor links; for example:
    * Guidance/Using the CSS, JS and assets
    * Foundations/Typography
3. Optionally repeat tests with `yarn build && npx serve build`.