### PR TITLE
Move summary group div

### DIFF
--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -11,12 +11,12 @@
     {% endif %}
     <div class="{{ className }}">
         {% for summary in params.summaries %}
-            <div {% if group.id is defined and group.id %}id="{{ group.id }}" {% endif %} class="ons-summary__group">
-                {% if summary.summaryTitle is defined and summary.summaryTitle %}
-                    <h2 class="ons-summary__title ons-u-mb-m">{{ summary.summaryTitle }}</h2>
-                    {% set titleSize = "3" %}
-                {% endif %}
-                {% for group in summary.groups %}
+            {% if summary.summaryTitle is defined and summary.summaryTitle %}
+                <h2 class="ons-summary__title ons-u-mb-m">{{ summary.summaryTitle }}</h2>
+                {% set titleSize = "3" %}
+            {% endif %}
+            {% for group in summary.groups %}
+                <div {% if group.id is defined and group.id %}id="{{ group.id }}" {% endif %} class="ons-summary__group">
                     {% if group.groupTitle is defined and group.groupTitle %}
                         <h{{ titleSize }} class="ons-summary__group-title">{{ group.groupTitle }}</h{{ titleSize }}>
                     {% endif %}
@@ -122,8 +122,8 @@
                             <a {% if group.summaryLink.attributes is defined and group.summaryLink.attributes %}{% for attribute, value in (group.summaryLink.attributes.items() if group.summaryLink.attributes is mapping and group.summaryLink.attributes.items else group.summaryLink.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %} href="{{ group.summaryLink.url }}">{{ group.summaryLink.text }}</a>
                         </div>
                     {% endif %}
-                {% endfor %}
-            </div>
+                </div>
+            {% endfor %}
         {% endfor %}
     </div>
 {% endmacro %}


### PR DESCRIPTION
### What is the context of this PR?
The summary group `div` is in the wrong place currently. There is one summary group `div` above the summary title and around the whole summary, when there should be one around each summary group.

### How to review
- Changes make sense
- Summaries still work and look as expected
- Tests pass

