### PR TITLE
Fix cookie banner content displaying in print

### DIFF
--- a/src/scss/print.scss
+++ b/src/scss/print.scss
@@ -2,7 +2,7 @@ $color-black: #222;
 
 .ons-btn,
 .ons-summary__actions,
-footer,
+.ons-footer,
 .ons-cookies-banner,
 .ons-language-links,
 .ons-breadcrumb {


### PR DESCRIPTION
### What is the context of this PR?
![image](https://user-images.githubusercontent.com/42928680/136529084-4fa250b1-8e58-4415-95bc-fe2066670942.png)

Cookie banner content is showing when printing

This PR adds `!important` so that it overrides the `<h2>` and `<p>` styles which are setting display to "block"

### How to review
When printing the cookie banner example check that nothing is now shown
