### PR TITLE
Added more config to onsQuestion

### DIFF
--- a/src/components/breadcrumbs/_macro-options.md
+++ b/src/components/breadcrumbs/_macro-options.md
@@ -1,9 +1,9 @@
-| Name      | Type                   | Required | Description                                                     |
-| --------- | ---------------------- | -------- | --------------------------------------------------------------- |
-| classes   | string                 | false    | Custom classes to add to the breadcrumbs                        |
-| ariaLabel | string                 | false    | The label added to the `nav` element. Defaults to `Breadcrumbs` |
-| id        | string                 | false    | The ID added to the `nav` element                               |
-| itemsList | Array<BreadcrumbsItem> | true     | An array of items to show in the breadcrumbs list               |
+| Name      | Type                     | Required | Description                                                     |
+| --------- | ------------------------ | -------- | --------------------------------------------------------------- |
+| classes   | string                   | false    | Custom classes to add to the breadcrumbs                        |
+| ariaLabel | string                   | false    | The label added to the `nav` element. Defaults to `Breadcrumbs` |
+| id        | string                   | false    | The ID added to the `nav` element                               |
+| itemsList | `Array<BreadcrumbsItem>` | true     | An array of items to show in the breadcrumbs list               |
 
 ## BreadcrumbsItem
 | Name | Type | Required | Description |

--- a/src/components/collapsible/_macro-options.md
+++ b/src/components/collapsible/_macro-options.md
@@ -4,7 +4,7 @@
 | title             | string              | true     | The title for the collapsible                                                            |
 | titleTag          | string              | false    | The HTML tag to wrap the title text in. Will default to a `div`                          |
 | content           | string              | true     | HTML content for the collapsible                                                         |
-| button            | `CollapsibleButton` | false    | Settings for the close button. If not specified button will not render                   |
+| button            | `CollapsibleButton` | true     | Settings for the close button. If not specified button will not render                   |
 | classes           | string              | false    | Classes to add to the collapsible element                                                |
 | saveState         | boolean             | false    | Allows saving of collapsible state (open or closed) locally                              |
 | attributes        | object              | false    | HTML attributes (for example, data attributes) to add to the collapsible element         |

--- a/src/components/collapsible/_macro.njk
+++ b/src/components/collapsible/_macro.njk
@@ -45,19 +45,17 @@
                 {{ params.content | safe }}{{ caller() if caller }}
             {% else %}
                 {{ params.content | safe }}{{ caller() if caller }}
-                {% if params.isAccordion != true %}
-                    {{
-                        onsButton({
-                            "type": "button",
-                            "text": params.button.close | default ('Hide this'),
-                            "buttonContext": (params.button.context | default(params.title)) + " " + params.button.contextSuffix | default("content"),
-                            "classes": "ons-js-collapsible-button ons-u-d-no " + (params.button.classes | default("ons-btn--secondary")),
-                            "innerClasses": "ons-js-collapsible-button-inner",
-                            "variants": "small",
-                            "attributes": params.button.attributes
-                        })
-                    }}
-                {% endif %}
+                {{
+                    onsButton({
+                        "type": "button",
+                        "text": params.button.close | default ('Hide this'),
+                        "buttonContext": (params.button.context | default(params.title)) + " " + params.button.contextSuffix | default("content"),
+                        "classes": "ons-js-collapsible-button ons-u-d-no " + (params.button.classes | default("ons-btn--secondary")),
+                        "innerClasses": "ons-js-collapsible-button-inner",
+                        "variants": "small",
+                        "attributes": params.button.attributes
+                    })
+                }}
             {% endif %}
         </div>
     </div>

--- a/src/components/collapsible/_macro.njk
+++ b/src/components/collapsible/_macro.njk
@@ -45,12 +45,12 @@
                 {{ params.content | safe }}{{ caller() if caller }}
             {% else %}
                 {{ params.content | safe }}{{ caller() if caller }}
-                {% if params.button is defined and params.button and params.button.close is defined and params.button.close and params.isAccordion != true %}
+                {% if params.isAccordion != true %}
                     {{
                         onsButton({
                             "type": "button",
-                            "text": params.button.close,
-                            "buttonContext": (params.button.context | default(params.title)) + " " + params.button.contextSuffix,
+                            "text": params.button.close | default ('Hide this'),
+                            "buttonContext": (params.button.context | default(params.title)) + " " + params.button.contextSuffix | default("content"),
                             "classes": "ons-js-collapsible-button ons-u-d-no " + (params.button.classes | default("ons-btn--secondary")),
                             "innerClasses": "ons-js-collapsible-button-inner",
                             "variants": "small",

--- a/src/components/fieldset/_macro.njk
+++ b/src/components/fieldset/_macro.njk
@@ -14,14 +14,14 @@
             >
                 <legend class="ons-fieldset__legend{% if params.legendIsQuestionTitle is defined and params.legendIsQuestionTitle %} ons-u-mb-no{% endif %}{% if params.legendClasses is defined and params.legendClasses %} {{ params.legendClasses }}{% endif %}">
                     {% if params.legendIsQuestionTitle %}
-                        <h1 id="fieldset-legend-title" class="ons-fieldset__legend-title {% if params.legendTitleClasses is defined and params.legendTitleClasses %}{{ params.legendTitleClasses }}{% endif %}">
+                        <h1 id="fieldset-legend-title" class="ons-fieldset__legend-title ons-u-mb-m{% if params.legendTitleClasses is defined and params.legendTitleClasses %} {{ params.legendTitleClasses }}{% endif %}">
                             {{- params.legend | safe -}}
                         </h1>
                     {% else %}
                         {{- params.legend | safe -}}
                     {% endif %}
                     {% if params.description is defined and params.description %}
-                        <div class="ons-fieldset__description {% if params.legendIsQuestionTitle %}ons-fieldset__description--title{% endif %}">{{ params.description | safe }}</div>
+                        <div class="ons-fieldset__description{% if params.legendIsQuestionTitle %} ons-fieldset__description--title ons-u-mb-m{% endif %}">{{ params.description | safe }}</div>
                     {% endif %}
                 </legend>
                 {{ caller() }}

--- a/src/components/lists/_macro.njk
+++ b/src/components/lists/_macro.njk
@@ -13,91 +13,89 @@
         {% set otherClasses = '' %}
     {% endif %}
 
-    {% if params.element is defined and params.element == 'ol' %}
-        {% if listLength < 2 and params.element == 'ol' %}
-            {% set listEl = 'p' %}
-        {% else %}
-            {% set listEl = params.element | lower %}
-        {% endif %}
+    {% if params.element is defined and params.element %}
+        {% set listEl = params.element | lower %}
     {% else %}
         {% set listEl = 'ul' %}
     {% endif %}
 
-    <{{listEl}} {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %}class="{% if listLength > 1 %}ons-list{% endif %}{% if params.classes is defined and params.classes %} {{ params.classes -}}{% endif %}{% if params.variants is defined and params.variants %}{% if params.variants is not string %}{% for variant in params.variants %} ons-list--{{ variant }}{% endfor %}{% else %} ons-list--{{ params.variants }}{% endif %}{% endif %}{% if otherClasses %} {{ otherClasses -}}{% endif %}">
-        {%- for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) -%}
-            {%- if params.element == 'ol' and listLength < 2 -%}
-            {%- else -%}
-            <li class="ons-list__item{% if item.listClasses is defined and item.listClasses %} {{ item.listClasses }}{% endif %}"{% if item.current is defined and item.current %} aria-current="true"{% endif %}>
-            {%- endif -%}
+    {% if (params.element is defined and params.element == 'ol') and listLength < 2 %}
+        <p {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %}{% if params.classes is defined and params.classes %} class="{{ params.classes -}}"{% endif %}>
+            {%- for item in params.itemsList -%}
+                {{ item.text }}
+            {%- endfor -%}
+        </p>
+    {% else %}
+        <{{listEl}} {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %}class="{% if listLength > 1 %}ons-list{% endif %}{% if params.classes is defined and params.classes %} {{ params.classes -}}{% endif %}{% if params.variants is defined and params.variants %}{% if params.variants is not string %}{% for variant in params.variants %} ons-list--{{ variant }}{% endfor %}{% else %} ons-list--{{ params.variants }}{% endif %}{% endif %}{% if otherClasses %} {{ otherClasses -}}{% endif %}">
+            {%- for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) -%}
+                <li class="ons-list__item{% if item.listClasses is defined and item.listClasses %} {{ item.listClasses }}{% endif %}"{% if item.current is defined and item.current %} aria-current="true"{% endif %}>
 
-                {% set itemText = item.text %}
+                    {% set itemText = item.text %}
 
-                {% if params.itemsList[0] is defined and item.iconType is defined and item.iconType %}
-                    {% set iconType = item.iconType if item.iconType else '' %}
-                {% endif %}
+                    {% if params.itemsList[0] is defined and item.iconType is defined and item.iconType %}
+                        {% set iconType = item.iconType if item.iconType else '' %}
+                    {% endif %}
 
-                {# For Craft support we also support title and navigation title #}
-                {% if item.navigationTitle is defined and item.navigationTitle %}
-                    {% set itemText = item.navigationTitle %}
-                {% elif item.title is defined and item.title %}
-                    {% set itemText = item.title %}
-                {% endif %}
+                    {# For Craft support we also support title and navigation title #}
+                    {% if item.navigationTitle is defined and item.navigationTitle %}
+                        {% set itemText = item.navigationTitle %}
+                    {% elif item.title is defined and item.title %}
+                        {% set itemText = item.title %}
+                    {% endif %}
 
-                {%- if item.index is defined and item.index or item.prefix is defined and item.prefix or (params.iconPosition is defined and params.iconPosition == 'before') -%}
-                    <span class="ons-list__prefix"{% if listEl != 'ol' %} aria-hidden="true"{% endif %}>
-                    {%- if item.prefix is defined and item.prefix -%}
-                        {{- item.prefix -}}.
-                    {%- elif (item.index is defined and item.index and listEl != 'ol') or (item.index is defined and item.index and listEl == 'ol' and 'bare' in variants) -%}
-                        {{- loop.index -}}.
-                    {% elif params.iconPosition is defined and params.iconPosition == 'before' %}
-                        {% from "components/icons/_macro.njk" import onsIcon %}
-                        {{
-                            onsIcon({
-                                "iconType": iconType,
-                                "iconSize": params.iconSize
-                            })
-                        }}
+                    {%- if item.index is defined and item.index or item.prefix is defined and item.prefix or (params.iconPosition is defined and params.iconPosition == 'before') -%}
+                        <span class="ons-list__prefix"{% if listEl != 'ol' %} aria-hidden="true"{% endif %}>
+                        {%- if item.prefix is defined and item.prefix -%}
+                            {{- item.prefix -}}.
+                        {%- elif (item.index is defined and item.index and listEl != 'ol') or (item.index is defined and item.index and listEl == 'ol' and 'bare' in variants) -%}
+                            {{- loop.index -}}.
+                        {% elif params.iconPosition is defined and params.iconPosition == 'before' %}
+                            {% from "components/icons/_macro.njk" import onsIcon %}
+                            {{
+                                onsIcon({
+                                    "iconType": iconType,
+                                    "iconSize": params.iconSize
+                                })
+                            }}
+                        {%- endif -%}
+                        </span>
                     {%- endif -%}
-                    </span>
-                {%- endif -%}
-                {%- if item.url is defined and item.url and item.current != true -%}
-                    {%- if item.external is defined and item.external -%}
-                        {% from "components/external-link/_macro.njk" import onsExternalLink %}
-                        {{
-                            onsExternalLink({
-                                "url": item.url,
-                                "linkText": itemText
-                            })
-                        }}
+                    {%- if item.url is defined and item.url and item.current != true -%}
+                        {%- if item.external is defined and item.external -%}
+                            {% from "components/external-link/_macro.njk" import onsExternalLink %}
+                            {{
+                                onsExternalLink({
+                                    "url": item.url,
+                                    "linkText": itemText
+                                })
+                            }}
+                        {%- else -%}
+                            <a href="{{ item.url }}" class="ons-list__link {% if item.variant == 'inPageLink' %}ons-js-inpagelink {% endif %} {{ item.classes }}"{% if item.index is defined and item.index %} data-qa="list-item-{{ loop.index }}"{% endif %}{% if item.target is defined and item.target %} target="{{ item.target }}"{% endif %}{% if item.rel is defined and item.rel %} rel="{{ item.rel }}"{% endif %}>
+                                {%- if item.prefix is defined and item.prefix -%}<span class="ons-u-vh">{{- item.prefix -}}</span>{%- endif -%} {{- itemText | safe -}}
+                                {%- if item.target is defined and item.target == "_blank" -%}<span class="ons-u-vh">{{- item.screenreaderMessage | default("this link will open in a new tab") -}}</span>{%- endif -%}
+                            </a>
+                        {%- endif -%}
                     {%- else -%}
-                        <a href="{{ item.url }}" class="ons-list__link {% if item.variant == 'inPageLink' %}ons-js-inpagelink {% endif %} {{ item.classes }}"{% if item.index is defined and item.index %} data-qa="list-item-{{ loop.index }}"{% endif %}{% if item.target is defined and item.target %} target="{{ item.target }}"{% endif %}{% if item.rel is defined and item.rel %} rel="{{ item.rel }}"{% endif %}>
-                            {%- if item.prefix is defined and item.prefix -%}<span class="ons-u-vh">{{- item.prefix -}}</span>{%- endif -%} {{- itemText | safe -}}
-                            {%- if item.target is defined and item.target == "_blank" -%}<span class="ons-u-vh">{{- item.screenreaderMessage | default("this link will open in a new tab") -}}</span>{%- endif -%}
-                        </a>
+                        {{- itemText | safe -}}
                     {%- endif -%}
-                {%- else -%}
-                    {{- itemText | safe -}}
-                {%- endif -%}
-                {%- if item.suffix is defined and item.suffix or (params.iconPosition is defined and params.iconPosition == 'after') -%}
-                    <span class="ons-list__suffix"{% if listEl != 'ol' %} aria-hidden="true"{% endif %}>
-                    {%- if item.suffix is defined and item.suffix -%}
-                        {{- item.suffix -}}
-                    {%- elif (item.index is defined and item.index and listEl != 'ol') or (item.index is defined and item.index and listEl == 'ol' and 'bare' in variants) -%}
-                        {{- loop.index -}}
-                    {% elif params.iconPosition is defined and params.iconPosition == 'after' %}
-                        {% from "components/icons/_macro.njk" import onsIcon %}
-                        {{
-                            onsIcon({
-                                "iconType": iconType,
-                                "iconSize": params.iconSize
-                            })
-                        }}
-                    {%- endif -%} </span>
-                {%- endif -%}
-            {%- if params.element == 'ol' and listLength < 2 -%}
-            {%- else -%}
-            </li>
-            {%- endif -%}
-        {%- endfor -%}
-    </{{listEl}}>
+                    {%- if item.suffix is defined and item.suffix or (params.iconPosition is defined and params.iconPosition == 'after') -%}
+                        <span class="ons-list__suffix"{% if listEl != 'ol' %} aria-hidden="true"{% endif %}>
+                        {%- if item.suffix is defined and item.suffix -%}
+                            {{- item.suffix -}}
+                        {%- elif (item.index is defined and item.index and listEl != 'ol') or (item.index is defined and item.index and listEl == 'ol' and 'bare' in variants) -%}
+                            {{- loop.index -}}
+                        {% elif params.iconPosition is defined and params.iconPosition == 'after' %}
+                            {% from "components/icons/_macro.njk" import onsIcon %}
+                            {{
+                                onsIcon({
+                                    "iconType": iconType,
+                                    "iconSize": params.iconSize
+                                })
+                            }}
+                        {%- endif -%} </span>
+                    {%- endif -%}
+                </li>
+            {%- endfor -%}
+        </{{listEl}}>
+    {% endif %}
 {% endmacro %}

--- a/src/components/lists/_macro.njk
+++ b/src/components/lists/_macro.njk
@@ -13,15 +13,22 @@
         {% set otherClasses = '' %}
     {% endif %}
 
-    {% if params.element is defined and params.element %}
-        {% set listEl = params.element | lower %}
+    {% if params.element is defined and params.element == 'ol' %}
+        {% if listLength < 2 and params.element == 'ol' %}
+            {% set listEl = 'p' %}
+        {% else %}
+            {% set listEl = params.element | lower %}
+        {% endif %}
     {% else %}
         {% set listEl = 'ul' %}
     {% endif %}
 
-    <{{listEl}} {% if params.id is defined and params.id %}id="{{ params.id }} "{% endif %}class="ons-list{% if params.classes is defined and params.classes %} {{ params.classes -}}{% endif %}{% if params.variants is defined and params.variants %}{% if params.variants is not string %}{% for variant in params.variants %} ons-list--{{ variant }}{% endfor %}{% else %} ons-list--{{ params.variants }}{% endif %}{% endif %}{% if otherClasses %} {{ otherClasses -}}{% endif %}">
+    <{{listEl}} {% if params.id is defined and params.id %}id="{{ params.id }}"{% endif %}class="{% if listLength > 1 %}ons-list{% endif %}{% if params.classes is defined and params.classes %} {{ params.classes -}}{% endif %}{% if params.variants is defined and params.variants %}{% if params.variants is not string %}{% for variant in params.variants %} ons-list--{{ variant }}{% endfor %}{% else %} ons-list--{{ params.variants }}{% endif %}{% endif %}{% if otherClasses %} {{ otherClasses -}}{% endif %}">
         {%- for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) -%}
-                <li class="ons-list__item{% if item.listClasses is defined and item.listClasses %} {{ item.listClasses }}{% endif %}"{% if item.current is defined and item.current %} aria-current="true"{% endif %}>
+            {%- if params.element == 'ol' and listLength < 2 -%}
+            {%- else -%}
+            <li class="ons-list__item{% if item.listClasses is defined and item.listClasses %} {{ item.listClasses }}{% endif %}"{% if item.current is defined and item.current %} aria-current="true"{% endif %}>
+            {%- endif -%}
 
                 {% set itemText = item.text %}
 
@@ -87,7 +94,10 @@
                         }}
                     {%- endif -%} </span>
                 {%- endif -%}
+            {%- if params.element == 'ol' and listLength < 2 -%}
+            {%- else -%}
             </li>
+            {%- endif -%}
         {%- endfor -%}
     </{{listEl}}>
 {% endmacro %}

--- a/src/components/lists/_macro.njk
+++ b/src/components/lists/_macro.njk
@@ -13,17 +13,15 @@
         {% set otherClasses = '' %}
     {% endif %}
 
-    {% if listLength < 2 %}
-        {% set listEl = 'p' %}
-    {% elif params.element is defined and params.element %}
+    {% if params.element is defined and params.element %}
         {% set listEl = params.element | lower %}
     {% else %}
         {% set listEl = 'ul' %}
     {% endif %}
 
-    <{{listEl}} {% if params.id is defined and params.id %}id="{{ params.id }} "{% endif %}class="{% if listLength > 1 %}ons-list{% endif %}{% if params.classes is defined and params.classes %} {{ params.classes -}}{% endif %}{% if params.variants is defined and params.variants %}{% if params.variants is not string %}{% for variant in params.variants %} ons-list--{{ variant }}{% endfor %}{% else %} ons-list--{{ params.variants }}{% endif %}{% endif %}{% if otherClasses %} {{ otherClasses -}}{% endif %}">
+    <{{listEl}} {% if params.id is defined and params.id %}id="{{ params.id }} "{% endif %}class="ons-list{% if params.classes is defined and params.classes %} {{ params.classes -}}{% endif %}{% if params.variants is defined and params.variants %}{% if params.variants is not string %}{% for variant in params.variants %} ons-list--{{ variant }}{% endfor %}{% else %} ons-list--{{ params.variants }}{% endif %}{% endif %}{% if otherClasses %} {{ otherClasses -}}{% endif %}">
         {%- for item in (params.itemsList if params.itemsList is iterable else params.itemsList.items()) -%}
-            {% if listLength > 1 %}<li class="ons-list__item{% if item.listClasses is defined and item.listClasses %} {{ item.listClasses }}{% endif %}"{% if item.current is defined and item.current %} aria-current="true"{% endif %}>{% endif %}
+                <li class="ons-list__item{% if item.listClasses is defined and item.listClasses %} {{ item.listClasses }}{% endif %}"{% if item.current is defined and item.current %} aria-current="true"{% endif %}>
 
                 {% set itemText = item.text %}
 
@@ -89,7 +87,7 @@
                         }}
                     {%- endif -%} </span>
                 {%- endif -%}
-            {% if listLength > 1 %}</li>{%- endif -%}
+            </li>
         {%- endfor -%}
     </{{listEl}}>
 {% endmacro %}

--- a/src/components/question/_macro-options.md
+++ b/src/components/question/_macro-options.md
@@ -31,10 +31,11 @@
 
 ## Lists
 
-| Name        | Type               | Required | Description                             |
-| ----------- | ------------------ | -------- | --------------------------------------- |
-| listHeading | string             | false    | A heading for each include/exclude list |
-| itemsList   | `Array<ItemsList>` | true     | An array of list items                  |
+| Name            | Type               | Required | Description                             |
+| --------------- | ------------------ | -------- | --------------------------------------- |
+| listHeading     | string             | false    | A heading for each include/exclude list |
+| listLeadingLine | string             | false    | A leading line for each list            |
+| itemsList       | `Array<ItemsList>` | true     | An array of list items                  |
 
 ## ItemsList
 

--- a/src/components/question/_macro-options.md
+++ b/src/components/question/_macro-options.md
@@ -1,10 +1,51 @@
-| Name                  | Type    | Required | Description                                                                                               |
-| --------------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------- |
-| title                 | string  | true     | The question                                                                                              |
-| description           | string  | false    | The question description                                                                                  |
-| instruction           | string  | false    | An interviewer instruction                                                                                |
-| id                    | string  | false    | ID for the wrapping element                                                                               |
-| classes               | string  | false    | Classes to add the wrapping element                                                                       |
-| attributes            | object  | false    | HTML attributes (for example, data attributes) to add to the wrapping element                             |
-| readDescriptionFirst  | boolean | false    | If set to `true` will screen readers will read out question description first                             |
-| legendIsQuestionTitle | boolean | false    | Creates a `h1` inside the legend [further information](/components/fieldset#legend-as-pagequestion-title) |
+| Name                  | Type                                           | Required | Description                                                                                                                        |
+| --------------------- | ---------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| title                 | string                                         | true     | The question heading                                                                                                               |
+| description           | string                                         | false    | The question description to be used to provide added context to the question. This can be a string of HTML.                        |
+| instruction           | string                                         | false    | An interviewer instruction. This can be a string of HTML.                                                                          |
+| definition            | `<Object>QuestionDefinition`                   | false    | An object for the question definition. To be used to define a word or acronym that is in the question.                             |
+| guidance              | `<Object>QuestionGuidance`                     | false    | An object for the question guidance. To be used to state what should be included or excluded from the answer.                      |
+| justification         | `<Object>QuestionJustification`                | false    | The question justification. To be used to explain why a question is being asked if there is evidence that users want to know this. |
+| submitButton          | string                                         | false    | The question justification. To be used to explain why a question is being asked if there is evidence that users want to know this. |
+| submitButton          | `<Object>Button` [_(ref)_](/components/button) | true     | Settings for the submit button.                                                                                                    |
+| id                    | string                                         | false    | ID for the wrapping element                                                                                                        |
+| classes               | string                                         | false    | Classes to add the wrapping element                                                                                                |
+| attributes            | object                                         | false    | HTML attributes (for example, data attributes) to add to the wrapping element                                                      |
+| readDescriptionFirst  | boolean                                        | false    | If set to `true` will screen readers will read out question description first                                                      |
+| legendIsQuestionTitle | boolean                                        | false    | Creates a `h1` inside the legend [further information](/components/fieldset#legend-as-pagequestion-title)                          |
+
+## QuestionDefinition
+
+| Name    | Type   | Required | Description                                                                                                            |
+| ------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| id      | string | false    | The `id` of the question definition collapsible.                                                                       |
+| title   | string | false    | The title of the question definition collapsible. Should be written as statement, for example, “What we mean by “NVQ”” |
+| content | string | false    | The content of the question definition collapsible. This can be a string of HTML.                                      |
+
+## QuestionGuidance
+
+| Name    | Type           | Required | Description                                                                                         |
+| ------- | -------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| content | string         | false    | The contents of the question guidance panel. This can be a string of HTML.                          |
+| lists   | `Array<Lists>` | false    | An array of lists an sub-headings used to list what should be included or excluded from the answer. |
+
+## Lists
+
+| Name        | Type               | Required | Description                             |
+| ----------- | ------------------ | -------- | --------------------------------------- |
+| listHeading | string             | false    | A heading for each include/exclude list |
+| itemsList   | `Array<ItemsList>` | true     | An array of list items                  |
+
+## ItemsList
+
+| Name | Type   | Required | Description                       |
+| ---- | ------ | -------- | --------------------------------- |
+| text | string | true     | Text to display for the list item |
+
+## QuestionJustification
+
+| Name    | Type   | Required | Description                                                                                                                  |
+| ------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| id      | string | false    | The `id` of the question justification collapsible.                                                                          |
+| title   | string | false    | The title of the question justification collapsible. Should be written as statement, for example, “Why we ask this question” |
+| content | string | false    | The content of the question definition collapsible. This can be a string of HTML.                                            |

--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -62,7 +62,7 @@
 
     <div
         {% if params.id is defined and params.id %} id="{{ params.id }}"{% endif %}
-        class="ons-question ons-u-mb-xl{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
+        class="ons-question ons-u-mb-l{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
         {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
     >
         {% if params.legendIsQuestionTitle is defined and params.legendIsQuestionTitle %}

--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -47,7 +47,7 @@
             {% if params.guidance.content %}
                 {{ params.guidance.content | safe }}
             {% endif %}
-            {%- for item in (params.guidance.list if params.guidance.list is iterable else params.guidance.list.items()) -%}
+            {%- for item in params.guidance.list -%}
                 {% if item.title %}
                     <h2 class="ons-u-fs-r--b">{{ item.title }}</h2>
                 {% endif %}
@@ -57,7 +57,7 @@
                         "itemsList": item.itemsList
                     })
                 }}
-            {% endfor %}
+            {% endfor -%}
         {% endcall %}
     {% endset %}
 

--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -43,20 +43,22 @@
             {% if params.guidance.content is defined and params.guidance.content %}
                 {{ params.guidance.content | safe }}
             {% endif %}
-            {%- for item in params.guidance.lists -%}
-                {% if item.listHeading %}
-                    <h2 class="ons-u-fs-r--b">{{ item.listHeading }}</h2>
-                {% endif %}
-                {% if item.listLeadingLine %}
-                    <p>{{ item.listLeadingLine }}</h2>
-                {% endif %}
-                {% from "components/lists/_macro.njk" import onsList %}
-                {{
-                    onsList({
-                        "itemsList": item.itemsList
-                    })
-                }}
-            {% endfor -%}
+            {% if params.guidance.lists is defined and params.guidance.lists %}
+                {%- for item in params.guidance.lists -%}
+                    {% if item.listHeading is defined and item.listHeading %}
+                        <h2 class="ons-u-fs-r--b">{{ item.listHeading }}</h2>
+                    {% endif %}
+                    {% if item.listLeadingLine is defined and item.listLeadingLine %}
+                        <p>{{ item.listLeadingLine }}</h2>
+                    {% endif %}
+                    {% from "components/lists/_macro.njk" import onsList %}
+                    {{
+                        onsList({
+                            "itemsList": item.itemsList
+                        })
+                    }}
+                {% endfor -%}
+            {% endif -%}
         {% endcall %}
     {% endset %}
 

--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -11,7 +11,7 @@
         {% if params.readDescriptionFirst is defined and params.readDescriptionFirst == true %} 
             <div aria-hidden="true" {% if params.legendIsQuestionTitle is not defined %}class="ons-question__description"{% endif %}>{{ params.description | safe }}</div>
         {% elif params.legendIsQuestionTitle is not defined %}
-            <div class="ons-question__description">{{ params.description | safe }}</div>
+            <div class="ons-question__description ons-u-mb-m">{{ params.description | safe }}</div>
         {% else %}
             {{ params.description | safe }}
         {% endif %}
@@ -21,12 +21,52 @@
         <div class="ons-question__instruction ons-u-mb-s">{{ params.instruction | safe }}</div>
     {% endset %}
 
+    {% set justificationHtml %}
+        {{ params.justification.content | safe }}
+    {% endset %}
+
+    {% set questionDefinition %}
+        {% from "components/collapsible/_macro.njk" import onsCollapsible %}
+        {% call onsCollapsible({
+            "id": params.definition.id,
+            "titleTag": 'h2',
+            "classes": 'ons-u-mb-m',
+            "title": params.definition.title
+        }) %}
+            {% if params.definition.content %}
+                {{ params.definition.content | safe }}
+            {% endif %}
+        {% endcall %}
+    {% endset %}
+
+    {% set questionGuidance %}
+        {% from "components/panel/_macro.njk" import onsPanel %}
+        {% call onsPanel({
+            "classes": "ons-u-mb-m"
+        }) %}
+            {% if params.guidance.content %}
+                {{ params.guidance.content | safe }}
+            {% endif %}
+            {%- for item in (params.guidance.list if params.guidance.list is iterable else params.guidance.list.items()) -%}
+                {% if item.title %}
+                    <h2 class="ons-u-fs-r--b">{{ item.title }}</h2>
+                {% endif %}
+                {% from "components/lists/_macro.njk" import onsList %}
+                {{
+                    onsList({
+                        "itemsList": item.itemsList
+                    })
+                }}
+            {% endfor %}
+        {% endcall %}
+    {% endset %}
+
     <div
         {% if params.id is defined and params.id %} id="{{ params.id }}"{% endif %}
-        class="ons-question{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
+        class="ons-question ons-u-mb-xl{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
         {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
     >
-        {% if params.legendIsQuestionTitle %}
+        {% if params.legendIsQuestionTitle is defined and params.legendIsQuestionTitle %}
             {% from "components/fieldset/_macro.njk" import onsFieldset %}
 
             {# Resolves caller issue in jijna: https://github.com/pallets/jinja/issues/371 #}
@@ -44,7 +84,17 @@
                     {{- instHtml -}}
                 {% endif %}
 
-                {{ content }}
+                {% if params.definition is defined and params.definition %}
+                    {{- questionDefinition | safe -}}
+                {% endif %}
+
+                {% if params.guidance is defined and params.guidance %}
+                    {{- questionGuidance | safe -}}
+                {% endif %}
+
+                <div class="ons-question__answer ons-u-mb-m">
+                    {{ content }}
+                </div>
             {% endcall %}
 
         {% else %}
@@ -60,8 +110,43 @@
                 {{- instHtml | safe -}}
             {% endif %}
 
-            {{ caller () }}
+            {% if params.definition is defined and params.definition %}
+                {{- questionDefinition | safe -}}
+            {% endif %}
+
+            {% if params.guidance is defined and params.guidance %}
+                {{- questionGuidance | safe -}}
+            {% endif %}
+
+            <div class="ons-question__answer ons-u-mb-m">
+                {{ caller () }}
+            </div>
         {% endif %}
 
+        {% if params.justification is defined and params.justification %}
+            {% from "components/collapsible/_macro.njk" import onsCollapsible %}
+
+            {% call onsCollapsible({
+                "id": params.justification.id,
+                "classes": 'ons-u-mb-m' + (' ' + params.justification.classes if params.justification.classes is defined and params.justification.classes else ''),
+                "title": params.justification.title | default('Why we ask this question')
+            }) %}
+                {{- justificationHtml | safe -}}
+            {% endcall %}
+        {% endif %}
     </div>
+
+    {% if params.submitButton is defined and params.submitButton %}
+        {% from "components/button/_macro.njk" import onsButton %}
+
+        {{
+            onsButton({
+                "id": params.submitButton.id,
+                "submitType": params.submitButton.submitType,
+                "text": params.submitButton.text | default ('Save and continue'),
+                "classes": params.submitButton.classes,
+                "attributes": params.submitButton.attributes
+            })
+        }}
+    {% endif %}
 {% endmacro %}

--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -40,7 +40,7 @@
         {% call onsPanel({
             "classes": "ons-u-mb-m"
         }) %}
-            {% if params.guidance.content %}
+            {% if params.guidance.content is defined and params.guidance.content %}
                 {{ params.guidance.content | safe }}
             {% endif %}
             {%- for item in params.guidance.lists -%}

--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -47,6 +47,9 @@
                 {% if item.listHeading %}
                     <h2 class="ons-u-fs-r--b">{{ item.listHeading }}</h2>
                 {% endif %}
+                {% if item.listLeadingLine %}
+                    <p>{{ item.listLeadingLine }}</h2>
+                {% endif %}
                 {% from "components/lists/_macro.njk" import onsList %}
                 {{
                     onsList({
@@ -67,31 +70,17 @@
 
             {# Resolves caller issue in jijna: https://github.com/pallets/jinja/issues/371 #}
             {% set content = caller() %}
-
-            {% call onsFieldset({
-                "legendIsQuestionTitle": params.legendIsQuestionTitle,
-                "legend": titleHtml,
-                "description": descHtml if params.description is defined and params.description else '',
-                "legendClasses": params.legendClasses,
-                "legendTitleClasses": params.legendTitleClasses
-            }) %}
-
-                {% if params.instruction is defined and params.instruction %}
-                    {{- instHtml -}}
-                {% endif %}
-
-                {% if params.definition is defined and params.definition %}
-                    {{- questionDefinition | safe -}}
-                {% endif %}
-
-                {% if params.guidance is defined and params.guidance %}
-                    {{- questionGuidance | safe -}}
-                {% endif %}
-
-                <div class="ons-question__answer ons-u-mb-m">
+            <div class="ons-question__answer ons-u-mb-m">
+                {% call onsFieldset({
+                    "legendIsQuestionTitle": params.legendIsQuestionTitle,
+                    "legend": titleHtml,
+                    "description": descHtml if params.description is defined and params.description else '',
+                    "legendClasses": params.legendClasses,
+                    "legendTitleClasses": params.legendTitleClasses
+                }) %}
                     {{ content }}
-                </div>
-            {% endcall %}
+                {% endcall %}
+            </div>
 
         {% else %}
             <h1 id="question-title" class="ons-question__title">
@@ -123,6 +112,7 @@
             {% from "components/collapsible/_macro.njk" import onsCollapsible %}
             {% call onsCollapsible({
                 "id": params.justification.id,
+                "titleTag": 'h2',
                 "classes": 'ons-u-mb-m',
                 "title": params.justification.title | default('Why we ask this question')
             }) %}

--- a/src/components/question/_macro.njk
+++ b/src/components/question/_macro.njk
@@ -18,11 +18,7 @@
     {% endset %}
 
     {% set instHtml %}
-        <div class="ons-question__instruction ons-u-mb-s">{{ params.instruction | safe }}</div>
-    {% endset %}
-
-    {% set justificationHtml %}
-        {{ params.justification.content | safe }}
+        <div class="ons-question__instruction ons-u-mb-m">{{ params.instruction | safe }}</div>
     {% endset %}
 
     {% set questionDefinition %}
@@ -47,9 +43,9 @@
             {% if params.guidance.content %}
                 {{ params.guidance.content | safe }}
             {% endif %}
-            {%- for item in params.guidance.list -%}
-                {% if item.title %}
-                    <h2 class="ons-u-fs-r--b">{{ item.title }}</h2>
+            {%- for item in params.guidance.lists -%}
+                {% if item.listHeading %}
+                    <h2 class="ons-u-fs-r--b">{{ item.listHeading }}</h2>
                 {% endif %}
                 {% from "components/lists/_macro.njk" import onsList %}
                 {{
@@ -125,13 +121,12 @@
 
         {% if params.justification is defined and params.justification %}
             {% from "components/collapsible/_macro.njk" import onsCollapsible %}
-
             {% call onsCollapsible({
                 "id": params.justification.id,
-                "classes": 'ons-u-mb-m' + (' ' + params.justification.classes if params.justification.classes is defined and params.justification.classes else ''),
+                "classes": 'ons-u-mb-m',
                 "title": params.justification.title | default('Why we ask this question')
             }) %}
-                {{- justificationHtml | safe -}}
+                {{ params.justification.content | safe }}
             {% endcall %}
         {% endif %}
     </div>

--- a/src/components/question/_question.scss
+++ b/src/components/question/_question.scss
@@ -2,7 +2,8 @@
   margin: 1rem 0 0;
 
   &__title {
-    margin: 0 0 1rem;
+    @extend .ons-u-mb-m;
+
     em,
     .ons-highlight {
       background-color: $color-highlight;
@@ -15,6 +16,13 @@
       padding: 0 0.5rem;
     }
   }
+
+  &__description {
+    p:last-of-type {
+      margin-bottom: 0 !important;
+    }
+  }
+
   &__instruction {
     background-color: $color-instruction-tint;
     border: 5px solid $color-instruction;

--- a/src/components/question/examples/question-ccs/index.njk
+++ b/src/components/question/examples/question-ccs/index.njk
@@ -8,7 +8,7 @@ layout: none
 {% from "components/button/_macro.njk" import onsButton %}
 
 {% set pageConfig = {
-    "title": "Interviewer led question",
+    "title": "Interviewer led question example",
     "breadcrumbs": {
         "ariaLabel": 'Breadcrumbs',
         "itemsList": [
@@ -24,18 +24,15 @@ layout: none
     {% call onsQuestion({
         "title": "How many visitors do you have staying overnight at 3 Severn Road on Sunday 21 March 2021 ?",
         "description": "<p>A visitor is anyone aged <strong>16 years or over</strong> who usually lives at another address. Enter “0” if there are no visitors staying overnight.</p>",
-        "instruction": "<p>Tell respondent to turn to <strong>Showcard 2</strong> or show them the following Electronic Showcard</p>"
-    }) %}
-
-        {% call onsCollapsible({
-            "id": "question-justification",
+        "instruction": "<p>Tell respondent to turn to <strong>Showcard 2</strong> or show them the following Electronic Showcard</p>",
+        "justification": {
             "title": "Electronic Showcard",
-            "button": {
-                "close": "Hide this"
-            }
-        }) %}
-            <p>Visitor information is collected to ensure that everyone is counted, in order to produce accurate estimates of the population, to facilitate effective planning and funding decisions.</p>
-        {% endcall %}
+            "content": "<p>Visitor information is collected to ensure that everyone is counted, in order to produce accurate estimates of the population, to facilitate effective planning and funding decisions.</p>"
+        },
+        "submitButton": {
+            "submitType": "timer"
+        }
+    }) %}
 
         {{ onsInput({
             "id": "number-of-visitors",
@@ -48,9 +45,4 @@ layout: none
         }) }}
 
     {% endcall %}
-
-    {{ onsButton({
-        "text": "Save and continue",
-        "classes": "ons-u-mt-xl"
-    }) }}
 {% endblock %}

--- a/src/components/question/examples/question-fieldset/index.njk
+++ b/src/components/question/examples/question-fieldset/index.njk
@@ -11,13 +11,13 @@ layout: none
 {% set pageConfig = {
   "title": "Question example",
   "breadcrumbs": {
-    "ariaLabel": 'Breadcrumbs',
-    "itemsList": [
-      {
-        "url": '#0',
-        "text": 'Previous'
-      }
-    ]
+      "ariaLabel": 'Breadcrumbs',
+      "itemsList": [
+          {
+              "url": '#0',
+              "text": 'Previous'
+          }
+      ]
   }
 } %}
 

--- a/src/components/question/examples/question-fieldset/index.njk
+++ b/src/components/question/examples/question-fieldset/index.njk
@@ -9,7 +9,7 @@ layout: none
 {% from "components/button/_macro.njk" import onsButton %}
 
 {% set pageConfig = {
-  "title": "Anatomy of a question",
+  "title": "Question example",
   "breadcrumbs": {
     "ariaLabel": 'Breadcrumbs',
     "itemsList": [
@@ -30,12 +30,12 @@ layout: none
             <p>Only select “paused trading” if all trading or operations have <strong>temporarily</strong> stopped.</p>",
         "definition": {
             "title": "What we mean by “employee”",
-            "content": "<p>An employee is a person that your organisation   directly pays from its payroll(s), in return for carrying out a full-time or part-time job.</p>"
+            "content": "<p>An employee is a person that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job.</p>"
         },
         "guidance": {
-            "list": [
+            "lists": [
                 {
-                    "title": "Include:",
+                    "listHeading": "Include:",
                     "itemsList": [
                         {
                             "text": "All employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
@@ -43,7 +43,7 @@ layout: none
                     ]
                 },
                 {
-                    "title": "Exclude:",
+                    "listHeading": "Exclude:",
                     "itemsList": [
                         {
                             "text": "trainees on government schemes"
@@ -56,6 +56,7 @@ layout: none
             ]
         },
         "justification": {
+            "title": "Why we ask this question",
             "content": "<p>We ask this question in order to understand the size of organisations in the UK.</p>"
         },
         "submitButton": {

--- a/src/components/question/examples/question-fieldset/index.njk
+++ b/src/components/question/examples/question-fieldset/index.njk
@@ -9,16 +9,16 @@ layout: none
 {% from "components/button/_macro.njk" import onsButton %}
 
 {% set pageConfig = {
-    "title": "Anatomy of a question",
-    "breadcrumbs": {
-        "ariaLabel": 'Breadcrumbs',
-        "itemsList": [
-            {
-                "url": '#0',
-                "text": 'Previous'
-            }
-        ]
-    }
+  "title": "Anatomy of a question",
+  "breadcrumbs": {
+    "ariaLabel": 'Breadcrumbs',
+    "itemsList": [
+      {
+        "url": '#0',
+        "text": 'Previous'
+      }
+    ]
+  }
 } %}
 
 {% set questionTitle = "On 1 May 2016, what was the number of employees for Bolt and Ratchet?" %}
@@ -26,74 +26,73 @@ layout: none
 {% block main %}
     {% call onsQuestion({
         "title": questionTitle,
-        "description": "<p>This is all employees aged 16 years or over that your organisation employs</p>"
-    }) %}
-        {% call onsCollapsible({
-            "id": "question-definition",
+        "description": "<p>You can interpret 'trading' as 'operating'.</p>
+            <p>Only select 'paused trading' if all trading or operations have <strong>temporarily</strong> stopped.</p>",
+        "definition": {
             "title": "What we mean by “employee”",
-            "button": {
-                "close": "Hide this"
-            }
-        }) %}
-            <p>An employee is a person that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job.</p>
-        {% endcall %}
-
-        {% call onsPanel() %}
-            <strong>Include:</strong>
-            <ul>
-                <li>all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period</li>
-            </ul>
-            <strong>Exclude:</strong>
-            <ul>
-                <li>trainees on government schemes</li>
-                <li>employees working abroad unless paid directly from this business’s GB payroll</li>
-            </ul>
-        {% endcall %}
-
-        {{ onsRadios({
-            "id": "number-of-employees",
-            "name": "number-of-employees",
-            "legend": questionTitle,
-            "legendClasses": "ons-u-vh",
-            "radios": [
+            "content": "<p>An employee is a person that your organisation   directly pays from its payroll(s), in return for carrying out a full-time or part-time job.</p>"
+        },
+        "guidance": {
+            "list": [
                 {
-                    "id": "number-of-employees-1-9",
-                    "label": {
-                        "text": "1 – 9 employees"
-                    },
-                    "value": "1-9"
+                    "title": "Include:",
+                    "itemsList": [
+                        {
+                            "text": "All employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
+                        }
+                    ]
                 },
                 {
-                    "id": "number-of-employees-10-49",
-                    "label": {
-                        "text": "10 – 49 employees"
-                    },
-                    "value": "10-49"
-                },
-                {
-                    "id": "number-of-employees-50-100",
-                    "label": {
-                        "text": "50 – 100+ employees",
-                        "description": "Include multi-corporations"
-                    },
-                    "value": "50-100"
+                    "title": "Exclude:",
+                    "itemsList": [
+                        {
+                            "text": "trainees on government schemes"
+                        },
+                        {
+                            "text": "employees working abroad unless paid directly from this business’s GB payroll"
+                        }
+                    ]
                 }
             ]
-        }) }}
+        },
+        "justification": {
+            "content": "<p>We ask this question in order to understand the size of organisations in the UK.</p>"
+        },
+        "submitButton": {
+            "submitType": 'timer'
+        }
+    }) %}
 
-        {% call onsCollapsible({
-            "id": "question-justification",
-            "title": "Why we ask this question",
-            "button": {
-                "close": "Hide this"
-            }
-        }) %}
-            <p>We ask this question in order to understand the size of organisations in the UK.</p>
-        {% endcall %}
-    {% endcall %}
-
-    {{ onsButton({
-        "text": "Save and continue",
-        "classes": "ons-u-mt-xl"
+    {{ onsRadios({
+      "id": "number-of-employees",
+      "name": "number-of-employees",
+      "legend": questionTitle,
+      "legendClasses": "ons-u-vh",
+      "radios": [
+        {
+            "id": "number-of-employees-1-9",
+            "label": {
+                "text": "1 – 9 employees"
+            },
+            "value": "1-9"
+        },
+        {
+            "id": "number-of-employees-10-49",
+            "label": {
+                "text": "10 – 49 employees"
+            },
+            "value": "10-49"
+        },
+        {
+            "id": "number-of-employees-50-100",
+            "label": {
+                "text": "50 – 100+ employees",
+                "description": "Include multi-corporations"
+            },
+            "value": "50-100"
+        }
+      ]
     }) }}
+
+  {% endcall %}
 {% endblock %}

--- a/src/components/question/examples/question-fieldset/index.njk
+++ b/src/components/question/examples/question-fieldset/index.njk
@@ -26,8 +26,8 @@ layout: none
 {% block main %}
     {% call onsQuestion({
         "title": questionTitle,
-        "description": "<p>You can interpret 'trading' as 'operating'.</p>
-            <p>Only select 'paused trading' if all trading or operations have <strong>temporarily</strong> stopped.</p>",
+        "description": "<p>You can interpret “trading” as “operating”.</p>
+            <p>Only select “paused trading” if all trading or operations have <strong>temporarily</strong> stopped.</p>",
         "definition": {
             "title": "What we mean by “employee”",
             "content": "<p>An employee is a person that your organisation   directly pays from its payroll(s), in return for carrying out a full-time or part-time job.</p>"
@@ -59,40 +59,40 @@ layout: none
             "content": "<p>We ask this question in order to understand the size of organisations in the UK.</p>"
         },
         "submitButton": {
-            "submitType": 'timer'
+            "submitType": "timer"
         }
     }) %}
 
-    {{ onsRadios({
-      "id": "number-of-employees",
-      "name": "number-of-employees",
-      "legend": questionTitle,
-      "legendClasses": "ons-u-vh",
-      "radios": [
-        {
-            "id": "number-of-employees-1-9",
-            "label": {
-                "text": "1 – 9 employees"
+        {{ onsRadios({
+        "id": "number-of-employees",
+        "name": "number-of-employees",
+        "legend": questionTitle,
+        "legendClasses": "ons-u-vh",
+        "radios": [
+            {
+                "id": "number-of-employees-1-9",
+                "label": {
+                    "text": "1 – 9 employees"
+                },
+                "value": "1-9"
             },
-            "value": "1-9"
-        },
-        {
-            "id": "number-of-employees-10-49",
-            "label": {
-                "text": "10 – 49 employees"
+            {
+                "id": "number-of-employees-10-49",
+                "label": {
+                    "text": "10 – 49 employees"
+                },
+                "value": "10-49"
             },
-            "value": "10-49"
-        },
-        {
-            "id": "number-of-employees-50-100",
-            "label": {
-                "text": "50 – 100+ employees",
-                "description": "Include multi-corporations"
-            },
-            "value": "50-100"
-        }
-      ]
-    }) }}
+            {
+                "id": "number-of-employees-50-100",
+                "label": {
+                    "text": "50 – 100+ employees",
+                    "description": "Include multi-corporations"
+                },
+                "value": "50-100"
+            }
+        ]
+        }) }}
 
-  {% endcall %}
+    {% endcall %}
 {% endblock %}

--- a/src/components/question/examples/question-interviewer-note/index.njk
+++ b/src/components/question/examples/question-interviewer-note/index.njk
@@ -23,12 +23,11 @@ layout: none
 {% block main %}
     {% call onsQuestion({
         "title": "<mark class=\"ons-instruction\">Interviewer note:</mark>Who to interview",
-        "instruction": "<p>Only interview a person who was usually living at the property on <em>Sunday 21 March 2021</em>.</p><p>If none of those house members are available, you must save and sign out and return to the address to interview one of them at a later date.</p>"
+        "instruction": "<p>Only interview a person who was usually living at the property on <em>Sunday 21 March 2021</em>.</p><p>If none of those house members are available, you must save and sign out and return to the address to interview one of them at a later date.</p>",
+        "submitButton": {
+            "submitType": "timer",
+            "text": "Continue"
+        }
     }) %}
     {% endcall %}
-
-    {{ onsButton({
-        "text": "Continue",
-        "classes": "ons-u-mt-xl"
-    }) }}
 {% endblock %}

--- a/src/components/question/examples/question-no-fieldset/index.njk
+++ b/src/components/question/examples/question-no-fieldset/index.njk
@@ -8,7 +8,7 @@ layout: none
 {% from "components/button/_macro.njk" import onsButton %}
 
 {% set pageConfig = {
-    "title": "Anatomy of a question",
+    "title": "Question example",
     "breadcrumbs": {
         "ariaLabel": 'Breadcrumbs',
         "itemsList": [
@@ -23,7 +23,14 @@ layout: none
 {% block main %}
     {% call onsQuestion({
         "title": "How many visitors are staying overnight at 3 Severn Road on 13 May 2019?",
-        "description": "<p>Enter “0” if there are no visitors staying overnight</p>"
+        "description": "<p>Enter “0” if there are no visitors staying overnight</p>",
+        "justification": {
+            "title": "Why we ask this question",
+            "content": "<p>Visitor information is collected to ensure that everyone is counted, in order to produce accurate estimates of the population, to facilitate effective planning and funding decisions.</p>"
+        },
+        "submitButton": {
+            "submitType": "timer"
+        }
     }) %}
         {{ onsInput({
             "id": "number-of-visitors",
@@ -34,20 +41,5 @@ layout: none
                 "text": "Number of visitors"
             }
         }) }}
-
-        {% call onsCollapsible({
-            "id": "question-justification",
-            "title": "Why we ask this question",
-            "button": {
-                "close": "Hide this"
-            }
-        }) %}
-            <p>Visitor information is collected to ensure that everyone is counted, in order to produce accurate estimates of the population, to facilitate effective planning and funding decisions.</p>
-        {% endcall %}
     {% endcall %}
-
-    {{ onsButton({
-        "text": "Save and continue",
-        "classes": "ons-u-mt-xl"
-    }) }}
 {% endblock %}

--- a/src/foundations/style/typography/lists/examples/list-ordered/index.njk
+++ b/src/foundations/style/typography/lists/examples/list-ordered/index.njk
@@ -4,13 +4,13 @@
         "element": 'ol',
         "itemsList": [
             {
-                "text": 'Introduction.'
+                "text": 'Introduction'
             },
             {
-                "text": 'Questionnaire.'
+                "text": 'Questionnaire'
             },
             {
-                "text": 'Summary.'
+                "text": 'Summary'
             }
         ]
     })

--- a/src/patterns/pages/question/examples/question-anatomy/_pl-question-anatomy.scss
+++ b/src/patterns/pages/question/examples/question-anatomy/_pl-question-anatomy.scss
@@ -1,25 +1,30 @@
 .ons-pl-question-anatomy {
   border-collapse: collapse;
   border-spacing: 0;
+  margin: -1.5rem;
   max-width: $grid-max-width;
 
   &__row {
     &:not(:last-child) {
-      border-bottom: 1px dashed $color-grey-15;
+      border-bottom: 1px dashed $color-grey-35;
     }
   }
 
   &__component {
-    padding: 1rem 1rem 1rem 0;
+    padding: 1rem 1.5rem;
     vertical-align: top;
   }
 
   &__description {
-    padding: 1rem 0 1rem 1rem;
+    background-color: $color-grey-5;
+    padding: 1rem;
     text-align: left;
+  }
 
-    strong {
-      color: $color-errors;
-    }
+  code {
+    background: #f5f5f6;
+    color: #d0021b;
+    font-weight: 400;
+    padding: 0.05rem 0.25rem;
   }
 }

--- a/src/patterns/pages/question/examples/question-anatomy/index.njk
+++ b/src/patterns/pages/question/examples/question-anatomy/index.njk
@@ -1,6 +1,7 @@
 {% from "components/collapsible/_macro.njk" import onsCollapsible %}
 {% from "components/panel/_macro.njk" import onsPanel %}
 {% from "components/radios/_macro.njk" import onsRadios %}
+{% from "components/button/_macro.njk" import onsButton %}
 
 <table class="ons-pl-question-anatomy">
     <tbody class="ons-pl-question-anatomy__row">
@@ -9,7 +10,8 @@
                 <h1 class="ons-u-fs-l">On 1 May 2021, what was the number of employees for Bolt and Ratchet?</h1>
             </td>
             <th class="ons-pl-question-anatomy__description" scope="col">
-                <h2 class="ons-u-fs-r">Question heading</h2>
+                <h2 class="ons-u-fs-r ons-u-mb-no">Question heading</h2>
+                <p><code>title</code></p>
             </th>
         </tr>
     </tbody>
@@ -19,8 +21,9 @@
                 <p>This is all employees aged 16 years or over that your organisation employs</p>
             </td>
             <th class="ons-pl-question-anatomy__description" scope="col">
-                <h2 class="ons-u-fs-r">Question description <small>(optional)</small></h2>
-                <p class="ons-u-fs-s">To provide added context to the question</p>
+                <h2 class="ons-u-fs-r ons-u-mb-no">Question description <span class="ons-u-fs-s">(optional)</span></h2>
+                <p><code>description</code></p>
+                <p class="ons-u-fs-s ons-u-mb-no">To provide added context to the question</p>
             </th>
         </tr>
     </tbody>
@@ -38,9 +41,9 @@
                 {% endcall %}
             </td>
             <th class="ons-pl-question-anatomy__description" scope="col">
-                <h2 class="ons-u-fs-r">Question definition <small>(optional)</small></h2>
-                <p class="ons-u-fs-s">Only to be used to define word(s) or acronym(s) within the question.</p>
-                <p class="ons-u-fs-s"><strong>Only to be used once</strong></p>
+                <h2 class="ons-u-fs-r ons-u-mb-no">Question definition <span class="ons-u-fs-s">(optional)</span></h2>
+                <p><code>definition</code></p>
+                <p class="ons-u-fs-s ons-u-mb-no">Only to be used to define word(s) or acronym(s) within the question.</p>
             </th>
         </tr>
     </tbody>
@@ -60,7 +63,8 @@
                 {% endcall %}
             </td>
             <th class="ons-pl-question-anatomy__description" scope="col">
-                <h2 class="ons-u-fs-r">Question guidance <small>(optional)</small></h2>
+                <h2 class="ons-u-fs-r ons-u-mb-no">Question guidance <span class="ons-u-fs-s">(optional)</span></h2>
+                <p><code>guidance</code></p>
                 <p class="ons-u-fs-s">Only to be used to state what should be included or excluded from the answer</p>
             </th>
         </tr>
@@ -118,8 +122,22 @@
                 {% endcall %}
             </td>
             <th class="ons-pl-question-anatomy__description" scope="col">
-                <h2 class="ons-u-fs-r">Question justification <small>(optional)</small></h2>
-                <p class="ons-u-fs-s"><strong>Not to be used as a definition</strong></p>
+                <h2 class="ons-u-fs-r ons-u-mb-no">Question justification <span class="ons-u-fs-s">(optional)</span></h2>
+                <p class="ons-u-mb-no"><code>justification</code></p>
+            </th>
+        </tr>
+    </tbody>
+    <tbody class="ons-pl-question-anatomy__row">
+        <tr>
+            <td class="ons-pl-question-anatomy__component">
+                {{
+                    onsButton({
+                        "text": 'Save and continue'
+                    })
+                }}
+            </td>
+            <th class="ons-pl-question-anatomy__description" scope="col">
+                <h2 class="ons-u-fs-r ons-u-mb-no">Submit button</h2>
             </th>
         </tr>
     </tbody>

--- a/src/patterns/pages/question/index.njk
+++ b/src/patterns/pages/question/index.njk
@@ -18,9 +18,11 @@ Use this pattern when you need a user to give you some information.
 Do not use this pattern for any pages that are not asking for information. For example, use start pages and interstitial pages to give the user information they need to complete the questions.
 
 ## How to use this pattern
+A question page can be built using the question macro `onsQuestion()`.
+
+Use the parameters in the following table to build the common question elements. This will make sure the they are used correctly and the spacing is consistent across all questions. You need to import any applicable component for the required type of answer.
 {{ patternlibExample({
-    "path": "patterns/pages/question/examples/question-anatomy/index.njk",
-    "noTabs": true
+    "path": "patterns/pages/question/examples/question-anatomy/index.njk"
 }) }}
 
 Use the [basic content principles](/guidance/basic-content-principles) to make sure the content on your question pages is clearly written and accessible. Keep your content short so users do not have too much to read and can continue their journey without interruption. Each part of the page should follow the specific content guidance.
@@ -55,7 +57,7 @@ Other things to remember for headings are:
     })
 }}
 
-### Question descriptions (optional)
+### Question description (optional)
 A question description adds context to a survey question. It could be an instruction on how to answer it. It should not be used unless there is evidence that users need it to help them answer.
 
 Question descriptions should be relevant to that question and not refer to any previous or upcoming questions.
@@ -179,11 +181,18 @@ To avoid the visual repetition of text you should wrap the `<h1>` inside the `<l
     "path": "components/question/examples/question-ccs/index.njk"
 }) }}
 
+{# 
+## TO DO: Move and convert to a new 'Interstitial' page pattern
+## We shouldn't show this example here as the guidance states you shouldn't use the question pattern for interstitial pages
+
+
 ### Interstitial with an interviewer instruction
 
 {{ patternlibExample({
     "path": "components/question/examples/question-interviewer-note/index.njk"
 }) }}
+
+#}
 
 ## Help improve this pattern
 Let us know how we could improve this pattern or share your user research findings.

--- a/src/scss/objects/_spacing.scss
+++ b/src/scss/objects/_spacing.scss
@@ -9,9 +9,7 @@
   .ons-figure,
   .ons-field,
   .ons-field-group,
-  .ons-fieldset,
   .ons-input-items,
-  .ons-panel:not(.ons-panel--bare),
   .ons-summary__group,
   .ons-collapsible:not(.ons-collapsible--accordion) {
     margin-top: 1.5rem;

--- a/src/scss/objects/_spacing.scss
+++ b/src/scss/objects/_spacing.scss
@@ -10,8 +10,7 @@
   .ons-field,
   .ons-field-group,
   .ons-input-items,
-  .ons-summary__group,
-  .ons-collapsible:not(.ons-collapsible--accordion) {
+  .ons-summary__group {
     margin-top: 1.5rem;
   }
 }

--- a/src/scss/objects/_spacing.scss
+++ b/src/scss/objects/_spacing.scss
@@ -9,6 +9,7 @@
   .ons-figure,
   .ons-field,
   .ons-field-group,
+  .ons-fieldset,
   .ons-input-items,
   .ons-summary__group {
     margin-top: 1.5rem;

--- a/src/tests/spec/collapsible/collapsible.spec.js
+++ b/src/tests/spec/collapsible/collapsible.spec.js
@@ -204,35 +204,6 @@ describe('Component: collapsible', function() {
       });
     });
   });
-
-  describe('If the component does not have a button', function() {
-    beforeEach(function() {
-      delete params.button;
-      const component = renderComponent(params);
-
-      Object.keys(component).forEach(key => {
-        this[key] = component[key];
-      });
-    });
-
-    afterEach(function() {
-      if (this.wrapper) {
-        this.wrapper.remove();
-      }
-    });
-
-    describe('When the component initialises', function() {
-      beforeEach(function() {
-        this.collapsible = new Collapsible(this.collapsible);
-      });
-
-      it('there should be no closeButton or buttonOpen properties', function() {
-        expect(this.collapsible.button).to.be.null;
-        expect(this.collapsible.closeButton).to.be.undefined;
-        expect(this.collapsible.buttonOpen).to.be.undefined;
-      });
-    });
-  });
 });
 
 function renderComponent(params) {


### PR DESCRIPTION
### What is the context of this PR?
To ensure questions are presented more consistently, and spacing between elements is the same, I've made changes to `onsQuestion` so it now contains config for the common question components:
- Title
- Description
- Definition (collapsible)
- Guidance (include/exclude panel)
- Justification (collapsible)
- Submit button

The only flexibility in the type of component used for the answer.

Also... 
To prevent the need to always set the `button` parameters in the definition and justification elements, I've added default text for collapsible hide button and made the button mandatory in the component. If it has been deemed necessary it should be mandatory. I've also added default text for the button `contextSuffix` so it's never empty.

### How to review
- Check all question elements can accept the required content and that all applicable answer types can be used.
- Check spacing between elements is consistent.