### PR TITLE
Allow header titles to wrap above medium breakpoint

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -62,6 +62,7 @@
     &--with-description,
     &--with-button {
       @include mq(m) {
+        margin-bottom: 0;
         margin-top: 0.45rem;
       }
     }

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -38,9 +38,6 @@
     background: $color-header;
     padding: 0.56rem 0;
 
-    @include mq(m) {
-      height: 95px;
-    }
     &--border {
       border-bottom: 3px solid $color-header;
       border-top: 3px solid $color-header;
@@ -57,6 +54,7 @@
     color: $color-white;
 
     @include mq(m) {
+      margin-bottom: 1rem;
       margin-top: 0.8rem;
     }
 

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -5,6 +5,7 @@
   -moz-osx-font-smoothing: grayscale;
   margin: 0;
   position: relative;
+
   & &__title--svg-logo {
     display: block;
     fill: $color-white;

--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -87,7 +87,7 @@
                                 })
                             }}
                         {% else %}
-                            <{{ title_tag }} class="ons-header__title{% if params.desc is defined and params.desc %} ons-header__title--with-description{% endif %}{% if params.button is defined and params.button %} header__title--with-button{% endif %}">{{ params.title }}</{{ title_tag }}>
+                            <{{ title_tag }} class="ons-header__title{% if params.desc is defined and params.desc %} ons-header__title--with-description{% endif %}{% if params.button is defined and params.button %} ons-header__title--with-button{% endif %}">{{ params.title }}</{{ title_tag }}>
                         {% endif %}
                         {% if params.titleLogoHref is defined and params.titleLogoHref %}</a>{% endif %}
                     </div>

--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -87,7 +87,7 @@
                                 })
                             }}
                         {% else %}
-                            <{{ title_tag }} class="ons-header__title{% if params.desc is defined and params.desc %} header__title--with-description{% endif %}{% if params.button is defined and params.button %} header__title--with-button{% endif %}">{{ params.title }}</{{ title_tag }}>
+                            <{{ title_tag }} class="ons-header__title{% if params.desc is defined and params.desc %} ons-header__title--with-description{% endif %}{% if params.button is defined and params.button %} header__title--with-button{% endif %}">{{ params.title }}</{{ title_tag }}>
                         {% endif %}
                         {% if params.titleLogoHref is defined and params.titleLogoHref %}</a>{% endif %}
                     </div>
@@ -95,7 +95,7 @@
                         <div class="ons-grid__col ons-col-auto ons-u-flex-no-shrink ons-u-d-no@xxs@m">
                             {{ onsButton({
                                 "text": params.button.text,
-                                "classes": "ons-u-d-no@xxs@m ons-u-mt-xs@m",
+                                "classes": "ons-u-d-no@xxs@m",
                                 "variants": "ghost",
                                 "name": params.button.name,
                                 "attributes": params.button.attributes,

--- a/src/components/input/_macro.njk
+++ b/src/components/input/_macro.njk
@@ -127,7 +127,7 @@
         {% call onsMutuallyExclusive({
             "id": params.fieldId,
             "legend": params.legend,
-            "legendClasses": params.legendClasses ~ "ons-js-input-legend",
+            "legendClasses": params.legendClasses ~ " ons-js-input-legend",
             "description": params.description,
             "dontWrap": params.dontWrap,
             "legendIsQuestionTitle": params.legendIsQuestionTitle,

--- a/src/patterns/ask-users-for/email-addresses/index.njk
+++ b/src/patterns/ask-users-for/email-addresses/index.njk
@@ -88,7 +88,7 @@ Use the [correct errors pattern](/patterns/correct-errors) and show the error de
 Use “Enter an email address”.
 
 ##### If the email address entered is not in a valid format
-Use “Enter an email address in a valid format, for example, name@example.com”.
+Use “Enter an email address in a valid format, for example, name\@example.com”.
 
 ## Help improve this pattern
 Let us know how we could improve this pattern or share your user research findings.

--- a/src/patterns/help-users-to/correct-errors/examples/errors-proto/errors/index.njk
+++ b/src/patterns/help-users-to/correct-errors/examples/errors-proto/errors/index.njk
@@ -192,6 +192,7 @@ layout: none
             onsDateInput({
                 "legend": "Date of birth",
                 "description": "For example, 31 3 1980",
+                "legendOrLabel": "Date of birth",
                 "id": "dates",
                 "day": {
                     "label": {
@@ -290,8 +291,10 @@ layout: none
                 "label": {
                     "text": "Email address"
                 },
+                "legend": "Get a confirmation email",
+                "legendClasses": "ons-u-vh",
                 "error": {
-                    "text": "Enter an email address in the correct format, such as name@example.com",
+                    "text": "Enter an email address in a valid format, for example, name@example.com",
                     "id": "email-error"
                 },
                 "mutuallyExclusive": {

--- a/src/patterns/help-users-to/correct-errors/examples/errors-proto/index.njk
+++ b/src/patterns/help-users-to/correct-errors/examples/errors-proto/index.njk
@@ -127,6 +127,7 @@ layout: none
             onsDateInput({
                 "legend": "Date of birth",
                 "description": "For example, 31 3 1980",
+                "legendOrLabel": "Date of birth",
                 "day": {
                     "label": {
                         "text": "Day"
@@ -212,6 +213,8 @@ layout: none
                 "label": {
                     "text": "Email address"
                 },
+                "legend": "Get a confirmation email",
+                "legendClasses": "ons-u-vh",
                 "mutuallyExclusive": {
                     "or": "Or",
                     "deselectMessage": "Selecting this will clear your email address",


### PR DESCRIPTION
### What is the context of this PR?
- When long header titles wrap above `m` breakpoint, the container height remains fixed. This PR allows the height to increase when the title wraps.

### How to review
Check header variants with titles appropriately allow for long wrapping titles at all breakpoints.