### PR TITLE
Move summary group id to table element

### DIFF
--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -21,8 +21,8 @@
                         <h{{ titleSize }} class="ons-summary__group-title">{{ group.groupTitle }}</h{{ titleSize }}>
                     {% endif %}
                     {% if group.headers is defined and group.headers and group.rows is defined and group.rows %}
-                        <table class="ons-summary__items">
-                            <thead {% if group.id is defined and group.id %}id="{{ group.id }}" {% endif %}class="ons-u-vh">
+                        <table {% if group.id is defined and group.id %}id="{{ group.id }}" {% endif %} class="ons-summary__items">
+                            <thead class="ons-u-vh">
                                 <tr>
                                     {% for header in group.headers %}
                                         <th>{{ header }}</th>


### PR DESCRIPTION
### What is the context of this PR?
This PR is to move the summary group id to table element. It makes more sense for it to be on the `<table>` rather than the `<thead>`

### How to review
Id now gets set on `<table>` correctly
