### PR TITLE
Timeout modal - fix status code check and multiple fetches

### DIFF
--- a/src/components/timeout-modal/timeout.js
+++ b/src/components/timeout-modal/timeout.js
@@ -169,7 +169,8 @@ export default class Timeout {
       if (!canSetNewExpiry) {
         this.redirect();
       } else {
-        this.closeModalAndRestartTimeout();
+        const newExpiryTimeInMilliseconds = this.convertTimeToMilliSeconds(canSetNewExpiry).toString();
+        this.closeModalAndRestartTimeout(newExpiryTimeInMilliseconds);
       }
     }
   }
@@ -207,7 +208,7 @@ export default class Timeout {
       method: fetchMethod,
       headers: { 'Cache-Control': 'no-cache', 'Content-type': 'application/json; charset=UTF-8' },
     });
-    if (!response.ok) {
+    if (response.status === 401) {
       this.redirect();
       return false;
     }


### PR DESCRIPTION
### What is the context of this PR?
The timeout modal has been implemented in EQ and has raised a couple of issues:

- Setting of a new expiry time happening multiple times for a single action
- Need to specifically test for a status code of 401 not 200

### How to review
This needs to be tested in EQ as it requires connection to an endpoint.