### PR TITLE
Remove inert attribute to fix modal

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -52,7 +52,6 @@ export default class Modal {
         document.querySelector('body').classList.add(ie11Class);
       }
 
-      this.makePageContentInert();
       this.saveLastFocusedEl();
 
       if (event) {
@@ -79,20 +78,6 @@ export default class Modal {
     }
   }
 
-  makePageContentInert() {
-    if (document.querySelector('.ons-page')) {
-      document.querySelector('.ons-page').inert = true;
-      document.querySelector('.ons-page').setAttribute('aria-hidden', 'true');
-    }
-  }
-
-  removeInertFromPageContent() {
-    if (document.querySelector('.ons-page')) {
-      document.querySelector('.ons-page').inert = false;
-      document.querySelector('.ons-page').setAttribute('aria-hidden', 'false');
-    }
-  }
-
   isDialogOpen() {
     return this.component['open'];
   }
@@ -111,7 +96,6 @@ export default class Modal {
 
       this.component.close();
       this.setFocusOnLastFocusedEl(this.lastFocusedEl);
-      this.removeInertFromPageContent();
     }
   }
 }

--- a/src/components/timeout-modal/index.njk
+++ b/src/components/timeout-modal/index.njk
@@ -81,7 +81,6 @@ The WCAG  guidelines state:
 
 - there should be no limit to the number of times a user can extend their session
 - the timeout modal should announce the remaining time at appropriate intervals to assistive technology
-- the underlying page content should be made inert, and the available action on the modal must be put in focus, for example, the “Continue” button
 - when the modal is closed the previously focused element on the page must be put back in focus
 
 

--- a/src/tests/spec/modal/modal.spec.js
+++ b/src/tests/spec/modal/modal.spec.js
@@ -49,14 +49,6 @@ describe('Component: Modal', function() {
       it('then the modal should be visible', function() {
         expect(this.component.classList.contains('ons-u-db')).to.be.true;
       });
-
-      it('then the underlying page should be hidden from screen readers', function() {
-        expect(document.querySelector('.ons-page').getAttribute('aria-hidden')).to.equal('true');
-      });
-
-      it('then the underlying page should be set to inert', function() {
-        expect(document.querySelector('.ons-page').inert).to.equal(true);
-      });
     });
 
     describe('When the continue button is clicked', function() {
@@ -71,14 +63,6 @@ describe('Component: Modal', function() {
 
       it('then the underlying page should not be hidden from screen readers', function() {
         expect(document.querySelector('.ons-page').getAttribute('aria-hidden')).to.equal('false');
-      });
-
-      it('then the underlying page should not be set to inert', function() {
-        expect(document.querySelector('.ons-page').inert).to.equal(false);
-      });
-
-      it('then the body should not contain the overlay class', function() {
-        expect(document.body.classList.contains('ons-modal-overlay')).to.be.false;
       });
     });
   });


### PR DESCRIPTION
### What is the context of this PR?
Updating to Chrome 102 has uncovered a bug when using the `inert` attribute with modals. Because it now is supported by Chrome as of 102 it is causing the modal button itself to become inert so that the user is unable to click on it. The functionality we are getting from `inert` (disabling the page content below the modal) we are already getting for free by using the modal. So this PR is to remove the use of `inert` from the DS.

### How to review
Test in eQ to see that the page underneath the modal is not interactable/tabbable. Instructions on how to do this are at the bottom of the readme on this page (https://github.com/ONSdigital/eq-questionnaire-runner) and its best to use the `test_timeout_modal` schema
