### PR TITLE
Visual regression tests - run on push to master

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -1,0 +1,21 @@
+name: Run visual tests
+on:
+  push:
+    branches:
+      - master
+env:
+  PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+jobs:
+  run-tests:
+    name: Visual tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install dependencies
+        run: yarn install
+      - name: Run visual regression tests
+        run: yarn test-visual


### PR DESCRIPTION
### What is the context of this PR?
Percy visual regression tests didn't, by default run when we pushed a commit to master. Only PR's using the `test-visual` in the last commit message would make it run upon merge.

Created a GH action that will run the visual tests on any push to master.

### How to review
We will need to merge this and see if it runs (possibly on the next commit).