### PR TITLE
Change CTA button icon to forward arrow

### DIFF
--- a/src/components/button/_macro.njk
+++ b/src/components/button/_macro.njk
@@ -29,8 +29,11 @@
             {% set iconType = "loader" %}
             {% set iconPosition = "after" %}
         {# CTA or mobile menu toggle #}
-        {% elif params.url is defined and params.url or params.buttonStyle is defined and params.buttonStyle == "mobile" %}
+        {% elif params.buttonStyle is defined and params.buttonStyle == "mobile" %}
             {% set iconType = "chevron" %}
+            {% set iconPosition = "after" %}
+        {% elif params.url is defined and params.url %}
+            {% set iconType = "arrow-next" %}
             {% set iconPosition = "after" %}
         {% endif %}
     {% endif %}

--- a/src/foundations/style/icons/index.njk
+++ b/src/foundations/style/icons/index.njk
@@ -115,13 +115,13 @@ A directional icon should be placed before or after a button label or link to he
 
 Use forward navigation icons after the text and backward navigation icons before the text.
 
-For example, the chevron icon on the [call to action button](/components/button#call-to-action) shows the button will move the user forward to the next page.
+For example, the `arrow-next` icon after the [call to action button](/components/button#call-to-action) shows the button will move the user forward to the next page.
 
 {{
     patternlibExample({ "path": "components/button/examples/button-link/index.njk", "componentFolderPath": "components/button" })
 }}
 
-The chevron icon on the [back link](/components/back-link) shows the link will move the user back to the previous page.
+The `chevron` icon before the [back link](/components/back-link) shows the link will move the user back to the previous page.
 
 {{
     patternlibExample({ "path": "components/back-link/examples/back-link/index.njk", "componentFolderPath": "components/breadcrumbs" })


### PR DESCRIPTION
### What is the context of this PR?
The directional icon used for CTA button does not use the same consistent metaphor as 'Next page' pagination icon. This PR replaces the chevron on the CTA button with an arrow.

From:
![Screenshot 2022-01-28 at 11 51 02](https://user-images.githubusercontent.com/43346934/151542389-62ce5960-dcc0-4fd4-aefb-377f5d0bce16.png)

To:
![Screenshot 2022-01-28 at 11 50 35](https://user-images.githubusercontent.com/43346934/151542343-56902518-9a44-431d-9bb6-13b233bed078.png)

Closes #1863 

### How to review
Check CTA button default icon
