### PR TITLE
Remove related links import to fix CDN build error

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -47,7 +47,6 @@
 @import '../components/radios/radio';
 @import '../components/radios/radios';
 @import '../components/related-content/related-content';
-@import '../components/related-links/related-links';
 @import '../components/relationships/relationships';
 @import '../components/search/search';
 @import '../components/section-navigation/section-navigation';


### PR DESCRIPTION
### What is the context of this PR?
Related links has been removed so this import is causing a CDN error in the latest release

![image](https://user-images.githubusercontent.com/42928680/142623687-c7674bea-6063-486b-8435-0613bf1a4b00.png)


### How to review
Check changes make sense
