### PR TITLE
Removed unwanted fieldgroup margin

### DIFF
--- a/src/components/field/_field-group.scss
+++ b/src/components/field/_field-group.scss
@@ -4,7 +4,6 @@
   .ons-field {
     display: inline-block;
     font-size: 1rem;
-    margin-bottom: 0;
     margin-top: 0;
     vertical-align: top;
 

--- a/src/components/field/_field-group.scss
+++ b/src/components/field/_field-group.scss
@@ -4,7 +4,7 @@
   .ons-field {
     display: inline-block;
     font-size: 1rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0;
     margin-top: 0;
     vertical-align: top;
 


### PR DESCRIPTION
### What is the context of this PR?
- Removed bottom margin from fields within field group.  This was causing inconsistent spacing noticeable in mutually exclusive examples: date, duration.

### How to review
Check spacing in all field groups