### PR TITLE
Correct hub and spoke examples

### DIFF
--- a/src/patterns/pages/hub-and-spoke/examples/hub-complete/index.njk
+++ b/src/patterns/pages/hub-and-spoke/examples/hub-complete/index.njk
@@ -55,7 +55,7 @@ layout: none
                                 ]
                             },
                             {
-                                "rowTitle": "Accommodation",
+                                "rowTitle": "Household accommodation",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -67,7 +67,7 @@ layout: none
                                         "actions": [
                                             {
                                                 "text": "View answers",
-                                                "ariaLabel": "View answers for Accommodation",
+                                                "ariaLabel": "View answers for Household accommodation",
                                                 "url": "#0"
                                             }
                                         ]

--- a/src/patterns/pages/hub-and-spoke/examples/hub-complete/index.njk
+++ b/src/patterns/pages/hub-and-spoke/examples/hub-complete/index.njk
@@ -17,7 +17,13 @@ layout: none
 } %}
 
 {% block main %}
-    <h1 class="ons-u-mt-m">Choose another section to complete</h1>
+    <h1 class="ons-u-mt-m">Submit study</h1>
+
+    {% call onsPanel({
+        "type": 'warn'
+    }) %}
+        <p>You must submit this study to complete it</p>
+    {% endcall %}
 
     {{ onsSummary({
         "hub": true,
@@ -92,16 +98,17 @@ layout: none
                                 "rowTitle": "John Smith",
                                 "rowItems": [
                                     {
+                                        "iconType": "check",
                                         "valueList": [
                                             {
-                                                "text": "Partially completed"
+                                                "text": "Completed"
                                             }
                                         ],
                                         "actions": [
                                             {
-                                                "text": "Continue with section",
-                                                "ariaLabel": "Continue with John Smith's section",
-                                                "url": "/patterns/hub-and-spoke/examples/spoke-continue/"
+                                                "text": "View answers",
+                                                "ariaLabel": "View answers for John Smith",
+                                                "url": "#0"
                                             }
                                         ]
                                     }
@@ -111,16 +118,17 @@ layout: none
                                 "rowTitle": "Billy Smith",
                                 "rowItems": [
                                     {
+                                        "iconType": "check",
                                         "valueList": [
                                             {
-                                                "text": "Not started"
+                                                "text": "Completed"
                                             }
                                         ],
                                         "actions": [
                                             {
-                                                "text": "Start section",
-                                                "ariaLabel": "Start Billy Smith's section",
-                                                "url": "/patterns/hub-and-spoke/examples/spoke-start/"
+                                                "text": "View answers",
+                                                "ariaLabel": "View answers for Billy Smith",
+                                                "url": "#0"
                                             }
                                         ]
                                     }
@@ -130,15 +138,16 @@ layout: none
                                 "rowTitle": "Mary Susannah Smith (Visitor)",
                                 "rowItems": [
                                     {
+                                        "iconType": "check",
                                         "valueList": [
                                             {
-                                                "text": "Not started"
+                                                "text": "Completed"
                                             }
                                         ],
                                         "actions": [
                                             {
-                                                "text": "Start section",
-                                                "ariaLabel": "Start Mary Susannah Smith's section",
+                                                "text": "View answers",
+                                                "ariaLabel": "View answers for Mary Susannah Smith (Visitor)",
                                                 "url": "#0"
                                             }
                                         ]
@@ -151,13 +160,13 @@ layout: none
             }
         ]
     }) }}
-
+    <div class="ons-u-mt-l">
+        <p>By submitting this study you are confirming that, to the best of your knowledge and belief, the details provided are correct.</p>
+    </div>
     {{
         onsButton({
-            "text": 'Continue',
-            "classes": 'ons-u-mb-m ons-u-mt-l',
-            "url": '/patterns/hub-and-spoke/examples/spoke-continue/',
-            "iconType": false
+            "text": 'Submit study',
+            "classes": 'ons-u-mb-m'
         })
     }}
 {% endblock %}

--- a/src/patterns/pages/hub-and-spoke/examples/hub/index.njk
+++ b/src/patterns/pages/hub-and-spoke/examples/hub/index.njk
@@ -49,7 +49,7 @@ layout: none
                                 ]
                             },
                             {
-                                "rowTitle": "Accommodation",
+                                "rowTitle": "Household accommodation",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -61,7 +61,7 @@ layout: none
                                         "actions": [
                                             {
                                                 "text": "View answers",
-                                                "ariaLabel": "View answers for Accommodation",
+                                                "ariaLabel": "View answers for Household accommodation",
                                                 "url": "#0"
                                             }
                                         ]

--- a/src/patterns/pages/hub-and-spoke/examples/spoke-continue/index.njk
+++ b/src/patterns/pages/hub-and-spoke/examples/spoke-continue/index.njk
@@ -1,0 +1,82 @@
+---
+layout: none
+---
+{% extends "foundations/layout/page-template/_template.njk" %}
+
+{% from "components/question/_macro.njk" import onsQuestion %}
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/summary/_macro.njk" import onsSummary %}
+{% from "components/button/_macro.njk" import onsButton %}
+{% from "components/lists/_macro.njk" import onsList %}
+{% from "components/collapsible/_macro.njk" import onsCollapsible %}
+{% from "components/date-input/_macro.njk" import onsDateInput %}
+
+{% set pageConfig = {
+    "title": "Spoke example",
+    "signoutButton": {
+        "text": "Save and sign out",
+        "iconType": "exit",
+        "iconPosition": "after"
+    },
+    "breadcrumbs": {
+        "itemsList": [
+            {
+                "url": '/patterns/hub-and-spoke/examples/hub/',
+                "text": 'Back'
+            }
+        ]
+    }
+} %}
+
+{% block main %}
+    {% call onsPanel()
+    %}
+        <p><strong>This is the last viewed question in this section</strong><br>
+        You can also <a href="/patterns/hub-and-spoke/examples/spoke-start/">go back to the start of the section</a></p>
+    {% endcall %}
+    {% call onsQuestion({
+        "title": 'What is <em class="highlight">John Smith’s</em> date of birth?',
+        "description": '<p>For example, 31 3 1980</p>',
+        "legendIsQuestionTitle": true
+    }) %}
+        {{
+            onsDateInput({
+                "id": "date",
+                "dontWrap": true,
+                "day": {
+                    "label": {
+                        "text": "Day"
+                    },
+                    "name": "day",
+                    "attributes": {
+                        "autocomplete": "bday-day"
+                    }
+                },
+                "month": {
+                    "label": {
+                        "text": "Month"
+                    },
+                    "name": "month",
+                    "attributes": {
+                        "autocomplete": "bday-month"
+                    }
+                },
+                "year": {
+                    "label": {
+                        "text": "Year"
+                    },
+                    "name": "year",
+                    "attributes": {
+                        "autocomplete": "bday-year"
+                    }
+                }
+            })
+        }}
+        {{
+            onsButton({
+                "text": 'Continue',
+                "classes": 'ons-u-mt-xl'
+            })
+        }}
+        {% endcall %}
+{% endblock %}

--- a/src/patterns/pages/hub-and-spoke/examples/spoke-continue/index.njk
+++ b/src/patterns/pages/hub-and-spoke/examples/spoke-continue/index.njk
@@ -5,10 +5,7 @@ layout: none
 
 {% from "components/question/_macro.njk" import onsQuestion %}
 {% from "components/panel/_macro.njk" import onsPanel %}
-{% from "components/summary/_macro.njk" import onsSummary %}
 {% from "components/button/_macro.njk" import onsButton %}
-{% from "components/lists/_macro.njk" import onsList %}
-{% from "components/collapsible/_macro.njk" import onsCollapsible %}
 {% from "components/date-input/_macro.njk" import onsDateInput %}
 
 {% set pageConfig = {
@@ -75,8 +72,9 @@ layout: none
         {{
             onsButton({
                 "text": 'Continue',
-                "classes": 'ons-u-mt-xl'
+                "classes": 'ons-u-mt-xl ons-u-mb-l'
             })
         }}
+        <p><a href="/patterns/hub-and-spoke/examples/hub/">Choose another section and return to this later</a></p>
         {% endcall %}
 {% endblock %}

--- a/src/patterns/pages/hub-and-spoke/examples/spoke-start/index.njk
+++ b/src/patterns/pages/hub-and-spoke/examples/spoke-start/index.njk
@@ -3,8 +3,6 @@ layout: none
 ---
 {% extends "foundations/layout/page-template/_template.njk" %}
 
-{% from "components/panel/_macro.njk" import onsPanel %}
-{% from "components/summary/_macro.njk" import onsSummary %}
 {% from "components/button/_macro.njk" import onsButton %}
 {% from "components/lists/_macro.njk" import onsList %}
 {% from "components/collapsible/_macro.njk" import onsCollapsible %}

--- a/src/patterns/pages/hub-and-spoke/examples/spoke-start/index.njk
+++ b/src/patterns/pages/hub-and-spoke/examples/spoke-start/index.njk
@@ -1,0 +1,87 @@
+---
+layout: none
+---
+{% extends "foundations/layout/page-template/_template.njk" %}
+
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/summary/_macro.njk" import onsSummary %}
+{% from "components/button/_macro.njk" import onsButton %}
+{% from "components/lists/_macro.njk" import onsList %}
+{% from "components/collapsible/_macro.njk" import onsCollapsible %}
+
+{% set pageConfig = {
+    "title": "Spoke example",
+    "signoutButton": {
+        "text": "Save and sign out",
+        "iconType": "exit",
+        "iconPosition": "after"
+    },
+    "breadcrumbs": {
+        "itemsList": [
+            {
+                "url": '/patterns/hub-and-spoke/examples/hub/',
+                "text": 'Back'
+            }
+        ]
+    }
+} %}
+
+{% block main %}
+    <h1 class="ons-u-mt-m">Billy Smith</h1>
+
+    <p>In this section, we are going to ask you questions about <strong>Billy Smith</strong>.</p>
+
+    <h2>What you will need to know</h2>
+
+    <p>To complete this section you will need to know personal details such as:</p>
+    {{
+        onsList({
+            "classes": 'ons-u-mb-m',
+            "itemsList": [
+                {
+                    "text": 'date of birth'
+                },
+                {
+                    "text": 'country of birth'
+                },
+                {
+                    "text": 'second or holiday homes'
+                },
+                {
+                    "text": 'main language'
+                },
+                {
+                    "text": 'general health'
+                },
+                {
+                    "text": 'unpaid care provided'
+                },
+                {
+                    "text": 'qualifications'
+                },
+                {
+                    "text": 'employment details'
+                }
+            ]
+        })
+    }}
+    {% call onsCollapsible({
+            "id": 'collapsible',
+            "title": 'If you can’t answer questions for this person',
+            "titleTag": 'h2',
+            "button": {
+                "close": 'Hide this',
+                "contextSuffix": 'content'
+            }
+        })
+    %}
+        <p>You can <strong>share your household access code</strong> with the people you live with so they can complete their own sections.</p>
+        <p>If this is not possible, there are <a href="#0">other ways each person can complete their own study</a>.</p>
+    {% endcall %}
+    {{
+        onsButton({
+            "text": 'Continue',
+            "classes": 'ons-u-mt-xl'
+        })
+    }}
+{% endblock %}

--- a/src/patterns/pages/hub-and-spoke/examples/spoke-summary/index.njk
+++ b/src/patterns/pages/hub-and-spoke/examples/spoke-summary/index.njk
@@ -1,0 +1,164 @@
+---
+layout: none
+---
+{% extends "foundations/layout/page-template/_template.njk" %}
+
+{% from "components/panel/_macro.njk" import onsPanel %}
+{% from "components/summary/_macro.njk" import onsSummary %}
+{% from "components/button/_macro.njk" import onsButton %}
+
+{% set pageConfig = {
+    "title": "Spoke example",
+    "signoutButton": {
+        "text": "Save and sign out",
+        "iconType": "exit",
+        "iconPosition": "after"
+    },
+    "breadcrumbs": {
+        "itemsList": [
+            {
+                "url": '/patterns/hub-and-spoke/examples/hub/',
+                "text": 'Back'
+            }
+        ]
+    }
+} %}
+
+{% block main %}
+    <h1 class="ons-u-mt-m">Household accommodation</h1>
+    {{
+        onsSummary({
+            "summaries": [
+                    {
+                        "groups": [
+                            {
+                            "headers":["Question", "Answer given", "Change answer"],
+                            "rows": [
+                                {
+                                    "rowTitle": "What type of accommodation is 68 Abingdon Road, Goathill?",
+                                    "rowItems": [
+                                        {
+                                            "valueList": [
+                                                {
+                                                    "text": "Whole house or bungalow"
+                                                }
+                                            ],
+                                            "actions": [
+                                                {
+                                                    "text": "Change",
+                                                    "ariaLabel": "Change answer",
+                                                    "url": "#0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rowTitle": "Are all the rooms in this accommodation, including the kitchen, bathroom and toilet, behind a door that only this household can use?",
+                                    "rowItems": [
+                                        {
+                                            "valueList": [
+                                                {
+                                                    "text": "Yes"
+                                                }
+                                            ],
+                                            "actions": [
+                                                {
+                                                    "text": "Change",
+                                                    "ariaLabel": "Change answer",
+                                                    "url": "#0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rowTitle": "How many bedrooms are available for use only by this household?",
+                                    "rowItems": [
+                                        {
+                                            "valueList": [
+                                                {
+                                                    "text": "3"
+                                                }
+                                            ],
+                                            "actions": [
+                                                {
+                                                    "text": "Change",
+                                                    "ariaLabel": "Change answer",
+                                                    "url": "#0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rowTitle": "What type of central heating does have?",
+                                    "rowItems": [
+                                        {
+                                            "valueList": [
+                                                {
+                                                    "text": "Mains gas"
+                                                }
+                                            ],
+                                            "actions": [
+                                                {
+                                                    "text": "Change",
+                                                    "ariaLabel": "Change answer",
+                                                    "url": "#0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rowTitle": "Does your household own or rent 68 Abingdon Road, Goathill?",
+                                    "rowItems": [
+                                        {
+                                            "valueList": [
+                                                {
+                                                    "text": "Owns outright"
+                                                }
+                                            ],
+                                            "actions": [
+                                                {
+                                                    "text": "Change",
+                                                    "ariaLabel": "Change answer",
+                                                    "url": "#0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "rowTitle": "In total, how many cars or vans are owned, or available for use, by members of this household?",
+                                    "rowItems": [
+                                        {
+                                            "valueList": [
+                                                {
+                                                    "text": "2"
+                                                }
+                                            ],
+                                            "actions": [
+                                                {
+                                                    "text": "Change",
+                                                    "ariaLabel": "Change answer",
+                                                    "url": "#0"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        })
+    }}
+    {{
+        onsButton({
+            "text": 'Continue',
+            "classes": 'ons-u-mt-xl'
+        })
+    }}
+{% endblock %}

--- a/src/patterns/pages/hub-and-spoke/index.njk
+++ b/src/patterns/pages/hub-and-spoke/index.njk
@@ -8,18 +8,53 @@ title: Hub and Spoke
 {% from "components/panel/_macro.njk" import onsPanel %}
 +++
 
-{{
-    onsPanel({
-        "body": "This pattern requires documentation."
-    })
-}}
+The hub and spoke pattern lets users complete a study in sections, in their preferred order.
 
-## Hub – partially completed
+## When to use this pattern
+Use this pattern when you need the user to answer a lot of study questions. It helps prevent the user feeling overwhelmed by splitting the questions up into sections which they can start in any order.
+
+## When not to use this pattern
+Do not use this pattern for small studies with only a few questions.
+
+## How to use this pattern
+When a study has a lot of questions, you should organise the questions into manageable, related sections.
+
+You should show the hub when the user has completed the first section of the study.
+
+### Hub – partially completed
+The hub uses the [summary component](/components/summary#hub) to let the user see their progress through the study, marking each section as they complete it.
+
+It also lets the user start sections in any order, as well as allowing them to leave a section and continue with it later.
+
+The user can view a summary of their answers once a section is complete.
+
+The “continue” button should always take the user to the next incomplete section.
 {{
     patternlibExample({ "path": "patterns/pages/hub-and-spoke/examples/hub/index.njk"})
 }}
 
-## Hub – completed
+### Spoke – view answers
+The user can choose to view a summary of all their answers to any completed section. They can [check their answers](/patterns/check-answers) and make any changes.
+{{
+    patternlibExample({ "path": "patterns/pages/hub-and-spoke/examples/spoke-summary/index.njk"})
+}}
+
+### Spoke – start a section
+The user can choose to start any section (spoke) from the hub. Every section should start with an introduction page telling the user what they will need to know in order to answer the required questions in the section.
+{{
+    patternlibExample({ "path": "patterns/pages/hub-and-spoke/examples/spoke-start/index.njk"})
+}}
+
+## Spoke – continue a section
+Once the user has started a section, they can choose to return to the hub from any page.
+
+The hub lets the user continue the section from where they left it. A panel lets the user go to the start of the section.
+{{
+    patternlibExample({ "path": "patterns/pages/hub-and-spoke/examples/spoke-continue/index.njk"})
+}}
+
+### Hub – completed
+Once all the sections of the study are complete, the user can submit the study.
 {{
     patternlibExample({ "path": "patterns/pages/hub-and-spoke/examples/hub-complete/index.njk"})
 }}

--- a/src/patterns/pages/hub-and-spoke/index.njk
+++ b/src/patterns/pages/hub-and-spoke/index.njk
@@ -14,8 +14,14 @@ title: Hub and Spoke
     })
 }}
 
+## Hub – partially completed
 {{
     patternlibExample({ "path": "patterns/pages/hub-and-spoke/examples/hub/index.njk"})
+}}
+
+## Hub – completed
+{{
+    patternlibExample({ "path": "patterns/pages/hub-and-spoke/examples/hub-complete/index.njk"})
 }}
 
 ## Help improve this pattern


### PR DESCRIPTION
### What is the context of this PR?
The hub example in the hub and spoke pattern incorrectly shows an information panel under the heading.  This removes that panel, as well as adding a 'complete' example which includes a warning panel. This also adds two spoke examples which are linked to within the partially complete hub example.

### How to review
Check hub examples and links to spoke examples.
