### PR TITLE
Checkboxes - select parent checkbox if child is selected on page load

### DIFF
--- a/src/components/checkboxes/_macro.njk
+++ b/src/components/checkboxes/_macro.njk
@@ -31,6 +31,7 @@
         {% endif %}
         <div class="ons-checkboxes__items">
             {% for checkbox in params.checkboxes %}
+                {% set childIsChecked = false %}
                 {% set labelHTML = checkbox.label.text %}
                 {% if params.mutuallyExclusive is defined and params.mutuallyExclusive %}
                     {% set exclusiveClass = ' ons-js-exclusive-group-item' %}
@@ -43,13 +44,18 @@
                     {% if checkbox.other.selectAllChildren is defined and checkbox.other.selectAllChildren == true %}
                         {% set otherClass = otherClass + " ons-js-select-all-children" %}
                     {% endif %}
+                    {% for otherCheckbox in checkbox.other.checkboxes %}
+                        {% if otherCheckbox.checked is defined and otherCheckbox.checked %}
+                            {% set childIsChecked = true %}
+                        {% endif %}
+                    {% endfor %}
                 {% endif %}
                 <span class="ons-checkboxes__item{{ " ons-checkboxes__item--no-border" if params.borderless }}">
                     {% set config = {
                         "id": checkbox.id,
                         "name": checkbox.name,
                         "value": checkbox.value,
-                        "checked": checkbox.checked,
+                        "checked": childIsChecked if childIsChecked == true else checkbox.checked,
                         "borderless": params.borderless,
                         "classes": checkbox.classes | default('') + borderless | default(''),
                         "inputClasses": exclusiveClass | default('') + otherClass | default(''),


### PR DESCRIPTION
### What is the context of this PR?
When using nested checkboxes if a child checkbox is checked on page load the parent should be selected by default.

### How to review
Set `checked: true` on a child checkbox (other checkboxes) and confirm the parent is selected and all child checkboxes are displayed.

![image](https://user-images.githubusercontent.com/1015442/148230742-b73574af-512f-4338-9a3a-cef42b6b7bb4.png)
