### PR TITLE
Handle panel spacing using spacing css

### DIFF
--- a/src/components/error/_macro.njk
+++ b/src/components/error/_macro.njk
@@ -14,7 +14,6 @@
     {% call onsPanel({
         "type": "error",
         "id": params.id,
-        "classes": "ons-u-mb-s",
         "dsExample": params.dsExample
     }) %}
        {{ content | safe }}

--- a/src/scss/objects/_spacing.scss
+++ b/src/scss/objects/_spacing.scss
@@ -7,6 +7,7 @@
 .ons-summary__group +,
 .ons-collapsible:not(.ons-collapsible--accordion) + {
   .ons-figure,
+  .ons-panel,
   .ons-field,
   .ons-field-group,
   .ons-fieldset,


### PR DESCRIPTION
### What is the context of this PR?
This is a change to fix this issue in runner

![image](https://user-images.githubusercontent.com/42928680/160379756-1ae48f52-aa75-46cb-8891-8c354b7cb47a.png)

Is will now mean that any panel that follows a field or another panel now has a margin top added and error panels no longer need a margin bottom.

Fixes #2092 and #1896

### How to review
- Test putting two error panels next to each other on a page
- Test putting an error panel following a field on a page
- Check percy output