### PR TITLE
Timeout modal - add parameter to set an initial expiry time

### DIFF
--- a/src/components/timeout-modal/_macro-options.md
+++ b/src/components/timeout-modal/_macro-options.md
@@ -2,7 +2,8 @@
 | --------------------------- | ------- | -------- | ---------------------------------------------------------------------------- |
 | showModalTimeInSeconds      | integer | true     | Number of seconds the modal will be displayed                                |
 | redirectUrl                 | string  | true     | URL to redirect to when session times out                                    |
-| serverSessionExpiryEndpoint | string  | true     | Endpoint to send requests                                                    |
+| sessionExpiresAt            | string  | true     | Initial expiry time set by server on page load in ISO format                 |
+| serverSessionExpiryEndpoint | string  | true     | Endpoint to send requests to get or update expiry time                       |
 | title                       | string  | true     | Title text for the modal, used by `aria-labelledby`                          |
 | textFirstLine               | string  | true     | Text content for modal e.g. 'You've been inactive for a while'               |
 | countdownText               | string  | true     | Text content to accompany timer e.g. 'You will be signed out in'             |

--- a/src/components/timeout-modal/_macro.njk
+++ b/src/components/timeout-modal/_macro.njk
@@ -6,7 +6,7 @@
             "classes": "ons-js-timeout-modal",
             "attributes": {
                 "data-redirect-url": params.redirectUrl,
-                "data-timeout-time": params.serverTimeoutTime,
+                "data-server-session-expires-at": params.sessionExpiresAt,
                 "data-show-modal-time": params.showModalTimeInSeconds,
                 "data-server-session-expiry-endpoint": params.serverSessionExpiryEndpoint,
                 "data-countdown-text": params.countdownText,

--- a/src/components/timeout-modal/index.njk
+++ b/src/components/timeout-modal/index.njk
@@ -29,6 +29,7 @@ The content of the timeout modal is set using the parameters shown in the macro 
 You will also need to set the parameters:
 
 - `showModalTimeInSeconds` with the number of seconds the modal should show for before the session expiry time (this should be at least 60 seconds)
+- `sessionExpiresAt` with the current expiry time in ISO format on page load
 - `serverSessionExpiryEndpoint` with a relative url to the server’s API endpoint for the component to send requests to
 - `redirectUrl` with a url to the [session timed out error page](/error-status-pages/#session-timed-out-error-when-user-is-not-signed-in) the user is directed to when the session has timed out
 

--- a/src/components/timeout-modal/timeout.dom.js
+++ b/src/components/timeout-modal/timeout.dom.js
@@ -8,7 +8,8 @@ async function modals() {
 
     timeouts.forEach(context => {
       let url = context.getAttribute('data-server-session-expiry-endpoint');
-      new Timeout(context, url);
+      let time = context.getAttribute('data-server-session-expires-at');
+      new Timeout(context, url, time);
     });
   }
 }

--- a/src/components/timeout-modal/timeout.js
+++ b/src/components/timeout-modal/timeout.js
@@ -34,7 +34,12 @@ export default class Timeout {
   }
 
   async initialise() {
-    this.expiryTime = await this.setNewExpiryTime();
+    if (this.initialExpiryTime) {
+      this.expiryTime = this.initialExpiryTime;
+    } else {
+      this.expiryTime = await this.setNewExpiryTime();
+    }
+
     this.expiryTimeInMilliseconds = this.convertTimeToMilliSeconds(this.expiryTime);
 
     this.bindEventListeners();

--- a/src/components/timeout-modal/timeout.js
+++ b/src/components/timeout-modal/timeout.js
@@ -34,7 +34,7 @@ export default class Timeout {
   }
 
   async initialise() {
-    if (this.initialExpiryTime) {
+    if (this.initialExpiryTime && this.sessionExpiryEndpoint) {
       this.expiryTime = this.initialExpiryTime;
     } else {
       this.expiryTime = await this.setNewExpiryTime();


### PR DESCRIPTION
### What is the context of this PR?

New `sessionExpiresAt` parameter to pass the expiry date so the JS doesn't have to make an initial call to the `/session-expiry` endpoint