### PR TITLE
Remove use of classes in table variants

### DIFF
--- a/src/components/table/_macro-options.md
+++ b/src/components/table/_macro-options.md
@@ -1,25 +1,25 @@
-| Name        | Type               | Required | Description                                                                                     |
-| ----------- | ------------------ | -------- | ----------------------------------------------------------------------------------------------- |
-| table_class | string             | false    | Classes to add to the table component                                                           |
-| id          | string             | false    | ID to add to the table component                                                                |
-| caption     | string             | false    | The caption for the table component                                                             |
-| hideCaption | boolean            | false    | Visually hides the caption                                                                      |
-| scrollable  | boolean            | false    | Sets the component to render as a scrollable table                                              |
-| ariaLabel   | string             | false    | The aria label added to the table if it is scrollable. Defaults to `Scrollable table`           |
-| sortable    | boolean            | false    | Sets the component to render as a sortable table                                                |
-| ths         | Array`<th>`        | true     | An array of `th` elements for table                                                             |
-| trs         | Array`<tr>`        | true     | An array of `tr` elements for table                                                             |
-| tfoot       | Array`<tfootCell>` | false    | An array of `td` elements for `tdfoot`                                                          |
-| ariaAsc     | string             | false    | Sets the `data-aria-asc` attribute for the table. Used to set aria labels when table is sorted  |
-| ariaDesc    | string             | false    | Sets the `data-aria-desc` attribute for the table. Used to set aria labels when table is sorted |
+| Name         | Type               | Required | Description                                                                                                                                                 |
+| ------------ | ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| variants     | array or string    | false    | An array of values or single value (string) to adjust the table using available variants: `compact`, `responsive`,`scrollable`, `sortable`, and `row-hover` |
+| tableClasses | string             | false    | Classes to add to the table component                                                                                                                       |
+| id           | string             | false    | ID to add to the table component                                                                                                                            |
+| caption      | string             | false    | The caption for the table component                                                                                                                         |
+| hideCaption  | boolean            | false    | Visually hides the caption                                                                                                                                  |
+| ariaLabel    | string             | false    | The ARIA label to be added if `scrollable` variant set, to inform screen reader users that the table can be scrolled. Defaults to `"Scrollable table"`      |
+| ths          | Array`<th>`        | true     | An array of `th` elements for table                                                                                                                         |
+| trs          | Array`<tr>`        | true     | An array of `tr` elements for table                                                                                                                         |
+| tfoot        | Array`<tfootCell>` | false    | An array of `td` elements for `tdfoot`                                                                                                                      |
+| ariaAsc      | string             | false    | Sets the `data-aria-asc` attribute for the table. Used to set aria labels when table is sorted                                                              |
+| ariaDesc     | string             | false    | Sets the `data-aria-desc` attribute for the table. Used to set aria labels when table is sorted                                                             |
 
 ## th
 
-| Name     | Type   | Required | Description                                            |
-| -------- | ------ | -------- | ------------------------------------------------------ |
-| class    | string | false    | Classes to add to the `th` element                     |
-| ariaSort | string | false    | Default is "none". Accepts "ascending" or "descending" |
-| value    | string | true     | The content for the `th` cell                          |
+| Name      | Type    | Required | Description                                             |
+| --------- | ------- | -------- | ------------------------------------------------------- |
+| thClasses | string  | false    | Classes to add to the `th` element                      |
+| ariaSort  | string  | false    | Default is "none". Accepts "ascending" or "descending"  |
+| value     | string  | true     | The content for the `th` cell                           |
+| numeric   | boolean | false    | Aligns the cell content to the right when set to `true` |
 
 ## tr
 
@@ -30,14 +30,15 @@
 
 ## td
 
-| Name     | Type    | Required | Description                                                         |
-| -------- | ------- | -------- | ------------------------------------------------------------------- |
-| class    | string  | false    | Classes to add to the `td` element                                  |
-| name     | string  | false    | Name to add to the `td` element                                     |
-| data     | string  | false    | The corresponding `th` for the `td` for responsive tables           |
-| dataSort | integer | false    | numerical ordering of a column of `td` elements for sortable table  |
-| value    | string  | false    | The content for the `td` cell                                       |
-| form     | object  | false    | Form attributes information for `method`, `action` and the `button` |
+| Name      | Type    | Required | Description                                                         |
+| --------- | ------- | -------- | ------------------------------------------------------------------- |
+| tdClasses | string  | false    | Classes to add to the `td` element                                  |
+| name      | string  | false    | Name to add to the `td` element                                     |
+| data      | string  | false    | The corresponding `th` for the `td` for responsive tables           |
+| dataSort  | integer | false    | numerical ordering of a column of `td` elements for sortable table  |
+| value     | string  | false    | The content for the `td` cell                                       |
+| numeric   | boolean | false    | Aligns the cell content to the right when set to `true`             |
+| form      | object  | false    | Form attributes information for `method`, `action` and the `button` |
 
 ## form
 

--- a/src/components/table/_macro.njk
+++ b/src/components/table/_macro.njk
@@ -1,20 +1,23 @@
 {% macro onsTable(params) %}
     {% from "components/button/_macro.njk" import onsButton %}
     {% from "components/icons/_macro.njk" import onsIcon %}
-    {% if params.scrollable is defined and params.scrollable %}
+
+    {% set variants = params.variants if params.variants else '' %}
+
+    {% if 'scrollable' in variants %}
     <div class="ons-table-scrollable ons-table-scrollable--on">
         <div class="ons-table-scrollable__content" tabindex="0" role="region" aria-label="{{ params.caption }}. {{ params.ariaLabel | default("Scrollable table") }} ">
     {% endif %}
-            <table {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %} class="ons-table {{ params.table_class }}" {% if params.sortable is defined and params.sortable %}data-aria-sort="{{ params.sortBy }}" data-aria-asc="{{ params.ariaAsc }}" data-aria-desc="{{ params.ariaDesc }}"{% endif %}>
+            <table {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %} class="ons-table{% if params.tableClasses is defined and params.tableClasses %} {{ params.tableClasses }}{% endif %}{% if variants is defined and variants %}{% if variants is not string %}{% for variant in variants %} ons-table--{{ variant }}{% endfor %}{% else %} ons-table--{{ variants }}{% endif %}{% endif %}" {% if params.sortBy is defined and params.sortBy and 'sortable' in variants %}data-aria-sort="{{ params.sortBy }}" data-aria-asc="{{ params.ariaAsc }}" data-aria-desc="{{ params.ariaDesc }}"{% endif %}>
                 {% if params.caption is defined and params.caption %}
                 <caption class="ons-table__caption{{ " ons-u-vh" if params.hideCaption }}">{{ params.caption }}</caption>
                 {% endif %}
                 <thead class="ons-table__head">
                     <tr class="ons-table__row">
                         {% for th in params.ths %}
-                        <th scope="col" class="ons-table__header {{ th.class }}"{% if th.ariaSort is defined and th.ariaSort %} aria-sort="{{- th.ariaSort | default('none') -}}"{% endif %}>
-                            <span {% if params.sortable is defined and params.sortable %}class="ons-u-vh"{% endif %}>{{- th.value -}}</span>
-                            {% if params.sortable is defined and params.sortable %}
+                        <th scope="col" class="ons-table__header{{ '' + params.thClasses if params.thClasses is defined and params.thClasses }}{{ " ons-table__header--numeric" if th.numeric is defined and th.numeric }}"{% if th.ariaSort is defined and th.ariaSort %} aria-sort="{{- th.ariaSort | default('none') -}}"{% endif %}>
+                            <span {% if 'sortable' in variants %}class="ons-u-vh"{% endif %}>{{- th.value -}}</span>
+                            {% if 'sortable' in variants %}
                                 {{
                                     onsIcon({
                                         "iconType": "sort-sprite",
@@ -30,7 +33,7 @@
                     {% for tr in params.trs %}
                     <tr class="ons-table__row{{ " ons-table__row--highlight" if tr.highlight }}" {% if tr.name is defined and tr.name %} name="{{ tr.name }}"{% endif %} {% if tr.id is defined and tr.id %} id="{{ tr.id }}"{% endif %}>
                         {% for td in tr.tds %}
-                        <td class="ons-table__cell {{ td.class }}" {% if td.id is defined and td.id %} id="{{ td.id }}"{% endif %} {% if td.name is defined and td.name %} name="{{ td.name }}"{% endif %} {% if td.data is defined and td.data %} data-th="{{ td.data }}"{% endif %} {% if td.dataSort is defined and td.dataSort %} data-sort-value="{{ td.dataSort }}"{% endif %}>
+                        <td class="ons-table__cell {{ '' + td.tdClasses if td.tdClasses is defined and td.tdClasses }}{{ " ons-table__cell--numeric" if td.numeric is defined and td.numeric }}" {% if td.id is defined and td.id %} id="{{ td.id }}"{% endif %} {% if td.name is defined and td.name %} name="{{ td.name }}"{% endif %} {% if td.data is defined and td.data %} data-th="{{ td.data }}"{% endif %} {% if td.dataSort is defined and td.dataSort %} data-sort-value="{{ td.dataSort }}"{% endif %}>
                             {% if td.form is defined and td.form %}
                                 <form action="{{ td.form.action }}" method="{{ td.form.method | default('POST')}}">
                                     {{
@@ -68,7 +71,7 @@
                 </tfoot>
                 {% endif %}
             </table>
-        {% if params.scrollable is defined and params.scrollable %}
+        {% if 'scrollable' in variants %}
         </div>
     </div>
     {% endif %}

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -44,7 +44,7 @@
     border-top: 1px solid $color-borders;
   }
 
-  &--dense {
+  &--compact {
     .ons-table__head,
     .ons-table__body,
     .ons-table__foot {
@@ -54,7 +54,7 @@
 
   &--row-hover {
     .ons-table__body .ons-table__row:hover {
-      background: $color-grey-5;
+      background: $color-highlight;
     }
   }
 
@@ -86,133 +86,135 @@
       }
     }
   }
-}
 
-.ons-table-scrollable {
-  position: relative;
-  ::-webkit-scrollbar {
-    height: 7px;
-  }
-  ::-webkit-scrollbar-thumb {
-    background: $color-grey-75;
-    border-radius: 20px;
-  }
-  &--on {
-    .ons-table__header,
-    .ons-table__cell {
-      white-space: nowrap;
+  &-scrollable {
+    position: relative;
+    ::-webkit-scrollbar {
+      height: 7px;
     }
-  }
-  &__content {
-    overflow: visible;
-    overflow-x: scroll;
-    width: 100%;
-    &:focus {
-      outline: 3px solid $color-focus;
-      outline-offset: 3px;
+    ::-webkit-scrollbar-thumb {
+      background: $color-grey-75;
+      border-radius: 20px;
     }
-    .ons-table__header,
-    .ons-table__cell {
-      @include mq(xxs, m) {
+    &--on {
+      .ons-table__header,
+      .ons-table__cell {
         white-space: nowrap;
       }
     }
-    .ons-table__right-shadow,
-    .ons-table__left-shadow {
-      height: 100%;
-      position: absolute;
-      top: 0;
-      width: 5px;
-      z-index: 200;
+    &__content {
+      overflow: visible;
+      overflow-x: scroll;
+      width: 100%;
+      &:focus {
+        outline: 3px solid $color-focus;
+        outline-offset: 3px;
+      }
+      .ons-table__header,
+      .ons-table__cell {
+        @include mq(xxs, m) {
+          white-space: nowrap;
+        }
+      }
+      .ons-table__right-shadow,
+      .ons-table__left-shadow {
+        height: 100%;
+        position: absolute;
+        top: 0;
+        width: 5px;
+        z-index: 200;
 
-      &.ons-with-transition {
-        transition: box-shadow 0.4s ease-out;
+        &.ons-with-transition {
+          transition: box-shadow 0.4s ease-out;
+        }
       }
-    }
-    .ons-table__right-shadow {
-      right: 0;
-      &.ons-visible {
-        box-shadow: inset -1px 0 0 0 #bfc1c3, inset -5px 0 0 0 rgba(191, 193, 195, 0.4);
+      .ons-table__right-shadow {
+        right: 0;
+        &.ons-visible {
+          box-shadow: inset -1px 0 0 0 #bfc1c3, inset -5px 0 0 0 rgba(191, 193, 195, 0.4);
+        }
       }
-    }
-    .ons-table__left-shadow {
-      left: 0;
-      &.ons-visible {
-        box-shadow: inset 1px 0 0 0 #bfc1c3, inset -5px 0 0 0 rgba(191, 193, 195, 0.4);
+      .ons-table__left-shadow {
+        left: 0;
+        &.ons-visible {
+          box-shadow: inset 1px 0 0 0 #bfc1c3, inset -5px 0 0 0 rgba(191, 193, 195, 0.4);
+        }
       }
     }
   }
-}
 
-.ons-table--sortable {
-  [aria-sort='descending'].ons-table__header {
-    .ons-svg-icon {
-      .ons-topTriangle {
-        fill: $color-grey-35;
-      }
-      .ons-bottomTriangle {
-        fill: $color-text;
-      }
-    }
-    .ons-table__sort-button:focus {
+  &--sortable {
+    [aria-sort='descending'].ons-table__header {
       .ons-svg-icon {
         .ons-topTriangle {
-          fill: #b69502;
+          fill: $color-grey-35;
         }
-      }
-    }
-  }
-
-  [aria-sort='ascending'].ons-table__header {
-    .ons-svg-icon {
-      .ons-topTriangle {
-        fill: $color-text;
-      }
-      .ons-bottomTriangle {
-        fill: $color-grey-35;
-      }
-    }
-    .ons-table__sort-button:focus {
-      .ons-svg-icon {
         .ons-bottomTriangle {
-          fill: #b69502;
+          fill: $color-text;
+        }
+      }
+      .ons-table__sort-button:focus {
+        .ons-svg-icon {
+          .ons-topTriangle {
+            fill: #b69502;
+          }
         }
       }
     }
-  }
 
-  .ons-table__header {
-    position: relative;
-
-    .ons-table__sort-button {
-      background-color: transparent;
-      border: 0;
-      box-shadow: none;
-      color: $color-text-link;
-      display: inline-block;
-      font-family: $font-sans;
-      font-weight: 700;
-      line-height: 1rem;
-      text-decoration: underline;
-      white-space: nowrap;
-
-      &:hover {
-        color: $color-text-link-hover;
-        cursor: pointer;
-        text-decoration: underline solid $color-text-link-hover 2px;
-      }
-
+    [aria-sort='ascending'].ons-table__header {
       .ons-svg-icon {
-        fill: $color-grey-35;
-        height: 0.8rem;
-        padding-bottom: 0.1rem;
-        width: 0.8rem;
+        .ons-topTriangle {
+          fill: $color-text;
+        }
+        .ons-bottomTriangle {
+          fill: $color-grey-35;
+        }
       }
-
-      &:focus {
-        @extend a:focus;
+      .ons-table__sort-button:focus {
         .ons-svg-icon {
-          fill: $color-black;
+          .ons-bottomTriangle {
+            fill: #b69502;
+          }
+        }
+      }
+    }
+
+    .ons-table__header {
+      position: relative;
+
+      .ons-table__sort-button {
+        background-color: transparent;
+        border: 0;
+        box-shadow: none;
+        color: $color-text-link;
+        display: inline-block;
+        font-family: $font-sans;
+        font-weight: 700;
+        line-height: 1rem;
+        padding: 0 0 0.2rem;
+        text-decoration: underline;
+        text-underline-position: under;
+        white-space: nowrap;
+
+        &:hover {
+          color: $color-text-link-hover;
+          cursor: pointer;
+          text-decoration: underline solid $color-text-link-hover 2px;
+        }
+
+        .ons-svg-icon {
+          fill: $color-grey-35;
+          height: 0.8rem;
+          padding-bottom: 0.1rem;
+          width: 0.8rem;
+        }
+
+        &:focus {
+          @extend a:focus;
+          .ons-svg-icon {
+            fill: $color-black;
+          }
         }
       }
     }

--- a/src/components/table/examples/table-compact/index.njk
+++ b/src/components/table/examples/table-compact/index.njk
@@ -1,8 +1,8 @@
 {% from "components/table/_macro.njk" import onsTable %}
 {{
     onsTable({
-        "table_class": "ons-table--dense ons-table--row-hover",
-        "caption": "A basic table that compacts if more columns are required",
+        "variants": ['compact', 'row-hover'],
+        "caption": "A compacted table with a large number of columns",
         "ths": [
             {
                 "value": "Column A"
@@ -18,6 +18,9 @@
             },
             {
                 "value": "Column E"
+            },
+            {
+                "value": "Column F"
             }
         ],
         "trs": [
@@ -37,6 +40,9 @@
                     },
                     {
                         "value": "Cell E1"
+                    },
+                    {
+                        "value": "Cell F1"
                     }
                 ]
             },
@@ -55,7 +61,10 @@
                     "value": "Cell D2"
                     },
                     {
-                    "value": "Cell E2"
+                        "value": "Cell E1"
+                    },
+                    {
+                        "value": "Cell F1"
                     }
                 ]
             }

--- a/src/components/table/examples/table-numeric/index.njk
+++ b/src/components/table/examples/table-numeric/index.njk
@@ -4,48 +4,75 @@
         "caption": "A basic table with numeric values",
         "ths": [
             {
-                "value": "Column A",
-                "class": " table__header--numeric"
+                "value": "Country"
             },
             {
-                "value": "Column B",
-                "class": " table__header--numeric"
+                "value": "Population mid-2020",
+                "numeric": true
             },
             {
-                "value": "Column C",
-                "class": " table__header--numeric"
+                "value": "% change 2019 to 2020",
+                "numeric": true
             }
         ],
         "trs": [
             {
                 "tds": [
                     {
-                        "value": "200",
-                        "class": "table__cell--numeric"
+                        "value": "England"
                     },
                     {
-                        "value": "365",
-                        "class": "table__cell--numeric"
+                        "value": "67,081,000",
+                        "numeric": true
                     },
                     {
-                        "value": "24",
-                        "class": "table__cell--numeric"
+                        "value": "0.43",
+                        "numeric": true
                     }
                 ]
             },
             {
                 "tds": [
                     {
-                    "value": "345",
-                    "class": "table__cell--numeric"
+                        "value": "Northern Ireland"
                     },
                     {
-                    "value": "33",
-                    "class": "table__cell--numeric"
+                        "value": "1,896,000",
+                        "numeric": true
                     },
                     {
-                    "value": "13",
-                    "class": " table__cell--numeric"
+                        "value": "0.10",
+                        "numeric": true
+                    }
+                ]
+            },
+            {
+                "tds": [
+                    {
+                        "value": "Scotland"
+                    },
+                    {
+                        "value": "5,466,000",
+                        "numeric": true
+                    },
+                    {
+                        "value": "0.05",
+                        "numeric": true
+                    }
+                ]
+            },
+            {
+                "tds": [
+                    {
+                        "value": "Wales"
+                    },
+                    {
+                        "value": "3,170,000",
+                        "numeric": true
+                    },
+                    {
+                        "value": "0.53",
+                        "numeric": true
                     }
                 ]
             }

--- a/src/components/table/examples/table-responsive/index.njk
+++ b/src/components/table/examples/table-responsive/index.njk
@@ -1,49 +1,86 @@
 {% from "components/table/_macro.njk" import onsTable %}
 {{
     onsTable({
-        "table_class": "ons-table--responsive",
+        "variants": 'responsive',
         "caption": "Responsive table with stacked rows for small viewports",
         "ths": [
             {
-                "value": "Column A"
+                "value": "Country"
             },
             {
-                "value": "Column B"
+                "value": "Highest mountain"
             },
             {
-                "value": "Column C"
+                "value": "Height in metres",
+                "numeric": true
             }
         ],
         "trs": [
             {
                 "tds": [
                     {
-                        "value": "Cell A1",
-                        "data": "Column A"
+                        "value": "Scotland",
+                        "data": "Country"
                     },
                     {
-                        "value": "Cell B1",
-                        "data": "Column B"
+                        "value": "Ben Nevis",
+                        "data": "Highest mountain"
                     },
                     {
-                        "value": "Cell C1",
-                        "data": "Column C"
+                        "value": "1,345",
+                        "data": "Height",
+                        "numeric": true
                     }
                 ]
             },
             {
                 "tds": [
                     {
-                        "value": "Cell A2",
-                        "data": "Column A"
+                        "value": "Wales",
+                        "data": "Country"
                     },
                     {
-                        "value": "Cell B2",
-                        "data": "Column B"
+                        "value": "Snowdon",
+                        "data": "Highest mountain"
                     },
                     {
-                        "value": "Cell C2",
-                        "data": "Column C"
+                        "value": "1,085",
+                        "data": "Height",
+                        "numeric": true
+                    }
+                ]
+            },
+            {
+                "tds": [
+                    {
+                        "value": "England",
+                        "data": "Country"
+                    },
+                    {
+                        "value": "Scafell Pike",
+                        "data": "Highest mountain"
+                    },
+                    {
+                        "value": "978",
+                        "data": "Height",
+                        "numeric": true
+                    }
+                ]
+            },
+            {
+                "tds": [
+                    {
+                        "value": "Northern Ireland",
+                        "data": "Country"
+                    },
+                    {
+                        "value": "Slieve Donard",
+                        "data": "Highest mountain"
+                    },
+                    {
+                        "value": "850",
+                        "data": "Height",
+                        "numeric": true
                     }
                 ]
             }

--- a/src/components/table/examples/table-scrollable/index.njk
+++ b/src/components/table/examples/table-scrollable/index.njk
@@ -1,7 +1,7 @@
 {% from "components/table/_macro.njk" import onsTable %}
 {{
     onsTable({
-        "scrollable": true,
+        "variants": 'scrollable',
         "caption": "Scrollable table",
         "ariaLabel": "There are 7 columns in this table. Some of the table may be off screen. Scroll or drag horizontally to bring into view.",
         "ths": [

--- a/src/components/table/examples/table-sortable/index.njk
+++ b/src/components/table/examples/table-sortable/index.njk
@@ -2,8 +2,7 @@
 
 {{
     onsTable({
-        "sortable": true,
-        "table_class": "ons-table--sortable",
+        "variants": 'sortable',
         "caption": "Javascript enhanced sortable table",
         "sortBy": "Sort by",
         "ariaAsc": "ascending",

--- a/src/components/table/index.njk
+++ b/src/components/table/index.njk
@@ -26,42 +26,39 @@ Use the table component to let users compare information in rows and columns.
 
 ## How to use this component
 
-The 'basic table' is the default style for a table. There are variations available, added via `class` modifiers which can improve the usability of the `ons-table` element.
+The “basic table” is the default style for a table. The following variants can be set using the `variants` parameter.
 
-### Dense table
+### Compact table
+Setting `"variants": 'compact'` will reduce the font size of the table content. This can be used to compact a table with too many columns, to fit into the viewport.
+
+Setting an additional `row-hover` to the array will highlight a row when hovered, to help users focus on the content in it.
 {{
-    patternlibExample({"path": "components/table/examples/table-dense/index.njk"})
+    patternlibExample({"path": "components/table/examples/table-compact/index.njk"})
 }}
-- **Class** - `ons-table--dense`
-- **Output** - This reduces the `ons-font-size` to compact the table for basic tables which have many rows but only a few columns.
 
 ### Numeric table
+Setting `"numeric": true` to any table cell will right-align it’s figures to make them easier to compare with other rows.
 {{
     patternlibExample({"path": "components/table/examples/table-numeric/index.njk"})
 }}
-- **Class** - `ons-table__header--numeric` + `ons-table__cell--numeric`
-- **Output** - This aligns the content to the right for tables with all numeric values for best practice.
 
 ### Responsive table
+Setting `"variants": 'responsive'` will stack the cells of each table row vertically when viewing on devices less than 500px wide. The associated table header will display repeatedly alongside each cell.
 {{
     patternlibExample({"path": "components/table/examples/table-responsive/index.njk"})
 }}
-- **Class** - `ons-table--responsive`
-- **Output** - Stacks the rows on viewports that are `500px` and lower. Displays the corresponding header value with each cell.
 
 ### Scrollable table
+Setting `"variants": 'scrollable'` will create a full-width, scrollable table.
 {{
     patternlibExample({"path": "components/table/examples/table-scrollable/index.njk"})
 }}
-- **Class** - `ons-table--scrollable` `ons-table-scrollable--on`
-- **Output** - Creates a scrollable full width table on viewports that are `740px` and lower. Optionally allows for the table to be set at 100% on all viewports (shown in the example above).
 
 ### Sortable table
+Setting `"variants": 'sortable'` will apply a JavaScript enhancement to allow each column to be sorted. By default, the column will be sorted alphabetically, but an optional parameter `"dataSort": '<number>'`  can be added to each table cell to control it’s position for sorting.
 {{
     patternlibExample({"path": "components/table/examples/table-sortable/index.njk"})
 }}
-- **Class** - `ons-table--sortable`
-- **Output** - Applies JS enhancement to allow each column to be sorted. By default it will sort alphabetically, an optional `data-sort-value=foo` can be added to each `td` to control it's position for sorting.
 
 ## Help improve this component
 Let us know how we could improve this component or share your user research findings.

--- a/src/tests/spec/table/table-scrollable.spec.js
+++ b/src/tests/spec/table/table-scrollable.spec.js
@@ -2,7 +2,7 @@ import TableScroll from '../../../components/table/scrollable-table';
 import renderTemplate from '../../helpers/render-template';
 
 const params = {
-  scrollable: true,
+  variants: 'scrollable',
   ths: [
     {
       value: 'Column 1',

--- a/src/tests/spec/table/table-sortable.spec.js
+++ b/src/tests/spec/table/table-sortable.spec.js
@@ -2,8 +2,7 @@ import TableSort from '../../../components/table/sortable-table';
 import renderTemplate from '../../helpers/render-template';
 
 const params = {
-  sortable: true,
-  table_class: ' ons-table--sortable',
+  variants: 'sortable',
   sortBy: 'Sort by',
   ariaAsc: 'ascending',
   ariaDesc: 'descending',


### PR DESCRIPTION
## Breaking change

### What is the context of this PR?
- In line with changes made in #1684 this PR applies the same work to the table component, which was missed.
- Classes and boolean parameters are now replaced with a single `variants` parameter which can take an array to set the different variations of tables.
Also...
- Updated some of the variant examples with real content to help show how they work
- The Sass has been amended to use the parent selector where applicable
- The colour of `row-hover` has been changed to use the same variable for highlighting other elements: `$color-highlight`
- The `dense` variant has been changed to `compact`
- Documentation updated

### What is the breaking change?
- Developers using the `onsTable()` macro will need to replace the use of `table_class`, `class`, `sortable` and `scrollable` parameters with a new single parameter `variants` which can be set with an array of values or a single string e.g. `"variants": ['scrollable', 'row-hover']`
- Utility classes etc can still be added to `<table>`, `<th>`, and `<td>`, but the params have changed to: `tableClasses`, `thClasses` and `tdClasses`, for consistency with other components.

### How to review
Check all table variants work as expected and check docs