### PR TITLE
Prevent fieldsets with no legend

### DIFF
--- a/src/components/fieldset/_macro.njk
+++ b/src/components/fieldset/_macro.njk
@@ -2,11 +2,11 @@
 
 {% macro onsFieldset(params) %}
     {% set fieldset %}
-        {% if params.dontWrap %}
+        {% if params.dontWrap is defined and params.dontWrap %}
             <div class="ons-input-items">
                 {{ caller() }}
             </div>
-        {% else %}
+        {% elif (params.legend is defined and params.legend) or (params.legendIsQuestionTitle is defined and params.legendIsQuestionTitle) %}
             <fieldset
                 {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %}
                 class="ons-fieldset{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"

--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -31,7 +31,7 @@
 
             {# Resolves caller issue in jijna: https://github.com/pallets/jinja/issues/371 #}
             {% set content = caller() %}
-            
+
             {% call onsFieldset({
                 "legendIsQuestionTitle": params.legendIsQuestionTitle,
                 "legend": titleHtml,

--- a/src/components/question/examples/question-fieldset/index.njk
+++ b/src/components/question/examples/question-fieldset/index.njk
@@ -21,9 +21,11 @@ layout: none
     }
 } %}
 
+{% set questionTitle = "On 1 May 2016, what was the number of employees for Bolt and Ratchet?" %}
+
 {% block main %}
     {% call onsQuestion({
-        "title": "On 1 May 2016, what was the number of employees for Bolt and Ratchet?",
+        "title": questionTitle,
         "description": "<p>This is all employees aged 16 years or over that your organisation employs.</p>"
     }) %}
         {% call onsCollapsible({
@@ -51,6 +53,8 @@ layout: none
         {{ onsRadios({
             "id": "number-of-employees",
             "name": "number-of-employees",
+            "legend": questionTitle,
+            "legendClasses": "ons-u-vh",
             "radios": [
                 {
                     "id": "number-of-employees-1-9",


### PR DESCRIPTION
### What is the context of this PR?
Added conditions to fieldset macro to prevent components rendering with a fieldset but no legend, thus failing accessibility guidelines.

### How to review
Check that all components that call `onsFieldset` require either a legend or the two params required for '[legend as question heading](https://ons-design-system.netlify.app/patterns/question/#legend-as-question-heading)'