### PR TITLE
autocomplete - update default values for prevention

### DIFF
--- a/src/components/address-input/examples/address-input-editable/index.njk
+++ b/src/components/address-input/examples/address-input-editable/index.njk
@@ -26,7 +26,7 @@
     "noResults": "No results found. Try entering a different part of the address",
     "tooManyResults": "{n} results found. Enter more of the address to improve results",
     "typeMore": "Enter more of the address to get results",
-    "autocomplete": "new-password",
+    "autocomplete": "off",
     "errorTitle": "There is a problem with your answer",
     "errorMessageEnter": "Enter an address",
     "errorMessageSelect": "Select an address",

--- a/src/components/address-input/examples/address-input/index.njk
+++ b/src/components/address-input/examples/address-input/index.njk
@@ -10,7 +10,7 @@
     "isEditable": false,
     "mandatory": true,
     "externalInitialiser": true,
-    "autocomplete": "new-password",
+    "autocomplete": "off",
     "APIDomain": "https://whitelodge-eq-ai-api.census-gcp.onsdigital.uk",
     'APIDomainBearerToken': "some_token",
     "instructions": "Use up and down keys to navigate suggestions once you\'ve typed more than two characters. Use the enter key to select a suggestion. Touch device users, explore by touch or with swipe gestures.",

--- a/src/patterns/ask-users-for/addresses/examples/address-input/index.njk
+++ b/src/patterns/ask-users-for/addresses/examples/address-input/index.njk
@@ -43,7 +43,7 @@ layout: none
             "noResults": "No results found. Try entering a different part of the address",
             "tooManyResults": "{n} results found. Enter more of the address to improve results",
             "typeMore": "Enter more of the address to get results",
-            "autocomplete": "new-password",
+            "autocomplete": "off",
             "errorTitle": "There is a problem with your answer",
             "errorMessageEnter": "Enter an address",
             "errorMessageSelect": "Select an address",


### PR DESCRIPTION
### What is the context of this PR?
`autocomplete="new-password"` no longer prevents autofill in Chrome, but now `autocomplete="off"` does work as expected in Chrome.

### How to review
Check that no defaults use the value `new-password`