### PR TITLE
Improve phase banner content

### DIFF
--- a/src/components/autosuggest/index.njk
+++ b/src/components/autosuggest/index.njk
@@ -19,17 +19,17 @@ Autosuggest is used to suggest options to users as they enter something into an 
 Use the autosuggest component to help users select from a list of standard responses, for example, countries, languages or nationalities. You could also create your own list for the user to pick from.
 ## How to use
 
-The list needs to be made available as a `.json` file. To query the list we use a JavaScript library called {{
+The list needs to be made available as a JSON file (`.json`). To query the list we use a JavaScript library called {{
         onsExternalLink({
             "url": "https://fusejs.io",
             "linkText": "Fuse.js"
         })
-    }}. You will need to provide the URL where the json file is stored using the `autosuggestData` parameter.
+    }}. You will need to provide the URL where the JSON file is stored using the `autosuggestData` parameter.
 
 
 ### List formatting
 
-This code example shows how your json should be formatted. The `key` should be the language code that matches the `lang` attribute on the `<html>` element of the page.
+This code example shows how your JSON should be formatted. The `key` should be the language code that matches the `lang` attribute on the `<html>` element of the page.
 
 +++
 {% from "components/code-highlight/_macro.njk" import onsCodeHighlight %}

--- a/src/components/feedback/examples/feedback/index.njk
+++ b/src/components/feedback/examples/feedback/index.njk
@@ -7,7 +7,7 @@
                 "heading": "What do you think about this service?",
                 "content": "Your comments will help us make improvements",
                 "url": "#0",
-                "linkText": "Give Feedback"
+                "linkText": "Give feedback"
             })
         }}
     </div>

--- a/src/components/phase-banner/examples/phase-banner-alpha/index.njk
+++ b/src/components/phase-banner/examples/phase-banner-alpha/index.njk
@@ -4,7 +4,7 @@
 {% from "components/phase-banner/_macro.njk" import onsPhaseBanner %}
 {{
     onsPhaseBanner({
-        "badge": "Alpha",
-        "html": 'This is a new service – your <a href="#feedback">feedback</a> will help us improve it.'
+        "badge": 'Alpha',
+        "html": 'This is a new service – to help improve it please <a href="#0">give us your feedback</a>'
     })
 }}

--- a/src/components/phase-banner/examples/phase-banner-beta/index.njk
+++ b/src/components/phase-banner/examples/phase-banner-beta/index.njk
@@ -4,7 +4,7 @@
 {% from "components/phase-banner/_macro.njk" import onsPhaseBanner %}
 {{
     onsPhaseBanner({
-        "badge": "BETA",
-        "html": 'This is a new service – your <a href="#feedback">feedback</a> will help us improve it.'
+        "badge": 'BETA',
+        "html": 'This is a new service – to help improve it please <a href="#feedback">give us your feedback</a>'
     })
 }}

--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -7,7 +7,7 @@ title: Phase banner
 {% from "components/external-link/_macro.njk" import onsExternalLink %}
 +++
 
-The Phase banner lets users know the service is new and still being worked on, and encourages the user to provide feedback to help improve it.
+The phase banner lets users know the service is new and still being worked on, and encourages the user to provide feedback to help improve it.
 
 {{
     patternlibExample({"path": "components/phase-banner/examples/phase-banner-alpha/index.njk"})
@@ -18,15 +18,15 @@ The Phase banner lets users know the service is new and still being worked on, a
 }}
 
 ## When to use this component
-You must use the Phase banner when your service is in the alpha or beta phase and still being developed.
+Use this component when your service is in the alpha or beta phase and still being developed.
 
 ## How to use this component
-The Phase banner must be placed directly above the ONS [header](/components/header) at the very top of the page.
+The phase banner must be placed directly above the ONS [header](/components/header) at the very top of the page.
 
 ### Feedback link
-The feedback link should direct users to a form to collect page feedback on the service like the example in the [feedback](/patterns/feedback) pattern.
+The link should direct users to a form to collect feedback on the service like the [feedback form example](/patterns/feedback#feedback-form) in the feedback pattern.
 
-Ensure you always provide the user with a route back to the page they were on when they clicked the link.
+Make sure you always use a [back link](/components/back-link) on the form so the user can get back to the page they were on when they selected the link.
 
 ## Help improve this component
 Let us know how we could improve this component or share your user research findings.


### PR DESCRIPTION
### What is the context of this PR?
The feedback link in the current phase banner example does not provide enough context to users of screen readers (reading links out of context) because it's missing the verb. The link has also been moved to the end of the sentence to follow best practice and avoid interrupting the user's flow.

Closes #1601 

Note: Raised new issue #1984 to add ability to open the feedback form in a new tab

### How to review
Check the phase banner examples and documentation