### PR TITLE
Remove container from warning panel

### DIFF
--- a/src/components/panel/_macro.njk
+++ b/src/components/panel/_macro.njk
@@ -27,10 +27,8 @@
     {% endif %}
 
     {% if params is defined and params and params.type == "warn-branded" or params.type == "announcement" %}
-    <div class="{{containerClass}}">
-        <div class="ons-container">
-    {% elif params.type is defined and params.type == "warn" %}
-        <div class="ons-container">
+        <div class="{{containerClass}}">
+            <div class="ons-container">
     {% endif %}
 
         <div {% if params is defined and params and params.type == 'error' and params.title is defined and params.title %}aria-labelledby="error-summary-title" role="alert" tabindex="-1" {% if params.dsExample != true %}autofocus="autofocus" {% endif %}{% endif %}class="ons-panel{{ typeClass }}{{ iconClass }}{{ noTitleClass }}{{ spaciousClass }}{{ classes }}"{% if params is defined and params and params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params is defined and params and params.attributes is mapping and params.attributes.items is defined and params.attributes.items else params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}{% if params is defined and params and params.id is defined and params.id %} id="{{params.id}}"{% endif %}>
@@ -91,14 +89,11 @@
             <div class="ons-panel__body{% if params is defined and params and params.iconSize is defined and params.iconSize %} ons-svg-icon-margin--{{ params.iconSize }}{% endif %}">{{ (params.body if params else "") | safe }}
                 {{ caller() if caller }}
             </div>
-
         </div>
 
     {% if params is defined and params and params.type == "warn-branded" or params.type == "announcement"  %}
+            </div>
         </div>
-    </div>
-    {% elif params.type is defined and params.type == "warn" %}
-    </div>
     {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
### What is the context of this PR?
The warning panel currently is wrapped in a container element that gives it padding. This PR removes it because I is not needed on the warning panel

### How to review
Check warning panel and countdown panel now have left padding removed
