### PR TITLE
Code highlighter - fix prism js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "postcss-url": "^8.0.0",
     "prepend-file": "^1.3.1",
     "prettier": "^1.15.2",
-    "prismjs": "^1.23.0",
+    "prismjs": "1.24.0",
     "proxyquireify": "^3.2.1",
     "puppeteer": "^5.3.1",
     "remark-cli": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9322,10 +9322,10 @@ pretty-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.23.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.26.0.tgz#16881b594828bb6b45296083a8cbab46b0accd47"
-  integrity sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==
+prismjs@1.24.0:
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.24.0.tgz#0409c30068a6c52c89ef7f1089b3ca4de56be2ac"
+  integrity sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ==
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
### What is the context of this PR?
Describe what you have An upgrade to dependencies caused an issue with our code highlighter macro that uses prismjs.

### How to review
Check any code highlighting works as needed.