### PR TITLE
Fix Jinja compatability issue with checkboxes

### DIFF
--- a/src/components/checkboxes/_macro.njk
+++ b/src/components/checkboxes/_macro.njk
@@ -40,9 +40,9 @@
                 {% endif %}
                 {% if checkbox.other is defined and checkbox.other %}
                     {% set otherClass = " ons-js-other" %}
-                {% endif %}
-                {% if checkbox.other.selectAllChildren is defined and checkbox.other.selectAllChildren == true %}
-                    {% set otherClass = otherClass + " ons-js-select-all-children" %}
+                    {% if checkbox.other.selectAllChildren is defined and checkbox.other.selectAllChildren == true %}
+                        {% set otherClass = otherClass + " ons-js-select-all-children" %}
+                    {% endif %}
                 {% endif %}
                 <span class="ons-checkboxes__item{{ " ons-checkboxes__item--no-border" if params.borderless }}">
                     {% set config = {


### PR DESCRIPTION
### What is the context of this PR?
Jinja compatibility Issue with `checkbox.other.selectAllchildren`  inside `checkboxes/_macro.njk`.

The 'other' property wasn't being checked before checking for `selectAllChildren` which jinja doesn't like.

### How to review
Test it works.
