### PR TITLE
Remove the `ncp` dependency from `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "mdn-polyfills": "^5.14.0",
     "minimist": "^1.2.5",
     "mocha": "8.1.3",
-    "ncp": "^2.0.0",
     "normalize.css": "^8.0.1",
     "nunjucks": "^3.2.3",
     "postcss": "^8.3.5",


### PR DESCRIPTION
### What is the context of this PR?
The `ncp` dependency was removed from the `yarn.lock` file but somehow was not removed in the committed `package.json` file. Some command which is being ran automatically seems to be modifying the `yarn.lock` file dirtying the local copy of the repository which is preventing the npm publish task from working because the git command fails with:

> npm ERR! Git working directory not clean.
> npm ERR! M yarn.lock

### How to review
- Try running the npm publish task again.