### PR TITLE
Fixed pagination icons

### DIFF
--- a/src/components/content-pagination/_content-pagination.scss
+++ b/src/components/content-pagination/_content-pagination.scss
@@ -34,10 +34,6 @@
 
   &__link-title {
     display: block;
-
-    .ons-svg-icon {
-      transform: rotate(180deg);
-    }
   }
 
   &__link-text {

--- a/src/foundations/layout/page-template/examples/rtl/index.njk
+++ b/src/foundations/layout/page-template/examples/rtl/index.njk
@@ -118,7 +118,29 @@ layout: none
         ]
     }
 } %}
+{% block preMain %}
+    {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 
+{{
+    onsBreadcrumbs({
+        "ariaLabel": 'Breadcrumbs',
+        "itemsList": [
+            {
+                "url": '#0',
+                "text": 'Home'
+            },
+            {
+                "url": '#0',
+                "text": 'Help with the census'
+            },
+            {
+                "url": '#0',
+                "text": 'Languages'
+            }
+        ]
+    })
+}}
+{% endblock %}
 {% block main %}
 
     <h1 class="ons-u-mb-l">

--- a/src/foundations/layout/page-template/index.njk
+++ b/src/foundations/layout/page-template/index.njk
@@ -45,14 +45,6 @@ The example below shows a themed census version of the ONS base page template.
     patternlibExample({ "path": "foundations/layout/page-template/examples/census/index.njk" })
 }}
 
-## Census page template (right-to-left)
-
-The example below shows a themed census version of the ONS base page template which sets the direction property from right-to-left.
-
-{{
-    patternlibExample({ "path": "foundations/layout/page-template/examples/rtl/index.njk" })
-}}
-
 ### Changing template content
 
 The Nunjucks template allows 2 ways to change the content: {{

--- a/src/patterns/pages/guide/index.njk
+++ b/src/patterns/pages/guide/index.njk
@@ -19,7 +19,7 @@ Use this pattern when you want to present a collection of related pages on a top
 
 ## How to use this pattern
 
-View the nunjucks output below which shows the components required to create the guide pattern.
+View the Nunjucks output below which shows the components required to create the guide pattern.
 
 The first page of a guide serves as the "parent" to the other pages. In the table of contents it should be linked as "Overview".
 For accessibility the title `h1` should contain an additional visually hidden `span` that provides the additional "Overview" text, for example:
@@ -46,6 +46,14 @@ Other pages in the guide (below the parent) should include the title of the pare
 
 {{
     patternlibExample({ "path": "patterns/pages/guide/examples/guide/index.njk"})
+}}
+
+### Right-to-left languages
+
+To display a guide page for a right-to-left language (for example, Arabic) you can set `"bodyClasses": 'ons-rtl'` in the [base page template](/foundations/page-template).
+
+{{
+    patternlibExample({ "path": "foundations/layout/page-template/examples/rtl/index.njk" })
 }}
 
 ## Help improve this pattern


### PR DESCRIPTION
### What is the context of this PR?
- Content pager next/prev icons were pointing in the wrong direction after the macro was updated to use `onsIcon()`. The `transform` style was removed to correct this.
- Also moved the right-to-left example which uses the content pager, from base page template to the new 'guide' pattern

### How to review
Check pagination component icons and guide examples.
