### PR TITLE
Timeout modal - fix ie11 polyfill css

### DIFF
--- a/src/components/modal/_macro.njk
+++ b/src/components/modal/_macro.njk
@@ -5,19 +5,21 @@
         role="dialog"
         aria-labelledby="ons-modal-title"
         {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %} {{attribute}}="{{value}}"{% endfor %}{% endif %}
-    >
-        <h1 id="ons-modal-title" class="ons-modal__title">
-            {{ params.title }}
-        </h1>
-        <div class="ons-modal__body">
-            {{ (params.body if params else "") | safe }}{{ caller() if caller }}
+    >   
+        <div class="ons-modal__content">
+            <h1 id="ons-modal-title" class="ons-modal__title">
+                {{ params.title }}
+            </h1>
+            <div class="ons-modal__body">
+                {{ (params.body if params else "") | safe }}{{ caller() if caller }}
+            </div>
+            {% if params.btnText %}
+                {% from "components/button/_macro.njk" import onsButton %}
+                {{ onsButton({
+                    "text": params.btnText,
+                    "classes": "ons-js-modal-btn ons-u-mt-s"
+                }) }}
+            {% endif %}
         </div>
-        {% if params.btnText %}
-            {% from "components/button/_macro.njk" import onsButton %}
-            {{ onsButton({
-                "text": params.btnText,
-                "classes": "ons-js-modal-btn ons-u-mt-s"
-            }) }}
-        {% endif %}
     </dialog>
 {% endmacro %}

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -9,7 +9,19 @@ $backdrop-colour: rgba(0, 0, 0, 0.8);
   margin-right: 2rem;
   max-width: 500px;
   padding: 2rem;
+  position: relative;
   width: auto;
+
+  &-ie11 & {
+    background: $color-white;
+    bottom: 0;
+    height: 350px;
+    left: 0;
+    position: fixed;
+    right: 0;
+    top: 50%;
+    transform: translate(0, -50%);
+  }
 
   @media screen and (min-width: 600px) {
     margin-left: auto;
@@ -24,6 +36,11 @@ $backdrop-colour: rgba(0, 0, 0, 0.8);
 
   & + .backdrop {
     background: $backdrop-colour;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
   }
 }
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1,6 +1,7 @@
 import dialogPolyfill from 'dialog-polyfill';
 
 const overLayClass = 'ons-modal-overlay';
+const ie11Class = 'ons-modal-ie11';
 
 export default class Modal {
   constructor(component) {
@@ -8,7 +9,7 @@ export default class Modal {
     this.launcher = document.querySelector(`[data-modal-id=${component.id}]`);
     this.closeButton = component.querySelector('.ons-js-modal-btn');
     this.lastFocusedEl = null;
-
+    this.dialogCSSSupported = true;
     this.initialise();
   }
 
@@ -33,6 +34,7 @@ export default class Modal {
     } else {
       try {
         dialogPolyfill.registerDialog(this.component);
+        this.dialogCSSSupported = false;
         return true;
       } catch (error) {
         /* istanbul ignore next */
@@ -44,9 +46,15 @@ export default class Modal {
   openDialog(event) {
     if (!this.isDialogOpen()) {
       this.component.classList.add('ons-u-db');
-      document.querySelector('body').className += ' ' + overLayClass;
+      document.querySelector('body').classList.add(overLayClass);
+
+      if (!this.dialogCSSSupported) {
+        document.querySelector('body').classList.add(ie11Class);
+      }
+
       this.makePageContentInert();
       this.saveLastFocusedEl();
+
       if (event) {
         const modal = document.getElementById(event.target.getAttribute('data-modal-id'));
         modal.showModal();
@@ -96,6 +104,11 @@ export default class Modal {
       }
       this.component.classList.remove('ons-u-db');
       document.querySelector('body').classList.remove(overLayClass);
+
+      if (!this.dialogCSSSupported) {
+        document.querySelector('body').classList.remove(ie11Class);
+      }
+
       this.component.close();
       this.setFocusOnLastFocusedEl(this.lastFocusedEl);
       this.removeInertFromPageContent();

--- a/src/js/timeout.js
+++ b/src/js/timeout.js
@@ -30,7 +30,7 @@ export default class Timeout {
   }
 
   async initialise() {
-    if (this.initialExpiryTime && this.sessionExpiryEndpoint) {
+    if (this.initialExpiryTime) {
       this.expiryTime = this.initialExpiryTime;
     } else {
       this.expiryTime = await this.setNewExpiryTime();
@@ -124,7 +124,7 @@ export default class Timeout {
     let newExpiryTime;
     if (!this.sessionExpiryEndpoint) {
       // For demo purposes
-      const demoTime = new Date(this.initialExpiryTime ? this.initialExpiryTime : Date.now() + 60 * 1000);
+      const demoTime = new Date(Date.now() + 60 * 1000);
       newExpiryTime = new Date(demoTime).toISOString();
     } else {
       newExpiryTime = await this.fetchExpiryTime('PATCH');

--- a/src/tests/spec/timeout-modal/timeout-modal.spec.js
+++ b/src/tests/spec/timeout-modal/timeout-modal.spec.js
@@ -53,7 +53,7 @@ describe('Component: Timeout modal', function() {
         expect(this.hasExpiryTimeResetInAnotherTabSpy).to.have.been.called();
         expect(this.getExpiryTimeSpy).to.have.been.called();
         done();
-      }, 4000);
+      }, 5000);
     });
   });
 

--- a/src/tests/spec/timeout-modal/timeout-modal.spec.js
+++ b/src/tests/spec/timeout-modal/timeout-modal.spec.js
@@ -8,7 +8,7 @@ import eventMock from '../../stubs/event.stub.spec';
 chai.use(chaiSpies);
 
 const params = {
-  showModalTimeInSeconds: 5,
+  showModalTimeInSeconds: 56,
   redirectUrl: '#!',
   title: 'You will be signed out soon',
   textFirstLine: 'It appears you have been inactive for a while.',
@@ -38,8 +38,7 @@ describe('Component: Timeout modal', function() {
 
   describe('When the component initialises', function() {
     beforeEach(function() {
-      this.time = new Date(Date.now() + 7 * 1000);
-      this.timeoutModal = new TimeoutModal(this.component, null, this.time);
+      this.timeoutModal = new TimeoutModal(this.component, null, null);
       this.openModalSpy = chai.spy.on(this.timeoutModal.modal, 'openDialog');
       this.startUiCountdownSpy = chai.spy.on(this.timeoutModal.timeout, 'startUiCountdown');
       this.hasExpiryTimeResetInAnotherTabSpy = chai.spy.on(this.timeoutModal, 'hasExpiryTimeResetInAnotherTab');
@@ -60,27 +59,22 @@ describe('Component: Timeout modal', function() {
 
   describe('When the modal is open', function() {
     beforeEach(function() {
-      this.time = new Date(Date.now() + 10 * 1000);
-      this.timeoutModal = new TimeoutModal(this.component, null, this.time);
+      this.timeoutModal = new TimeoutModal(this.component, null, null);
     });
 
-    it('then the aria-live should be set to assertive', function() {
-      expect(document.querySelector('.ons-js-timeout-timer-acc').getAttribute('aria-live')).to.equal('assertive');
-    });
-
-    it('then the timer text should change to countdown expired text when 0 seconds are left', function(done) {
+    it('then the timer should show the seconds counting', function(done) {
+      const time = document.querySelector('.ons-js-timeout-timer span').innerHTML;
       setTimeout(() => {
-        const text = document.querySelector('.ons-js-timeout-timer span').innerHTML;
-        expect(text).to.equal('You are being signed out.');
+        const changedTime = document.querySelector('.ons-js-timeout-timer span').innerHTML;
+        expect(changedTime).to.not.equal(time);
         done();
-      }, 3000);
+      }, 2000);
     });
   });
 
   describe('When the modal is open and the escape key is pressed', function() {
     beforeEach(function(done) {
-      this.time = new Date(Date.now() + 7 * 1000);
-      this.timeoutModal = new TimeoutModal(this.component, null, this.time);
+      this.timeoutModal = new TimeoutModal(this.component, null, null);
       this.timeoutModal.modal.openDialog();
       this.closeModalSpy = chai.spy.on(this.timeoutModal, 'closeModalAndRestartTimeout');
       this.restartTimeoutSpy = chai.spy.on(this.timeoutModal.timeout, 'restartTimeout');
@@ -103,8 +97,7 @@ describe('Component: Timeout modal', function() {
 
   describe('When the modal is open and the continue button is clicked', function() {
     beforeEach(function(done) {
-      this.time = new Date(Date.now() + 7 * 1000);
-      this.timeoutModal = new TimeoutModal(this.component, null, this.time);
+      this.timeoutModal = new TimeoutModal(this.component, null, null);
       this.timeoutModal.modal.openDialog();
       this.restartTimeoutSpy = chai.spy.on(this.timeoutModal.timeout, 'restartTimeout');
 
@@ -122,8 +115,7 @@ describe('Component: Timeout modal', function() {
 
   describe('When the modal is open and expiry time has been updated elsewhere', function() {
     beforeEach(function(done) {
-      this.time = new Date(Date.now() + 7 * 1000);
-      this.timeoutModal = new TimeoutModal(this.component, null, this.time);
+      this.timeoutModal = new TimeoutModal(this.component, null, null);
       this.restartTimeoutSpy = chai.spy.on(this.timeoutModal.timeout, 'restartTimeout');
       setTimeout(() => {
         this.timeoutModal.timeout.expiryTime = new Date(Date.now() + 7 * 1000);
@@ -139,8 +131,7 @@ describe('Component: Timeout modal', function() {
 
   describe('When there is a click event', function() {
     beforeEach(function(done) {
-      this.time = new Date(Date.now() + 20 * 1000);
-      this.timeoutModal = new TimeoutModal(this.component, null, this.time);
+      this.timeoutModal = new TimeoutModal(this.component, null, null);
       this.timeoutModal.modal.closeDialog();
       this.throttleSpy = chai.spy.on(this.timeoutModal.timeout, 'throttle');
 


### PR DESCRIPTION
### What is the context of this PR?
The polyfill used for the `dialog` element for IE11 required some additional css to work.

Also updated timeout.js so it can be used with an initial expiry time without the need to make a request the session endpoint. This is needed for the timeout panel.

### How to review
This is best tested in EQ.