### PR TITLE
Update lodash and core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "pre-commit": "lint-staged",
       "post-checkout": "yarn tidy-clean && yarn install --check-files"
     }
-  },  
+  },
   "lint-staged": {
     "*.js": [
       "prettier --print-width 140 --single-quote --parser babylon --write",
@@ -79,7 +79,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-spies": "^1.0.0",
     "codecov": "3.7.2",
-    "core-js": "^3.15.2",
+    "core-js": "^3.21.1",
     "cssnano": "^4.1.11",
     "dialog-polyfill": "^0.5.6",
     "eslint": "^5.9.0",
@@ -119,7 +119,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "lighthouse": "^7.5.0",
     "lint-staged": "^8.1.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.21",
     "marked": "^2.1.3",
     "mdn-polyfills": "^5.14.0",
     "minimist": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3327,10 +3327,15 @@ core-js-compat@^3.20.0, core-js-compat@^3.20.2:
     browserslist "^4.19.1"
     semver "7.0.0"
 
-core-js@^3.0.0, core-js@^3.15.2, core-js@^3.20.2:
+core-js@^3.0.0, core-js@^3.20.2:
   version "3.20.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.2.tgz#46468d8601eafc8b266bd2dd6bf9dee622779581"
   integrity sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==
+
+core-js@^3.21.1:
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.21.1.tgz#f2e0ddc1fc43da6f904706e8e955bc19d06a0d94"
+  integrity sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==
 
 core-util-is@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### What is the context of this PR?
Force lodash to use at least v4.17.21 and update core-js to v3.21.1 to fix vulnerabilities highlighted during RASRM pen testing

### How to review
DS works as expected and tests pass
