### PR TITLE
Fix panel bug with no icon

### DIFF
--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -213,9 +213,10 @@
         margin-top: -15% !important;
       }
     }
-    &__body {
-      padding-left: 2rem;
-    }
+  }
+
+  &__icon + &__body {
+    padding-left: 2rem;
   }
 
   &--bare & {
@@ -228,6 +229,7 @@
     }
   }
 
+  &--info,
   &--bare,
   &--success,
   &--warn,


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2101 

This change will only add the padding left for icons when using an icon. It also fixes an issue where if an icon is used with an information panel it will not be aligned correctly

### How to review
- Test adding an icon to an information panel
- Test removing the icon from the success panel
