### PR TITLE
Add aside block to page template

### DIFF
--- a/src/components/question/examples/question-ccs/index.njk
+++ b/src/components/question/examples/question-ccs/index.njk
@@ -22,12 +22,12 @@ layout: none
 
 {% block main %}
     {% call onsQuestion({
-        "title": "How many visitors do you have staying overnight at 3 Severn Road on Sunday 21 March 2021 ?",
+        "title": "How many visitors do you have staying overnight at 3 Severn Road on Sunday 21 March 2021?",
         "description": "<p>A visitor is anyone aged <strong>16 years or over</strong> who usually lives at another address. Enter “0” if there are no visitors staying overnight.</p>",
         "instruction": "<p>Tell respondent to turn to <strong>Showcard 2</strong> or show them the following Electronic Showcard</p>",
-        "justification": {
+        "definition": {
             "title": "Electronic Showcard",
-            "content": "<p>Visitor information is collected to ensure that everyone is counted, in order to produce accurate estimates of the population, to facilitate effective planning and funding decisions.</p>"
+            "content": "<p>Visitor information is collected to ensure that everyone is counted, in order to produce accurate estimates of the population, to facilitate effective planning and funding decisions</p>"
         },
         "submitButton": {
             "submitType": "timer"

--- a/src/components/question/examples/question-fieldset/index.njk
+++ b/src/components/question/examples/question-fieldset/index.njk
@@ -26,11 +26,10 @@ layout: none
 {% block main %}
     {% call onsQuestion({
         "title": questionTitle,
-        "description": "<p>You can interpret “trading” as “operating”.</p>
-            <p>Only select “paused trading” if all trading or operations have <strong>temporarily</strong> stopped.</p>",
+        "description": "<p>This is all employees aged 16 years or over that your organisation employs</p>",
         "definition": {
             "title": "What we mean by “employee”",
-            "content": "<p>An employee is a person that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job.</p>"
+            "content": "<p>An employee is a person that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job</p>"
         },
         "guidance": {
             "lists": [
@@ -38,7 +37,7 @@ layout: none
                     "listHeading": "Include:",
                     "itemsList": [
                         {
-                            "text": "All employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
+                            "text": "all employees in Great Britain (England, Scotland and Wales), both full and part-time, who received pay in the relevant period"
                         }
                     ]
                 },
@@ -57,7 +56,7 @@ layout: none
         },
         "justification": {
             "title": "Why we ask this question",
-            "content": "<p>We ask this question in order to understand the size of organisations in the UK.</p>"
+            "content": "<p>We ask this question in order to understand the size of organisations in the UK</p>"
         },
         "submitButton": {
             "submitType": "timer"

--- a/src/foundations/layout/page-template/examples/basic/index.njk
+++ b/src/foundations/layout/page-template/examples/basic/index.njk
@@ -15,4 +15,7 @@ layout: none
 } %}
 {% block main %}
     <h1>Page Title</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+    <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 {% endblock %}

--- a/src/foundations/layout/page-template/examples/block-areas/_block-areas.scss
+++ b/src/foundations/layout/page-template/examples/block-areas/_block-areas.scss
@@ -4,6 +4,7 @@
   overflow: hidden;
   padding: 3rem 1rem 1rem;
   position: relative;
+  width: 100%;
 
   &__label {
     border-bottom: 2px dashed $color-grey-100;

--- a/src/foundations/layout/page-template/examples/block-areas/_block-areas.scss
+++ b/src/foundations/layout/page-template/examples/block-areas/_block-areas.scss
@@ -1,6 +1,7 @@
 .ons-pattern-lib-block {
   border: 2px dashed $color-grey-100;
   margin: 0 0 1rem;
+  min-width: 200px;
   overflow: hidden;
   padding: 3rem 1rem 1rem;
   position: relative;

--- a/src/foundations/layout/page-template/examples/block-areas/index.njk
+++ b/src/foundations/layout/page-template/examples/block-areas/index.njk
@@ -6,6 +6,7 @@ layout: example
 {% from "components/footer/_macro.njk" import onsFooter %}
 {% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
 {% from "components/related-content/_macro.njk" import onsRelatedContent %}
+{% from "components/section-navigation/_macro.njk" import onsSectionNavigation %}
 
 <div class="ons-pattern-lib-block">
     <div class="ons-pattern-lib-block__label">block: headIcons</div>
@@ -49,7 +50,7 @@ layout: example
                     "id": "main-nav",
                     "ariaLabel": "Main menu",
                     "ariaListLabel": "Navigation menu",
-                    "currentPath": "#home",
+                    "currentPath": "#patterns",
                     "itemsList": [
                         {
                             "title": "Home",
@@ -69,7 +70,7 @@ layout: example
                         },
                         {
                             "title": "Patterns",
-                            "url": "#0"
+                            "url": "#patterns"
                         }
                     ]
                 }
@@ -100,15 +101,51 @@ layout: example
         </div>
 
         <div class="ons-grid ons-grid--flex ons-grid--column@xxs@m">
+            <div class="ons-grid__col ons-grid__col--flex ons-u-flex-shrink">
+                <div class="ons-pattern-lib-block">
+                    <div class="ons-pattern-lib-block__label">block: aside (<code>before</code>)</div>
+                    <h3 class="ons-u-fs-r--b">Ask users for...</h3>
+                    {{
+                        onsSectionNavigation({
+                            "variants": "vertical",
+                            "id": "section-menu",
+                            "currentPath": "#email-addresses",
+                            "itemsList": [
+                                {
+                                    "title": "Access codes",
+                                    "url": "#0"
+
+                                },
+                                {
+                                    "title": "Addresses",
+                                    "url": "#0"
+                                },
+                                {
+                                    "title": "Dates",
+                                    "url": "#0"
+                                },
+                                {
+                                    "title": "Durations",
+                                    "url": "#0"
+                                },
+                                {
+                                    "title": "Email addresses",
+                                    "url": "#email-addresses"
+                                }
+                            ]
+                        })
+                    }}
+                </div>
+            </div>
             <div class="ons-grid__col ons-grid__col--flex ons-u-flex-grow">
                 <div class="ons-pattern-lib-block">
                     <div class="ons-pattern-lib-block__label">block: main</div>
                     <h1>Page content</h1>
                 </div>
             </div>
-            <div class="ons-grid__col ons-grid__col--auto">
+            <div class="ons-grid__col ons-grid__col--flex">
                 <div class="ons-pattern-lib-block">
-                    <div class="ons-pattern-lib-block__label">block: aside</div>
+                    <div class="ons-pattern-lib-block__label">block: aside (<code>after</code>)</div>
                     {{
                         onsRelatedContent({
                             "ariaLabel": 'Related content',

--- a/src/foundations/layout/page-template/examples/block-areas/index.njk
+++ b/src/foundations/layout/page-template/examples/block-areas/index.njk
@@ -4,6 +4,8 @@ layout: example
 {% from "components/skip-to-content/_macro.njk" import onsSkipToContent %}
 {% from "components/header/_macro.njk" import onsHeader %}
 {% from "components/footer/_macro.njk" import onsFooter %}
+{% from "components/breadcrumbs/_macro.njk" import onsBreadcrumbs %}
+{% from "components/related-content/_macro.njk" import onsRelatedContent %}
 
 <div class="ons-pattern-lib-block">
     <div class="ons-pattern-lib-block__label">block: headIcons</div>
@@ -80,12 +82,63 @@ layout: example
 
         <div class="ons-pattern-lib-block">
             <div class="ons-pattern-lib-block__label">block: preMain</div>
+            {{
+                onsBreadcrumbs({
+                    "ariaLabel": 'Breadcrumbs',
+                    "itemsList": [
+                        {
+                            "url": '/',
+                            "text": 'Home'
+                        },
+                        {
+                            "url": '/components',
+                            "text": 'Components'
+                        }
+                    ]
+                })
+            }}
         </div>
 
-        <div class="ons-pattern-lib-block">
-            <div class="ons-pattern-lib-block__label">block: main</div>
-            <h1>Page content</h1>
+        <div class="ons-grid ons-grid--flex ons-grid--column@xxs@m">
+            <div class="ons-grid__col ons-grid__col--flex ons-u-flex-grow">
+                <div class="ons-pattern-lib-block">
+                    <div class="ons-pattern-lib-block__label">block: main</div>
+                    <h1>Page content</h1>
+                </div>
+            </div>
+            <div class="ons-grid__col ons-grid__col--auto">
+                <div class="ons-pattern-lib-block">
+                    <div class="ons-pattern-lib-block__label">block: aside</div>
+                    {{
+                        onsRelatedContent({
+                            "ariaLabel": 'Related content',
+                            "rows": [
+                                {
+                                    "id": 'related-content',
+                                    "title": 'Related content',
+                                    "itemsList": [
+                                        {
+                                            "text": 'Base page template',
+                                            "url": '#0'
+                                        },
+                                        {
+                                            "text": 'Contribute',
+                                            "url": '#0'
+                                        },
+                                        {
+                                            "text": 'Contact us',
+                                            "url": '#0'
+                                        }
+                                    ]
+                                }
+                            ]
+
+                        })
+                    }}
+                </div>
+            </div>
         </div>
+
     </div>
 
     <div class="ons-pattern-lib-block">

--- a/src/foundations/layout/page-template/examples/custom/index.njk
+++ b/src/foundations/layout/page-template/examples/custom/index.njk
@@ -59,6 +59,10 @@ layout: none
             }
         ]
     },
+    "asideCol": {
+        "position": "after",
+        "colClasses": "ons-u-mt-l ons-u-mb-l"
+    },
     "footer": {
         "rows": [
             {
@@ -93,4 +97,36 @@ layout: none
 {% endblock %}
 {% block main %}
     <h1>Page Title</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+    <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+{% endblock %}
+{% block aside %}
+    {% from "components/related-content/_macro.njk" import onsRelatedContent %}
+    {{
+        onsRelatedContent({
+            "ariaLabel": 'Related content',
+            "rows": [
+                {
+                    "id": 'related-content',
+                    "title": 'Related content',
+                    "itemsList": [
+                        {
+                            "text": 'Base page template',
+                            "url": '#0'
+                        },
+                        {
+                            "text": 'Contribute',
+                            "url": '#0'
+                        },
+                        {
+                            "text": 'Contact us',
+                            "url": '#0'
+                        }
+                    ]
+                }
+            ]
+
+        })
+    }}
 {% endblock %}

--- a/src/foundations/layout/page-template/index.njk
+++ b/src/foundations/layout/page-template/index.njk
@@ -31,7 +31,7 @@ The example below shows the minimum requirements for an ONS base page template.
 
 ## Customised page template
 
-Components can be added to the base page template. The example below provides a [phase banner](/components/phase-banner), [change language](/patterns/change-language), [breadcrumbs](/components/breadcrumbs), [save button](/components/button) and [footer links](/components/footer).
+Components can be added to the base page template. The example below provides a [phase banner](/components/phase-banner), [change language](/patterns/change-language), [breadcrumbs](/components/breadcrumbs), [save button](/components/button), [related content](/components/related-content) and [footer links](/components/footer).
 
 {{
     patternlibExample({ "path": "foundations/layout/page-template/examples/custom/index.njk" })
@@ -65,7 +65,7 @@ The main difference between a variable and a block is that blocks can contain ma
 
 Variables can be set with:
 
-{{ onsCodeHighlight({ "code": "{% raw %}{% set variableName = value %}{% endraw %}" }) }}
+{{ onsCodeHighlight({ "code": "{% set variableName = value %}" }) }}
 
 | Variable Name   | Type                                | Required | Description                                                                                                                           |
 | --------------- | ----------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -100,8 +100,9 @@ Variables can be set with:
 | navigation    | `HeaderNavigation` [_(ref)_](/components/header)    | true (if `toggleButton` supplied) | Configuration for header navigation links                                                                                                     |
 | phase         | `PhaseBanner` [_(ref)_](/components/phase-banner)   | false                             | Settings for the Phase banner                                                                                                                 |
 | serviceLinks  | `Array<Navigation>` [_(ref)_](/components/header)   | false                             | An array to render the service links list                                                                                                     |
+| mainCol       | `MainColumn` [_(ref)_](#maincolumn)                 | false                             | Configuration for the main page column                                                                                                        |
+| asideCol      | `AsideColumn` [_(ref)_](#asidecolumn)               | false                             | Configuration for the page aside column                                                                                                       |
 | footer        | `PageFooter` [_(ref)_](#pagefooter)                 | true                              | Configuration for the page footer                                                                                                             |
-| pageColNumber | string                                              | false                             | sets the number of grid columns for the page (defaults to 8)                                                                                  |
 | description   | string                                              | true                              | Default description of the current page for search engines if headMeta.description is not provided.                                           |
 | absoluteUrl   | string                                              | true                              | Default URL for the preferred page for search engines to avoid duplicate content penalties. Used if if headMeta.canonicalUrl is not provided. |
 | wide          | boolean                                             | false                             | If sets to true passes sets the `wide` param on both the header and footer which will add css which will make the page use a wider style.     |
@@ -144,6 +145,22 @@ Variables can be set with:
 | url           | string | false    | URL for the CDN       |
 | lang          | string | false    | DS version on the CDN |
 
+##### MainColumn
+
+| Variable Name | Type   | Required | Description                                                             |
+| ------------- | ------ | -------- | ----------------------------------------------------------------------- |
+| columns       | string | false    | Sets the number of grid columns for the main page column (defaults to 8)|
+| colClasses    | string | false    | CSS classes to be added to the main page grid column                    |
+| classes       | string | false    | CSS classes to be added to the `<main>` container                       |
+
+##### AsideColumn
+
+| Variable Name | Type   | Required | Description                                                                |
+| ------------- | ------ | -------- | -------------------------------------------------------------------------- |
+| position      | string | true     | Sets the position of the aside to `before` or `after` the main page column |
+| colClasses    | string | false    | CSS classes to be added to the page aside grid column                      |
+| classes       | string | false    | CSS classes to be added to the page`<aside>` container                     |
+
 ###### PageFooter
 
 | Variable Name        | Type                                                     | Required | Description                                                                                          |
@@ -164,19 +181,19 @@ Variables can be set with:
 Blocks can be set with:
 
 +++
-{{ onsCodeHighlight({ "code": "{% raw %}{% block blockName %}
+{{ onsCodeHighlight({ "code": "{% block blockName %}
     HTML Here
-{% endblock %}{% endraw %}" }) }}
+{% endblock %}" }) }}
 +++
 
 To change the components that are included by default, set their equivalent blocks, for example:
 
 +++
-{{ onsCodeHighlight({ "code": "{% raw %}{% block header %}
+{{ onsCodeHighlight({ "code": "{% block header %}
     {{ onsHeader({
         ...
     }) }}
-{% endblock %}{% endraw %}" }) }}
+{% endblock %}" }) }}
 +++
 
 | Block Name | Description                                                                         |
@@ -191,8 +208,10 @@ To change the components that are included by default, set their equivalent bloc
 | page       | Override the default content and layout of the page                                 |
 | preMain    | Content to place before the main content                                            |
 | main       | Main content and markup                                                             |
+| aside      | Aside content and markup                                                            |
 | footer     | Override the default [footer](/components/footer) component                         |
-| bodyEnd    | Add content just after just before the closing `</body>` element                    |
+| bodyEnd    | Add content just before the closing `</body>` element                               |
+| scripts    | Add Javascript just before the closing `</body>` element                            |
 
 ##### Exploded view of the base page template block areas
 

--- a/src/foundations/layout/page-template/index.njk
+++ b/src/foundations/layout/page-template/index.njk
@@ -31,7 +31,7 @@ The example below shows the minimum requirements for an ONS base page template.
 
 ## Customised page template
 
-Components can be added to the base page template. The example below provides a [phase banner](/components/phase-banner), [change language](/patterns/change-language), [breadcrumbs](/components/breadcrumbs), [save button](/components/button), [related content](/components/related-content) and [footer links](/components/footer).
+Components can be added to the base page template. The example below provides a [phase banner](/components/phase-banner), [change language](/patterns/change-language), [breadcrumbs](/components/breadcrumbs), [save button](/components/button), [related content](/components/related-content), [section navigation](/components/section-navigation) and [footer links](/components/footer).
 
 {{
     patternlibExample({ "path": "foundations/layout/page-template/examples/custom/index.njk" })

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -44,7 +44,7 @@
 
 {# Page columns #}
 {% set mainColNumber = pageConfig.mainCol.columns | default("8") %}
-{% set mainColClasses = (' ' + pageConfig.mainCol.colClasses) if pageConfig.mainCol is defined and pageConfig.mainCol or pageConfig.asideCol.position is defined and pageConfig.asideCol.position == "before" %}
+{% set mainColClasses = (' ' + pageConfig.mainCol.colClasses) if pageConfig.mainCol.colClasses is defined and pageConfig.mainCol.colClasses %}
 {% set mainClasses = ' ' + pageConfig.mainCol.classes if pageConfig.mainCol.classes is defined and pageConfig.mainCol.classes %}
 
 {% set asideColNumber = 12 - mainColNumber if pageConfig.asideCol.position is defined and pageConfig.asideCol.position %}

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -43,13 +43,19 @@
 {% endif %}
 
 {# Page columns #}
-{% set mainColNumber = pageConfig.mainCol.columns | default("8") %}
-{% set mainColClasses = (' ' + pageConfig.mainCol.colClasses) if pageConfig.mainCol.colClasses is defined and pageConfig.mainCol.colClasses %}
-{% set mainClasses = ' ' + pageConfig.mainCol.classes if pageConfig.mainCol.classes is defined and pageConfig.mainCol.classes %}
+{% set mainColNumber = "8" %}
 
-{% set asideColNumber = 12 - mainColNumber if pageConfig.asideCol.position is defined and pageConfig.asideCol.position %}
-{% set asideColClasses = (' ' + pageConfig.asideCol.colClasses) if pageConfig.asideCol.colClasses is defined and pageConfig.asideCol.colClasses %}
-{% set asideClasses = ' ' + pageConfig.asideCol.classes if pageConfig.asideCol.classes is defined and pageConfig.asideCol.classes %}
+{% if pageConfig.mainCol is defined and pageConfig.mainCol %}
+    {% set mainColNumber = pageConfig.mainCol.columns if pageConfig.mainCol.columns is defined and pageConfig.mainCol.columns %}
+    {% set mainColClasses = (' ' + pageConfig.mainCol.colClasses) if pageConfig.mainCol.colClasses is defined and pageConfig.mainCol.colClasses %}
+    {% set mainClasses = (' ' + pageConfig.mainCol.classes) if pageConfig.mainCol.classes is defined and pageConfig.mainCol.classes %}
+{% endif %}
+
+{% if pageConfig.asideCol is defined and pageConfig.asideCol %}
+    {% set asideColNumber = 12 - mainColNumber if pageConfig.asideCol.position is defined and pageConfig.asideCol.position %}
+    {% set asideColClasses = (' ' + pageConfig.asideCol.colClasses) if pageConfig.asideCol.colClasses is defined and pageConfig.asideCol.colClasses %}
+    {% set asideClasses = (' ' + pageConfig.asideCol.classes) if pageConfig.asideCol.classes is defined and pageConfig.asideCol.classes %}
+{% endif %}
 
 <!doctype html>
 <html lang="{{ currentLanguageISOCode }}">

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -18,8 +18,6 @@
     {% set metaicons = "" %}
 {% endif %}
 
-{% set pageColNumber = pageConfig.pageColNumber | default("8") %}
-
 {% if pageConfig.cdn is defined and pageConfig.cdn or release_version is defined and release_version %}
     {# Production #}
     {% set cdn_url = (pageConfig.cdn.url if pageConfig.cdn is defined and pageConfig.cdn and pageConfig.cdn.url is defined and pageConfig.cdn.url) or "https://cdn.ons.gov.uk/sdc/design-system" %}
@@ -43,6 +41,15 @@
 {% else %}
     {% set page_title = "ONS Design System" %}
 {% endif %}
+
+{# Page columns #}
+{% set mainColNumber = pageConfig.mainCol.columns | default("8") %}
+{% set mainColClasses = (' ' + pageConfig.mainCol.colClasses) if pageConfig.mainCol is defined and pageConfig.mainCol or pageConfig.asideCol.position is defined and pageConfig.asideCol.position == "before" %}
+{% set mainClasses = ' ' + pageConfig.mainCol.classes if pageConfig.mainCol.classes is defined and pageConfig.mainCol.classes %}
+
+{% set asideColNumber = 12 - mainColNumber if pageConfig.asideCol.position is defined and pageConfig.asideCol.position %}
+{% set asideColClasses = (' ' + pageConfig.asideCol.colClasses) if pageConfig.asideCol.colClasses is defined and pageConfig.asideCol.colClasses %}
+{% set asideClasses = ' ' + pageConfig.asideCol.classes if pageConfig.asideCol.classes is defined and pageConfig.asideCol.classes %}
 
 <!doctype html>
 <html lang="{{ currentLanguageISOCode }}">
@@ -169,11 +176,26 @@
                             {% endif %}
                             {% block preMain %}{% endblock %}
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-{{ pageColNumber }}@m">
-                                    <main id="main-content" class="ons-page__main {{ pageClasses }}">
+                                {% if pageConfig.asideCol is defined and pageConfig.asideCol %}
+                                    {% set aside %}
+                                        <div class="ons-grid__col ons-col-{{ asideColNumber }}@m{{ asideColClasses }}">
+                                            <aside {% if pageConfig.asideCol.id is defined and pageConfig.asideCol.id %}id="{{ asideId }}" {% endif %}class="ons-page__aside{{ asideClasses }}">
+                                                {% block aside %}{% endblock %}
+                                            </aside>
+                                        </div>
+                                    {% endset %}
+                                {% endif %}
+                                {% if pageConfig.asideCol.position is defined and pageConfig.asideCol.position == "before" %}
+                                    {{ aside | safe }}
+                                {% endif %}
+                                <div class="ons-grid__col ons-col-{{ mainColNumber }}@m{{ mainColClasses }}">
+                                    <main id="main-content" class="ons-page__main{{ mainClasses }}">
                                         {% block main %}{% endblock %}
                                     </main>
                                 </div>
+                                {% if pageConfig.asideCol.position is defined and pageConfig.asideCol.position == "after" %}
+                                    {{ aside | safe }}
+                                {% endif %}
                             </div>
                         </div>
                     {% endblock %}

--- a/src/patterns/ask-users-for/addresses/examples/address-input-non-editable/register-address/index.njk
+++ b/src/patterns/ask-users-for/addresses/examples/address-input-non-editable/register-address/index.njk
@@ -3,10 +3,6 @@ layout: none
 ---
 {% extends "layout/_template.njk" %}
 
-{% from "components/question/_macro.njk" import onsQuestion %}
-{% from "components/address-input/_macro.njk" import onsAddressInput %}
-{% from "components/button/_macro.njk" import onsButton %}
-
 {% set pageConfig = {
     "title": "Non-editable address input example",
     "breadcrumbs": {
@@ -21,11 +17,7 @@ layout: none
     }
 } %}
 {% block main %}
-    {% call onsQuestion({
-        "title": "Register an address"
-    }) %}
-    
-        <p>If you can’t find your address, it may not be registered on our system.</p>
-        <p>To register your address, we need you to get in touch. You can call us free on 0800 141 2021 or <a href="#0">choose another way to contact us</a>.</p>
-    {% endcall %}
+    <h1>Register an address</h1>
+    <p>If you can’t find your address, it may not be registered on our system.</p>
+    <p>To register your address, we need you to get in touch. You can call us free on 0800 141 2021 or <a href="#0">choose another way to contact us</a>.</p>
 {% endblock %}

--- a/src/patterns/help-users-to/access-support-in-multiple-languages/examples/default/index.njk
+++ b/src/patterns/help-users-to/access-support-in-multiple-languages/examples/default/index.njk
@@ -10,7 +10,9 @@ layout: none
 {% set pageConfig = {
     "title": "Census 2021",
     "theme": "census",
-    "pageColNumber": "12",
+    "mainCol": {
+        "columns": "12"
+    },
     "absoluteUrl": pageInfo.url,
     "headMeta": {
         "description": "Census 2021 is a UK wide population survey."

--- a/src/patterns/help-users-to/download-resources/examples/download-resources-error/index.njk
+++ b/src/patterns/help-users-to/download-resources/examples/download-resources-error/index.njk
@@ -10,7 +10,9 @@ layout: none
 {% set pageConfig = {
     "title": "Census 2021",
     "theme": "census",
-    "pageColNumber": "12",
+    "mainCol": {
+        "columns": "12"
+    },
     "absoluteUrl": pageInfo.url,
     "headMeta": {
         "description": "Census 2021 is a UK wide population survey."

--- a/src/patterns/help-users-to/download-resources/examples/download-resources/index.njk
+++ b/src/patterns/help-users-to/download-resources/examples/download-resources/index.njk
@@ -10,7 +10,9 @@ layout: none
 {% set pageConfig = {
     "title": "Census 2021",
     "theme": "census",
-    "pageColNumber": "12",
+    "mainCol": {
+        "columns": "12"
+    },
     "absoluteUrl": pageInfo.url,
     "headMeta": {
         "description": "Census 2021 is a UK wide population survey."

--- a/src/patterns/pages/guide/examples/rtl/index.njk
+++ b/src/patterns/pages/guide/examples/rtl/index.njk
@@ -14,7 +14,9 @@ layout: none
 
 {% set pageConfig = {
     "theme": 'census',
-    "pageColNumber": "12",
+    "mainCol": {
+        "columns": "12"
+    },
     "bodyClasses": "ons-rtl",
     "header": {
         "logoHref": pageInfo.url,

--- a/src/patterns/pages/news/examples/article/index.njk
+++ b/src/patterns/pages/news/examples/article/index.njk
@@ -17,7 +17,9 @@ layout: none
 {% set pageConfig = {
     "title": 'Service name',
     "absoluteUrl": pageInfo.url,
-    "pageColNumber": '12',
+    "mainCol": {
+        "columns": "12"
+    },
     "breadcrumbs": {
         "ariaLabel": 'Breadcrumbs',
         "itemsList": [

--- a/src/patterns/pages/news/examples/category/index.njk
+++ b/src/patterns/pages/news/examples/category/index.njk
@@ -15,7 +15,9 @@ layout: none
 {% set pageConfig = {
     "title": 'Service name',
     "absoluteUrl": pageInfo.url,
-    "pageColNumber": '12',
+    "mainCol": {
+        "columns": "12"
+    },
     "breadcrumbs": {
         "ariaLabel": 'Breadcrumbs',
         "itemsList": [

--- a/src/patterns/pages/news/examples/landing/index.njk
+++ b/src/patterns/pages/news/examples/landing/index.njk
@@ -15,7 +15,9 @@ layout: none
 {% set pageConfig = {
     "title": 'Service name',
     "absoluteUrl": pageInfo.url,
-    "pageColNumber": '12',
+    "mainCol": {
+        "columns": "12"
+    },
     "breadcrumbs": {
         "ariaLabel": 'Breadcrumbs',
         "itemsList": [

--- a/src/patterns/pages/news/examples/tag/index.njk
+++ b/src/patterns/pages/news/examples/tag/index.njk
@@ -15,7 +15,9 @@ layout: none
 {% set pageConfig = {
     "title": 'Service name',
     "absoluteUrl": pageInfo.url,
-    "pageColNumber": '12',
+    "mainCol": {
+        "columns": "12"
+    },
     "breadcrumbs": {
         "ariaLabel": 'Breadcrumbs',
         "itemsList": [

--- a/src/patterns/pages/question/examples/question-anatomy/index.njk
+++ b/src/patterns/pages/question/examples/question-anatomy/index.njk
@@ -23,7 +23,7 @@
             <th class="ons-pl-question-anatomy__description" scope="col">
                 <h2 class="ons-u-fs-r ons-u-mb-no">Question description <span class="ons-u-fs-s">(optional)</span></h2>
                 <p><code>description</code></p>
-                <p class="ons-u-fs-s ons-u-mb-no">To provide added context to the question</p>
+                <p class="ons-u-fs-s ons-u-mb-no">Only to be used to provide added context to the question</p>
             </th>
         </tr>
     </tbody>
@@ -37,13 +37,13 @@
                         "close": "Hide this"
                     }
                 }) %}
-                    <p>An employee is a person that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job.</p>
+                    <p>An employee is a person that your organisation directly pays from its payroll(s), in return for carrying out a full-time or part-time job</p>
                 {% endcall %}
             </td>
             <th class="ons-pl-question-anatomy__description" scope="col">
                 <h2 class="ons-u-fs-r ons-u-mb-no">Question definition <span class="ons-u-fs-s">(optional)</span></h2>
                 <p><code>definition</code></p>
-                <p class="ons-u-fs-s ons-u-mb-no">Only to be used to define word(s) or acronym(s) within the question.</p>
+                <p class="ons-u-fs-s ons-u-mb-no">Only to be used to define word(s) or acronym(s) within the question</p>
             </th>
         </tr>
     </tbody>
@@ -123,7 +123,8 @@
             </td>
             <th class="ons-pl-question-anatomy__description" scope="col">
                 <h2 class="ons-u-fs-r ons-u-mb-no">Question justification <span class="ons-u-fs-s">(optional)</span></h2>
-                <p class="ons-u-mb-no"><code>justification</code></p>
+                <p><code>justification</code></p>
+                <p class="ons-u-fs-s">Only to be used to explain why a question is being asked if there is evidence that users want to know this</p>
             </th>
         </tr>
     </tbody>
@@ -138,6 +139,7 @@
             </td>
             <th class="ons-pl-question-anatomy__description" scope="col">
                 <h2 class="ons-u-fs-r ons-u-mb-no">Submit button</h2>
+                <p class="ons-u-mb-no"><code>submitButton</code></p>
             </th>
         </tr>
     </tbody>


### PR DESCRIPTION
## Contains breaking changes

### What is the context of this PR?
A new 'aside' block was required to allow users to position side navigation in the page template alongside the `<main>` container.
Closes #1867 

Includes fixes discovered in Percy visual regression check including a fix for #1910 

Also includes fixes for #1877 and #1773 

### What are the breaking changes?
Developers previously using `pageConfig.pageColNumber` to set the number of grid columns for the main page beyond the default '8', will now instead need to set the object `pageConfig.mainCol` with parameter `columns`.
e.g. 
```
{% set pageConfig = {
    "mainCol": {
        "columns": "6"
    }
}
```

### How to review
Check pageConfig can adjust the width of the main column, add classes, and also set and position a new aside column with classes and id.