### PR TITLE
Design system - fix exclude item from nav

### DIFF
--- a/lib/rendering/helpers/sub-navigation-helper.js
+++ b/lib/rendering/helpers/sub-navigation-helper.js
@@ -51,7 +51,7 @@ function getNavigationItemGroups(pageInfo) {
   } else {
     groups = [
       {
-        items: rootPage.children.filter(item => !!item.templatePath),
+        items: rootPage.children.filter(item => !!item.templatePath && !item.exclude),
       },
     ];
   }


### PR DESCRIPTION
### What is the context of this PR?
A change made in a previous PR #1805 caused the `exclude: true` frontmatter not to work and show excluded items in the side navigation on the DS website.

Have added this logic to the nav helper script.

### How to review
Make sure the excluded components'/patterns do not show.