### PR TITLE
Fix jinja compatability issue with radio 'other' selector

### DIFF
--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -21,10 +21,15 @@
             {% endif %}
             <span class="ons-radios__item{{ " ons-radios__item--no-border" if params.borderless }}">
                 <span class="ons-radio{{ " ons-radio--no-border" if params.borderless }}">
+                {%  if radio.other is defined and radio.other and radio.other.selectAllChildren is defined and radio.other.selectAllChildren == true %}
+                    {% set selectAllClass = ' ons-js-select-all-children' %}
+                {% else %}
+                    {% set selectAllClass = '' %}
+                {% endif %}
                     <input
                             type="radio"
                             id="{{ radio.id }}"
-                            class="ons-radio__input ons-js-radio{{ ' ' + radio.classes if radio.classes else '' }}{{ ' ons-js-other' if radio.other else '' }}{{ ' ons-js-select-all-children' if radio.other.selectAllChildren == true else '' }}"
+                            class="ons-radio__input ons-js-radio{{ ' ' + radio.classes if radio.classes else '' }}{{ ' ons-js-other' if radio.other else '' }}{{ selectAllClass }}"
                             value="{{ radio.value }}"
                             name="{{ params.name }}"
                             {% if (radio.checked is defined and radio.checked) or (params.value is defined and params.value == radio.value) %} checked {% endif %}
@@ -39,7 +44,6 @@
                             "classes": "ons-radio__label " + radio.label.classes | default(''),
                             "description": radio.label.description
                         }) }}
-
                     {% if radio.other is defined and radio.other %}
                         {% set otherType = radio.other.otherType | default('input') %}
                         <span class="ons-radio__other{{ " " + 'ons-radio__other--open' if radio.other.open else "" }}" id="{{ radio.id }}-other-wrap">


### PR DESCRIPTION
### What is the context of this PR?
Jinja compatibility Issue with `radio.other.selectAllchildren`  inside `radios/_macro.njk`.

The 'other' property wasn't being checked before checking for `selectAllChildren` which jinja doesn't like.

### How to review
Test it works.