### PR TITLE
Add ability to set attributes on list items

### DIFF
--- a/src/components/lists/_macro-options.md
+++ b/src/components/lists/_macro-options.md
@@ -17,12 +17,10 @@
 | url | string | false | Will wrap the text in a link |
 | listClasses | string | false | Classes to be added to the list item |
 | variants | string | false | Used for variations. Available `variants` values: `inPageLink` for use with error lists when a `url` is also provided |
-| rel | string | false | allows setting of rel attribute for list item links |
 | target | string | false | If `url` is provided this will set the target for that link |
 | screenreaderMessage | string | false | Sets a message to be read out by screen readers when `target` is set to `_blank` and link opens in a new tab. Defaults to `this link will open in a new tab` if not set |
-| index | boolean | false | Will prefix the list item with index number if set to `true` |
 | external | boolean | false | Will style the item like an external link |
 | prefix | string | true | Will prefix the list item with whatever prefix is set to |
 | suffix | string | true | Will suffix the list item with whatever suffix is set to |
 | iconType | string | true | Adds an icon to the list item when set to the name of one of the [available icons](/foundations/icons#a-to-z) |
-| attributes | object | false | HTML attributes (for example, data attributes) to add to the list item |
+| attributes | object | false | HTML attributes (for example, data attributes) to add to list item links |

--- a/src/components/lists/_macro-options.md
+++ b/src/components/lists/_macro-options.md
@@ -25,3 +25,5 @@
 | prefix | string | true | Will prefix the list item with whatever prefix is set to |
 | suffix | string | true | Will suffix the list item with whatever suffix is set to |
 | iconType | string | true | Adds an icon to the list item when set to the name of one of the [available icons](/foundations/icons#a-to-z) |
+| iconType | string | true | Adds an icon to the list item when set to the name of one of the [available icons](/foundations/icons#a-to-z) |
+| attributes | object | false | HTML attributes (for example, data attributes) to add to the list item |

--- a/src/components/lists/_macro-options.md
+++ b/src/components/lists/_macro-options.md
@@ -25,5 +25,4 @@
 | prefix | string | true | Will prefix the list item with whatever prefix is set to |
 | suffix | string | true | Will suffix the list item with whatever suffix is set to |
 | iconType | string | true | Adds an icon to the list item when set to the name of one of the [available icons](/foundations/icons#a-to-z) |
-| iconType | string | true | Adds an icon to the list item when set to the name of one of the [available icons](/foundations/icons#a-to-z) |
 | attributes | object | false | HTML attributes (for example, data attributes) to add to the list item |

--- a/src/components/lists/_macro.njk
+++ b/src/components/lists/_macro.njk
@@ -65,7 +65,7 @@
                                 })
                             }}
                         {%- else -%}
-                            <a href="{{ item.url }}" class="ons-list__link {% if item.variants == 'inPageLink' %}ons-js-inpagelink {% endif %} {{ item.classes }}"{% if item.index is defined and item.index %} data-qa="list-item-{{ loop.index }}"{% endif %}{% if item.target is defined and item.target %} target="{{ item.target }}"{% endif %}{% if item.rel is defined and item.rel %} rel="{{ item.rel }}"{% endif %}>
+                            <a href="{{ item.url }}" class="ons-list__link {% if item.variants == 'inPageLink' %}ons-js-inpagelink {% endif %} {{ item.classes }}"{% if item.index is defined and item.index %} data-qa="list-item-{{ loop.index }}"{% endif %}{% if item.target is defined and item.target %} target="{{ item.target }}"{% endif %}{% if item.rel is defined and item.rel %} rel="{{ item.rel }}"{% endif %}{% if item.attributes is defined and item.attributes %}{% for attribute, value in (item.attributes.items() if item.attributes is mapping and item.attributes.items else item.attributes) %} {{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}>
                                 {%- if item.prefix is defined and item.prefix -%}<span class="ons-u-vh">{{- item.prefix -}}</span>{%- endif -%} {{- itemText | safe -}}
                                 {%- if item.target is defined and item.target == "_blank" -%}<span class="ons-u-vh">{{- item.screenreaderMessage | default("this link will open in a new tab") -}}</span>{%- endif -%}
                             </a>

--- a/src/components/lists/_macro.njk
+++ b/src/components/lists/_macro.njk
@@ -38,21 +38,19 @@
                         {% set itemText = item.title %}
                     {% endif %}
 
-                    {%- if item.index is defined and item.index or item.prefix is defined and item.prefix or (params.iconPosition is defined and params.iconPosition == 'before') -%}
+                    {%- if item.prefix is defined and item.prefix or (params.iconPosition is defined and params.iconPosition == 'before') -%}
                         <span class="ons-list__prefix"{% if listEl != 'ol' %} aria-hidden="true"{% endif %}>
-                        {%- if item.prefix is defined and item.prefix -%}
-                            {{- item.prefix -}}.
-                        {%- elif (item.index is defined and item.index and listEl != 'ol') or (item.index is defined and item.index and listEl == 'ol' and 'bare' in variants) -%}
-                            {{- loop.index -}}.
-                        {% elif params.iconPosition is defined and params.iconPosition == 'before' %}
-                            {% from "components/icons/_macro.njk" import onsIcon %}
-                            {{
-                                onsIcon({
-                                    "iconType": iconType,
-                                    "iconSize": params.iconSize
-                                })
-                            }}
-                        {%- endif -%}
+                            {%- if item.prefix is defined and item.prefix -%}
+                                {{- item.prefix -}}.
+                            {% elif params.iconPosition is defined and params.iconPosition == 'before' %}
+                                {% from "components/icons/_macro.njk" import onsIcon %}
+                                {{
+                                    onsIcon({
+                                        "iconType": iconType,
+                                        "iconSize": params.iconSize
+                                    })
+                                }}
+                            {%- endif -%}
                         </span>
                     {%- endif -%}
                     {%- if item.url is defined and item.url and item.current != true -%}
@@ -65,7 +63,7 @@
                                 })
                             }}
                         {%- else -%}
-                            <a href="{{ item.url }}" class="ons-list__link {% if item.variants == 'inPageLink' %}ons-js-inpagelink {% endif %} {{ item.classes }}"{% if item.index is defined and item.index %} data-qa="list-item-{{ loop.index }}"{% endif %}{% if item.target is defined and item.target %} target="{{ item.target }}"{% endif %}{% if item.rel is defined and item.rel %} rel="{{ item.rel }}"{% endif %}{% if item.attributes is defined and item.attributes %}{% for attribute, value in (item.attributes.items() if item.attributes is mapping and item.attributes.items else item.attributes) %} {{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}>
+                            <a href="{{ item.url }}" class="ons-list__link{% if item.variants == 'inPageLink' %} ons-js-inpagelink{% endif %}{% if item.classes is defined and item.classes %} {{ item.classes }}{% endif %}"{% if item.target is defined and item.target %} target="{{ item.target }}"{% endif %}{% if item.attributes is defined and item.attributes %}{% for attribute, value in (item.attributes.items() if item.attributes is mapping and item.attributes.items else item.attributes) %} {{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}>
                                 {%- if item.prefix is defined and item.prefix -%}<span class="ons-u-vh">{{- item.prefix -}}</span>{%- endif -%} {{- itemText | safe -}}
                                 {%- if item.target is defined and item.target == "_blank" -%}<span class="ons-u-vh">{{- item.screenreaderMessage | default("this link will open in a new tab") -}}</span>{%- endif -%}
                             </a>

--- a/src/foundations/style/typography/lists/examples/list-icon-social/index.njk
+++ b/src/foundations/style/typography/lists/examples/list-icon-social/index.njk
@@ -9,25 +9,33 @@
                 "url": '#0',
                 "text": 'Twitter',
                 "iconType": 'twitter',
-                "rel": 'noreferrer external'
+                "attributes": {
+                    "rel": 'noreferrer external'
+                }
             },
             {
                 "url": '#0',
                 "text": 'Facebook',
                 "iconType": 'facebook',
-                "rel": 'noreferrer external'
+                "attributes": {
+                    "rel": 'noreferrer external'
+                }
             },
             {
                 "url": '#0',
                 "text": 'Instagram',
                 "iconType": 'instagram',
-                "rel": 'noreferrer external'
+                "attributes": {
+                    "rel": 'noreferrer external'
+                }
             },
             {
                 "url": '#0',
                 "text": 'LinkedIn',
                 "iconType": 'linkedin',
-                "rel": 'noreferrer external'
+                "attributes": {
+                    "rel": 'noreferrer external'
+                }
             }
         ]
     })


### PR DESCRIPTION
### What is the context of this PR?
Add ability to be able to set HTML attributes on link list items. This will allow data attributes to be set for runner error panel tests to find elements

This PR also removes the `rel` and `index` params. `rel` can now be set using the attributes param and it was felt `index` was no longer needed because there are other ways of prefixing lists with numbers.

Also this PR will fix the issue with extra spaces in the class attribute on list items.

### What are the breaking changes?
The breaking changes included in this PR mean that the `rel` and `index` attributes will no longer be available on lists.
- Use of `index` should be replaced with setting `"element": 'ol'` on the list and if needed add the `data-qa` attribute using the new `attributes` param. 
- `rel` should also now be set using the new `attributes` param.

### How to review
- Add an attribute to a list item that is a link and see that it has been added to the HTML
- See that extra space is removed from list item class lists

Fixes: #2097 