### PR TITLE
Timeout modal - fix bug with component restart

### DIFF
--- a/src/components/timeout-modal/timeout-modal.js
+++ b/src/components/timeout-modal/timeout-modal.js
@@ -27,14 +27,14 @@ export default class TimeoutModal {
   startTimeout() {
     clearTimeout(this.showModalTimeout);
     if (this.initialExpiryTime) {
-      this.expiryTimeInMilliseconds = this.timeout.convertTimeToMilliSeconds(this.initialExpiryTime);
+      this.totalMilliseconds = this.timeout.expiryTimeInMilliseconds;
     } else {
       // For demo purposes
-      this.expiryTimeInMilliseconds = 60000;
+      this.totalMilliseconds = 60000;
     }
     this.showModalTimeout = setTimeout(
       this.openModalAndStartCountdown.bind(this),
-      this.expiryTimeInMilliseconds - this.modalVisibleInMilliseconds,
+      this.totalMilliseconds - this.modalVisibleInMilliseconds,
     );
   }
 

--- a/src/js/timeout.js
+++ b/src/js/timeout.js
@@ -141,7 +141,10 @@ export default class Timeout {
     this.expiryTime = await this.getExpiryTime();
     this.clearTimers();
     clearInterval(this.shouldRestartCheck);
-    this.startUiCountdown();
+    if (this.countdownStarted) {
+      this.countdownStarted = false;
+      this.startUiCountdown();
+    }
   }
 
   async setNewExpiryTime() {


### PR DESCRIPTION
### What is the context of this PR?
Issue observed when the component was implemented in a service and connects to an api where the timer was not resetting correctly and was using the initial expiry time from page load.

### How to review
Will need to be implemented into a service that has the required api.