### PR TITLE
Add ability to set row ids on summaries

### DIFF
--- a/src/components/code-highlight/_macro-options.md
+++ b/src/components/code-highlight/_macro-options.md
@@ -1,4 +1,4 @@
 | Name     | Type   | Required | Description             |
 | -------- | ------ | -------- | ----------------------- |
-| language | string | false    | Lanugage the code is in |
+| language | string | false    | Language the code is in |
 | code     | string | true     | Code to be highlighted  |

--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -19,6 +19,7 @@
 | placeholderText | string               | false    | A message to be shown as a placeholder if there are no rows in the summary                |
 | groupTitle      | string               | false    | The title for a summary within a group                                                    |
 | headers         | Array                | true     | An array of headers to describe the data in each column of the summary for screen readers |
+| headerId        | string               | false    | The id for the header row                                                                 |
 | summaryLink     | Array`<SummaryLink>` | false    | Settings for the link to appear after the summary                                         |
 
 ## SummaryRow
@@ -27,6 +28,7 @@
 | ------------------ | ----------------------- | -------- | --------------------------------------------------------------------- |
 | rowItems           | Array`<SummaryRowItem>` | true     | An array of items for this row                                        |
 | rowTitle           | string                  | false    | The title for the row                                                 |
+| rowId              | string                  | false    | Id of the row item                                                    |
 | rowTitleAttributes | object                  | false    | HTML attributes (for example, data attributes) to add to the rowTitle |
 | error              | boolean                 | false    | Whether to render this item as an error                               |
 | errorMessage       | string                  | false    | Error message for the row                                             |

--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -19,7 +19,7 @@
 | placeholderText | string               | false    | A message to be shown as a placeholder if there are no rows in the summary                |
 | groupTitle      | string               | false    | The title for a summary within a group                                                    |
 | headers         | Array                | true     | An array of headers to describe the data in each column of the summary for screen readers |
-| headerId        | string               | false    | The id for the header row                                                                 |
+| groupHeaderId   | string               | false    | The ID for the group head                                                                 |
 | summaryLink     | Array`<SummaryLink>` | false    | Settings for the link to appear after the summary                                         |
 
 ## SummaryRow
@@ -28,7 +28,7 @@
 | ------------------ | ----------------------- | -------- | --------------------------------------------------------------------- |
 | rowItems           | Array`<SummaryRowItem>` | true     | An array of items for this row                                        |
 | rowTitle           | string                  | false    | The title for the row                                                 |
-| rowId              | string                  | false    | Id of the row item                                                    |
+| rowId              | string                  | false    | ID of the row                                                         |
 | rowTitleAttributes | object                  | false    | HTML attributes (for example, data attributes) to add to the rowTitle |
 | error              | boolean                 | false    | Whether to render this item as an error                               |
 | errorMessage       | string                  | false    | Error message for the row                                             |
@@ -39,6 +39,7 @@
 | Name       | Type                   | Required | Description                                                            |
 | ---------- | ---------------------- | -------- | ---------------------------------------------------------------------- |
 | iconType   | string                 | false    | Name of the icon to be placed next to the title                        |
+| rowItemId  | string                 | false    | ID of the row item                                                     |
 | title      | string                 | false    | Label for the row item                                                 |
 | valueList  | Array`<SummaryValue>`  | false    | The value(s) to the row item                                           |
 | actions    | Array`<SummaryAction>` | false    | Configurations for action links. If not specified no links will render |

--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -19,16 +19,16 @@
 | placeholderText | string               | false    | A message to be shown as a placeholder if there are no rows in the summary                |
 | groupTitle      | string               | false    | The title for a summary within a group                                                    |
 | headers         | Array                | true     | An array of headers to describe the data in each column of the summary for screen readers |
-| groupHeaderId   | string               | false    | The ID for the group head                                                                 |
+| id              | string               | false    | The ID for the group                                                                      |
 | summaryLink     | Array`<SummaryLink>` | false    | Settings for the link to appear after the summary                                         |
 
 ## SummaryRow
 
 | Name               | Type                    | Required | Description                                                           |
 | ------------------ | ----------------------- | -------- | --------------------------------------------------------------------- |
+| id                 | string                  | false    | ID of the row                                                         |
 | rowItems           | Array`<SummaryRowItem>` | true     | An array of items for this row                                        |
 | rowTitle           | string                  | false    | The title for the row                                                 |
-| rowId              | string                  | false    | ID of the row                                                         |
 | rowTitleAttributes | object                  | false    | HTML attributes (for example, data attributes) to add to the rowTitle |
 | error              | boolean                 | false    | Whether to render this item as an error                               |
 | errorMessage       | string                  | false    | Error message for the row                                             |
@@ -39,7 +39,7 @@
 | Name       | Type                   | Required | Description                                                            |
 | ---------- | ---------------------- | -------- | ---------------------------------------------------------------------- |
 | iconType   | string                 | false    | Name of the icon to be placed next to the title                        |
-| rowItemId  | string                 | false    | ID of the row item                                                     |
+| id         | string                 | false    | ID of the row item                                                     |
 | title      | string                 | false    | Label for the row item                                                 |
 | valueList  | Array`<SummaryValue>`  | false    | The value(s) to the row item                                           |
 | actions    | Array`<SummaryAction>` | false    | Configurations for action links. If not specified no links will render |

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -22,7 +22,7 @@
                     {% endif %}
                     {% if group.headers is defined and group.headers and group.rows is defined and group.rows %}
                         <table class="ons-summary__items">
-                            <thead {% if group.groupHeaderId is defined and group.groupHeaderId %}id="{{ group.groupHeaderId }}" {% endif %}class="ons-u-vh">
+                            <thead {% if group.id is defined and group.id %}id="{{ group.id }}" {% endif %}class="ons-u-vh">
                                 <tr>
                                     {% for header in group.headers %}
                                         <th>{{ header }}</th>
@@ -35,7 +35,7 @@
                                 {% if row.error is defined and row.error %} {% set itemClass = " ons-summary__item--error" %}{% endif %}
                                 {% if row.total is defined and row.total %} {% set itemClass = itemClass + " ons-summary__item--total" %}{% endif %}
 
-                                <tbody {% if row.rowId is defined and row.rowId %}id="{{ row.rowId }}" {% endif %}class="ons-summary__item{{ itemClass }}">
+                                <tbody {% if row.id is defined and row.id %}id="{{ row.id }}" {% endif %}class="ons-summary__item{{ itemClass }}">
                                     {% if row.errorMessage is defined and row.errorMessage or (row.rowItems | length > 1 and row.rowTitle) %}
                                         <tr class="ons-summary__row">
                                             <th colspan="3" class="ons-summary__row-title ons-u-fs-r">{{ row.errorMessage or row.rowTitle }}</th>
@@ -43,7 +43,7 @@
                                     {% endif %}
 
                                     {% for rowItem in row.rowItems %}
-                                        <tr {% if rowItem.rowItemId is defined and rowItem.rowItemId %}id="{{ rowItem.rowItemId }}" {% endif %}class="ons-summary__row{{ " ons-summary__row--has-values" if rowItem.valueList else "" }}">
+                                        <tr {% if rowItem.id is defined and rowItem.id %}id="{{ rowItem.id }}" {% endif %}class="ons-summary__row{{ " ons-summary__row--has-values" if rowItem.valueList else "" }}">
                                             <td
                                                 class="ons-summary__item-title"
                                                 {% if rowItem.rowTitleAttributes is defined and rowItem.rowTitleAttributes %}{% for attribute, value in (rowItem.rowTitleAttributes.items() if rowItem.rowTitleAttributes is mapping and rowItem.rowTitleAttributes.items else rowItem.rowTitleAttributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -22,7 +22,7 @@
                     {% endif %}
                     {% if group.headers is defined and group.headers and group.rows is defined and group.rows %}
                         <table class="ons-summary__items">
-                            <thead {% if group.headerId is defined and group.headerId %}id="{{ group.headerId }}" {% endif %}class="ons-u-vh">
+                            <thead {% if group.groupHeaderId is defined and group.groupHeaderId %}id="{{ group.groupHeaderId }}" {% endif %}class="ons-u-vh">
                                 <tr>
                                     {% for header in group.headers %}
                                         <th>{{ header }}</th>
@@ -43,7 +43,7 @@
                                     {% endif %}
 
                                     {% for rowItem in row.rowItems %}
-                                        <tr class="ons-summary__row{{ " ons-summary__row--has-values" if rowItem.valueList else "" }}">
+                                        <tr {% if row.rowItemId is defined and row.rowItemId %}id="{{ row.rowItemId }}" {% endif %}class="ons-summary__row{{ " ons-summary__row--has-values" if rowItem.valueList else "" }}">
                                             <td
                                                 class="ons-summary__item-title"
                                                 {% if rowItem.rowTitleAttributes is defined and rowItem.rowTitleAttributes %}{% for attribute, value in (rowItem.rowTitleAttributes.items() if rowItem.rowTitleAttributes is mapping and rowItem.rowTitleAttributes.items else rowItem.rowTitleAttributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -22,7 +22,7 @@
                     {% endif %}
                     {% if group.headers is defined and group.headers and group.rows is defined and group.rows %}
                         <table class="ons-summary__items">
-                            <thead id="{{ group.headerId }}" class="ons-u-vh">
+                            <thead {% if group.headerId is defined and group.headerId %}id="{{ group.headerId }}" {% endif %}class="ons-u-vh">
                                 <tr>
                                     {% for header in group.headers %}
                                         <th>{{ header }}</th>

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -43,7 +43,7 @@
                                     {% endif %}
 
                                     {% for rowItem in row.rowItems %}
-                                        <tr {% if row.rowItemId is defined and row.rowItemId %}id="{{ row.rowItemId }}" {% endif %}class="ons-summary__row{{ " ons-summary__row--has-values" if rowItem.valueList else "" }}">
+                                        <tr {% if rowItem.rowItemId is defined and rowItem.rowItemId %}id="{{ rowItem.rowItemId }}" {% endif %}class="ons-summary__row{{ " ons-summary__row--has-values" if rowItem.valueList else "" }}">
                                             <td
                                                 class="ons-summary__item-title"
                                                 {% if rowItem.rowTitleAttributes is defined and rowItem.rowTitleAttributes %}{% for attribute, value in (rowItem.rowTitleAttributes.items() if rowItem.rowTitleAttributes is mapping and rowItem.rowTitleAttributes.items else rowItem.rowTitleAttributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -22,7 +22,7 @@
                     {% endif %}
                     {% if group.headers is defined and group.headers and group.rows is defined and group.rows %}
                         <table class="ons-summary__items">
-                            <thead class="ons-u-vh">
+                            <thead id="{{ group.headerId }}" class="ons-u-vh">
                                 <tr>
                                     {% for header in group.headers %}
                                         <th>{{ header }}</th>
@@ -35,7 +35,7 @@
                                 {% if row.error is defined and row.error %} {% set itemClass = " ons-summary__item--error" %}{% endif %}
                                 {% if row.total is defined and row.total %} {% set itemClass = itemClass + " ons-summary__item--total" %}{% endif %}
 
-                                <tbody class="ons-summary__item{{ itemClass }}">
+                                <tbody {% if row.rowId is defined and row.rowId %}id="{{ row.rowId }}" {% endif %}class="ons-summary__item{{ itemClass }}">
                                     {% if row.errorMessage is defined and row.errorMessage or (row.rowItems | length > 1 and row.rowTitle) %}
                                         <tr class="ons-summary__row">
                                             <th colspan="3" class="ons-summary__row-title ons-u-fs-r">{{ row.errorMessage or row.rowTitle }}</th>

--- a/src/components/summary/examples/summary/index.njk
+++ b/src/components/summary/examples/summary/index.njk
@@ -13,9 +13,9 @@
                         {
                             "rowTitle": "What are the dates of the sales period you are reporting for?",
                             "rowId": "sales-dates-row",
-                            "rowItemId": "sales-dates",
                             "rowItems": [
                                 {
+                                    "rowItemId": "sales-dates",
                                     "valueList": [
                                         {
                                             "text": "1 January 2015 to 2 February 2017"
@@ -34,9 +34,9 @@
                         {
                             "rowTitle": "For the period 1 January 2015 to 2 February 2017, what was the value of your total turnover, excluding VAT?",
                             "rowId": "sales-value-row",
-                            "rowItemId": "sales-value",
                             "rowItems": [
                                 {
+                                    "rowItemId": "sales-value",
                                     "valueList": [
                                         {
                                             "text": "£180,440"
@@ -55,9 +55,9 @@
                         {
                             "rowTitle": "Please indicate the reasons for any changes in the total turnover",
                             "rowId": "sales-reasons-row",
-                            "rowItemId": "sales-reasons",
                             "rowItems": [
                                 {
+                                    "rowItemId": "sales-reasons",
                                     "valueList": [
                                         {
                                             "text": "Change in level of business activity"
@@ -80,9 +80,9 @@
                         {
                             "rowTitle": "Please describe the changes in total turnover in more detail",
                             "rowId": "sales-detail-row",
-                            "rowItemId": "sales-detail",
                             "rowItems": [
                                 {
+                                    "rowItemId": "sales-detail",
                                     "valueList": [
                                         {
                                             "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."

--- a/src/components/summary/examples/summary/index.njk
+++ b/src/components/summary/examples/summary/index.njk
@@ -7,10 +7,12 @@
                 "groups": [
                     {
                     "groupTitle": "Turnover",
+                    "headerId": "turnover",
                     "headers":["Question", "Answer given", "Change answer"],
                     "rows": [
                         {
                             "rowTitle": "What are the dates of the sales period you are reporting for?",
+                            "rowId": "sales-dates",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -30,6 +32,7 @@
                         },
                         {
                             "rowTitle": "For the period 1 January 2015 to 2 February 2017, what was the value of your total turnover, excluding VAT?",
+                            "rowId": "sales-value",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -49,6 +52,7 @@
                         },
                         {
                             "rowTitle": "Please indicate the reasons for any changes in the total turnover",
+                            "rowId": "sales-reasons",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -72,6 +76,7 @@
                         },
                         {
                             "rowTitle": "Please describe the changes in total turnover in more detail",
+                            "rowId": "sales-detail",
                             "rowItems": [
                                 {
                                     "valueList": [

--- a/src/components/summary/examples/summary/index.njk
+++ b/src/components/summary/examples/summary/index.njk
@@ -6,16 +6,16 @@
             {
                 "groups": [
                     {
+                    "id": "turnover",
                     "groupTitle": "Turnover",
-                    "groupHeaderId": "turnover",
                     "headers":["Question", "Answer given", "Change answer"],
                     "rows": [
                         {
+                            "id": "sales-dates-row",
                             "rowTitle": "What are the dates of the sales period you are reporting for?",
-                            "rowId": "sales-dates-row",
                             "rowItems": [
                                 {
-                                    "rowItemId": "sales-dates",
+                                    "id": "sales-dates",
                                     "valueList": [
                                         {
                                             "text": "1 January 2015 to 2 February 2017"
@@ -33,10 +33,10 @@
                         },
                         {
                             "rowTitle": "For the period 1 January 2015 to 2 February 2017, what was the value of your total turnover, excluding VAT?",
-                            "rowId": "sales-value-row",
+                            "id": "sales-value-row",
                             "rowItems": [
                                 {
-                                    "rowItemId": "sales-value",
+                                    "id": "sales-value",
                                     "valueList": [
                                         {
                                             "text": "£180,440"
@@ -53,11 +53,11 @@
                             ]
                         },
                         {
+                            "id": "sales-reasons-row",
                             "rowTitle": "Please indicate the reasons for any changes in the total turnover",
-                            "rowId": "sales-reasons-row",
                             "rowItems": [
                                 {
-                                    "rowItemId": "sales-reasons",
+                                    "id": "sales-reasons",
                                     "valueList": [
                                         {
                                             "text": "Change in level of business activity"
@@ -78,11 +78,11 @@
                             ]
                         },
                         {
+                            "id": "sales-detail-row",
                             "rowTitle": "Please describe the changes in total turnover in more detail",
-                            "rowId": "sales-detail-row",
                             "rowItems": [
                                 {
-                                    "rowItemId": "sales-detail",
+                                    "id": "sales-detail",
                                     "valueList": [
                                         {
                                             "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."

--- a/src/components/summary/examples/summary/index.njk
+++ b/src/components/summary/examples/summary/index.njk
@@ -7,12 +7,13 @@
                 "groups": [
                     {
                     "groupTitle": "Turnover",
-                    "headerId": "turnover",
+                    "groupHeaderId": "turnover",
                     "headers":["Question", "Answer given", "Change answer"],
                     "rows": [
                         {
                             "rowTitle": "What are the dates of the sales period you are reporting for?",
-                            "rowId": "sales-dates",
+                            "rowId": "sales-dates-row",
+                            "rowItemId": "sales-dates",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -32,7 +33,8 @@
                         },
                         {
                             "rowTitle": "For the period 1 January 2015 to 2 February 2017, what was the value of your total turnover, excluding VAT?",
-                            "rowId": "sales-value",
+                            "rowId": "sales-value-row",
+                            "rowItemId": "sales-value",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -52,7 +54,8 @@
                         },
                         {
                             "rowTitle": "Please indicate the reasons for any changes in the total turnover",
-                            "rowId": "sales-reasons",
+                            "rowId": "sales-reasons-row",
+                            "rowItemId": "sales-reasons",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -76,7 +79,8 @@
                         },
                         {
                             "rowTitle": "Please describe the changes in total turnover in more detail",
-                            "rowId": "sales-detail",
+                            "rowId": "sales-detail-row",
+                            "rowItemId": "sales-detail",
                             "rowItems": [
                                 {
                                     "valueList": [


### PR DESCRIPTION
### What is the context of this PR?
This adds the ability to set ids on summary rows. This is to allow scrolling to specific rows in runner.

I have also fixed a typo

### How to review
Check ids are set correctly
