### PR TITLE
Make summary headings mandatory

### DIFF
--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -13,20 +13,20 @@
 
 ## SummaryGroup
 
-| Name            | Type                    | Required | Description                                                                |
-| --------------- | ----------------------- | -------- | -------------------------------------------------------------------------- |
-| rows            | Array`<SummaryRows>`    | false    | An array of rows within a group                                            |
-| placeholderText | string                  | false    | A message to be shown as a placeholder if there are no rows in the summary |
-| groupTitle      | string                  | false    | The title for a summary within a group                                     |
-| headers         | Array`<SummaryHeaders>` | false    | An array of headers to describe the data in the summary                    |
-| summaryLink     | Array`<SummaryLink>`    | false    | Settings for the link to appear after the summary                          |
+| Name            | Type                 | Required | Description                                                                               |
+| --------------- | -------------------- | -------- | ----------------------------------------------------------------------------------------- |
+| rows            | Array`<SummaryRows>` | false    | An array of rows within a group                                                           |
+| placeholderText | string               | false    | A message to be shown as a placeholder if there are no rows in the summary                |
+| groupTitle      | string               | false    | The title for a summary within a group                                                    |
+| headers         | Array                | true     | An array of headers to describe the data in each column of the summary for screen readers |
+| summaryLink     | Array`<SummaryLink>` | false    | Settings for the link to appear after the summary                                         |
 
 ## SummaryRow
 
 | Name               | Type                    | Required | Description                                                           |
 | ------------------ | ----------------------- | -------- | --------------------------------------------------------------------- |
 | rowItems           | Array`<SummaryRowItem>` | true     | An array of items for this row                                        |
-| rowtitle           | string                  | false    | The title for the row                                                 |
+| rowTitle           | string                  | false    | The title for the row                                                 |
 | rowTitleAttributes | object                  | false    | HTML attributes (for example, data attributes) to add to the rowTitle |
 | error              | boolean                 | false    | Whether to render this item as an error                               |
 | errorMessage       | string                  | false    | Error message for the row                                             |

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -20,7 +20,7 @@
                     {% if group.groupTitle is defined and group.groupTitle %}
                         <h{{ titleSize }} class="ons-summary__group-title">{{ group.groupTitle }}</h{{ titleSize }}>
                     {% endif %}
-                    {% if group.rows is defined and group.rows %}
+                    {% if group.headers is defined and group.headers and group.rows is defined and group.rows %}
                         <table class="ons-summary__items">
                             <thead class="ons-u-vh">
                                 <tr>

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -22,15 +22,13 @@
                     {% endif %}
                     {% if group.rows is defined and group.rows %}
                         <table class="ons-summary__items">
-                            {% if group.headers is defined and group.headers %}
-                                <thead class="ons-u-vh">
-                                    <tr>
-                                        {% for header in group.headers %}
-                                            <th>{{ header }}</th>
-                                        {% endfor %}
-                                    </tr>
-                                </thead>
-                            {% endif %}
+                            <thead class="ons-u-vh">
+                                <tr>
+                                    {% for header in group.headers %}
+                                        <th>{{ header }}</th>
+                                    {% endfor %}
+                                </tr>
+                            </thead>
 
                             {% for row in (group.rows if group.rows is iterable else group.rows.items()) %}
                                 {% set itemClass = "" %}

--- a/src/components/summary/index.njk
+++ b/src/components/summary/index.njk
@@ -60,7 +60,7 @@ The summary component is made accessible by using the following `aria` attribute
 }}
 
 ### Headers
-The parameter `headers` must be provided with an array of values so screen reader users can understand the purpose of each column in the summary table. For example, a summary showing the questions and answers given in a questionnaire should have: `"headers": ["Question", "Answer given"]`.
+The parameter `headers` must be provided with an array of values, so screen reader users can understand the purpose of each column in the summary table. For example, for a 2-column summary showing the questions and answers given in a questionnaire should you should set: `"headers": ["Question", "Answer given"]`.
 
 ## Variants
 ### Summary without action

--- a/src/components/summary/index.njk
+++ b/src/components/summary/index.njk
@@ -59,6 +59,9 @@ The summary component is made accessible by using the following `aria` attribute
     })
 }}
 
+### Headers
+The parameter `headers` must be provided with an array of values so screen reader users can understand the purpose of each column in the summary table. For example, a summary showing the questions and answers given in a questionnaire should have: `"headers": ["Question", "Answer given"]`.
+
 ## Variants
 ### Summary without action
 A summary of an answer the user cannot directly change, due to it being automatically calculated.


### PR DESCRIPTION
## Breaking changes

### What is the context of this PR?
- All summary tables must have headers to screen reader users can understand the purpose of each column.
- Updated documentation, macro conditions, and options table.

### What is the breaking change?
- Developers using `onsSummary` macro will need to set parameter `headers` with an array of values describing each column of the summary e.g. `"headers":["Question", "Answer given", "Change answer"],`

### How to review
Check summary documentation and macro to ensure developers must provide `headers` to build a summary.