### PR TITLE
Fix card macro and tests

### DIFF
--- a/src/components/card/_macro-options.md
+++ b/src/components/card/_macro-options.md
@@ -1,14 +1,14 @@
-| Name         | Type                                                        | Required | Description                                                                               |
-| ------------ | ----------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------- |
-| title        | string                                                      | true     | The title for the card heading                                                            |
-| titleSize    | string                                                      | false    | Number used to determine the heading level of the card title. Defaults to `2`             |
-| titleClasses | string                                                      | false    | Font size classes for the card heading. Defaults to `ons-u-fs-m`                          |
-| url          | string                                                      | true     | The URL for the title link `href` attribute                                               |
-| id           | string                                                      | true     | The HTML `id` attribute for the card heading                                              |
-| text         | string                                                      | true     | The excerpt text for the card element                                                     |
-| textId       | string                                                      | true     | The HTML `id` for the card text excerpt. Used for the card’s `aria-describedBy` attribute |
-| image        | `Object<Image>`                                             | false    | An object containing path attributes for [the card’s image](#image)                       |
-| itemsList    | `Array<ListItem>` [_(ref)_](/foundations/typography/#lists) | false    | A list of links for child items of the card                                               |
+| Name         | Type                                                        | Required | Description                                                                                                                                           |
+| ------------ | ----------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title        | string                                                      | true     | The title for the card heading                                                                                                                        |
+| titleSize    | string                                                      | false    | Number used to determine the heading level of the card title. Defaults to `2`                                                                         |
+| titleClasses | string                                                      | false    | Font size classes for the card heading. Defaults to `ons-u-fs-m`                                                                                      |
+| url          | string                                                      | true     | The URL for the title link `href` attribute                                                                                                           |
+| id           | string                                                      | true     | The HTML `id` attribute for the card heading                                                                                                          |
+| text         | string                                                      | true     | The excerpt text for the card element                                                                                                                 |
+| textId       | string                                                      | true     | The HTML `id` for the card text excerpt. Used for the card’s `aria-describedBy` attribute                                                             |
+| image        | `Object<Image>` or `true`                                   | false    | An object containing path attributes for [the card’s image](#image). If value is `true` will show placeholder with root as `placeholderURL` base path |
+| itemsList    | `Array<ListItem>` [_(ref)_](/foundations/typography/#lists) | false    | A list of links for child items of the card                                                                                                           |
 
 ## Image
 

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -10,9 +10,9 @@
 
       <a href="{{ params.url }}" class="ons-card__link ons-u-db">
 
-        {% if params.image is defined and params.image and params.image.smallSrc is defined and params.image.smallSrc %}
+        {% if params.image.smallSrc is defined and params.image.smallSrc %}
           <img class="ons-card__image ons-u-mb-s" height="200" width="303"{% if params.image.largeSrc is defined and params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
-        {% else %}
+        {% elif params.image == true or params.image.placeholderURL is defined %}
           <img class="ons-card__image ons-u-mb-s" height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
         {% endif %}
 
@@ -24,8 +24,8 @@
 
     {%- else -%}
 
-      <h{{ titleSize }} class="{{ params.titleClasses | default('ons-u-fs-m') }}" id="{{ params.id }}">
-        <a href="{{ params.url }}">{{ params.title }}</a>
+      <h{{ titleSize }} class="ons-card__title {{ params.titleClasses | default('ons-u-fs-m') }}" id="{{ params.id }}">
+        <a class="ons-card__link" href="{{ params.url }}">{{ params.title }}</a>
       </h{{ titleSize }}>
 
     {%- endif -%}

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -4,7 +4,7 @@
 
   {% set titleSize = params.titleSize | default('2') %}
 
-  <div class="ons-card" aria-labelledBy="{{ params.id }}" aria-describedBy="{{ params.textId }}">
+  <div class="ons-card" aria-describedBy="{{ params.textId }}">
 
     {%- if params.image is defined and params.image -%}
 

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -7,25 +7,32 @@
   <div class="ons-card" aria-describedBy="{{ params.textId }}">
 
     {%- if params.image is defined and params.image -%}
+      {%- if params.url is defined and params.url -%}
+        <a href="{{ params.url }}" class="ons-card__link ons-u-db">
+      {%- endif -%}
+          {% if params.image.smallSrc is defined and params.image.smallSrc %}
+            <img class="ons-card__image ons-u-mb-s" height="200" width="303"{% if params.image.largeSrc is defined and params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
+          {% elif params.image == true or params.image.placeholderURL is defined %}
+            <img class="ons-card__image ons-u-mb-s" height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
+          {% endif %}
 
-      <a href="{{ params.url }}" class="ons-card__link ons-u-db">
-
-        {% if params.image.smallSrc is defined and params.image.smallSrc %}
-          <img class="ons-card__image ons-u-mb-s" height="200" width="303"{% if params.image.largeSrc is defined and params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
-        {% elif params.image == true or params.image.placeholderURL is defined %}
-          <img class="ons-card__image ons-u-mb-s" height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL is defined and params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
-        {% endif %}
-
-        <h{{ titleSize }} class="ons-card__title {{ params.titleClasses | default('ons-u-fs-m')}}" id="{{ params.id }}">
-          {{ params.title }}
-        </h{{ titleSize }}>
-
-      </a>
+          <h{{ titleSize }} class="ons-card__title {{ params.titleClasses | default('ons-u-fs-m')}}" id="{{ params.id }}">
+            {{ params.title }}
+          </h{{ titleSize }}>
+      {%- if params.url is defined and params.url -%}
+        </a>
+      {%- endif -%}
 
     {%- else -%}
 
       <h{{ titleSize }} class="ons-card__title {{ params.titleClasses | default('ons-u-fs-m') }}" id="{{ params.id }}">
-        <a class="ons-card__link" href="{{ params.url }}">{{ params.title }}</a>
+        {%- if params.url is defined and params.url -%}
+          <a class="ons-card__link" href="{{ params.url }}">
+        {%- endif -%}
+          {{ params.title }}
+        {%- if params.url is defined and params.url -%}
+          </a>
+        {%- endif -%}
       </h{{ titleSize }}>
 
     {%- endif -%}

--- a/src/components/card/_macro.spec.js
+++ b/src/components/card/_macro.spec.js
@@ -26,8 +26,16 @@ const EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE = {
   title: 'Example card title',
   text: 'Example card text.',
   textId: 'example-text-id',
-  placeholderURL: '/placeholder-image-url',
-  image: {},
+  image: true,
+};
+
+const EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE_WITH_PATH = {
+  title: 'Example card title',
+  text: 'Example card text.',
+  textId: 'example-text-id',
+  image: {
+    placeholderURL: '/placeholder-image-url',
+  },
 };
 
 describe('macro: card', () => {
@@ -206,21 +214,47 @@ describe('macro: card', () => {
       it('outputs an `img` element with the expected `srcset`', () => {
         const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE));
 
+        expect($('.ons-card__image').attr('srcset')).toBe('/img/small/placeholder-card.png 1x, /img/large/placeholder-card.png 2x');
+      });
+
+      it('outputs an `img` element with the expected `src`', () => {
+        const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE));
+
+        expect($('.ons-card__image').attr('src')).toBe('/img/small/placeholder-card.png');
+      });
+
+      it('outputs an `img` element with the expected empty alt text', () => {
+        const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE));
+
+        expect($('.ons-card__image').attr('alt')).toBe('');
+      });
+    });
+
+    describe('with a default placeholder image with `placeholderURL`', () => {
+      it('outputs an `img` element', () => {
+        const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE_WITH_PATH));
+
+        expect($('.ons-card__image')[0].tagName).toBe('img');
+      });
+
+      it('outputs an `img` element with the expected `srcset`', () => {
+        const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE_WITH_PATH));
+
         expect($('.ons-card__image').attr('srcset')).toBe(
           '/placeholder-image-url/img/small/placeholder-card.png 1x, /placeholder-image-url/img/large/placeholder-card.png 2x',
         );
       });
 
       it('outputs an `img` element with the expected `src`', () => {
-        const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE));
+        const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE_WITH_PATH));
 
         expect($('.ons-card__image').attr('src')).toBe('/placeholder-image-url/img/small/placeholder-card.png');
       });
 
-      it('outputs an `img` element with the expected alt text', () => {
-        const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE));
+      it('outputs an `img` element with the expected empty alt text', () => {
+        const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE_WITH_PATH));
 
-        expect($('.ons-card__image').attr('alt')).toBe('Image placeholder');
+        expect($('.ons-card__image').attr('alt')).toBe('');
       });
     });
   });

--- a/src/components/card/examples/card-image/index.njk
+++ b/src/components/card/examples/card-image/index.njk
@@ -10,9 +10,7 @@
                 "title": 'About the census',
                 "url": '#0',
                 "text": 'The census is a survey that gives us information about all the households in England and Wales.',
-                "image": {
-                    "placeholderURL": ''
-                }
+                "image": true
             }) }}
         </div>
 
@@ -23,9 +21,7 @@
                 "title": 'Working on the census',
                 "url": '#0',
                 "text": 'For Census 2021, we’ll be hiring at least 30,000 field staff across England and Wales.',
-                "image": {
-                    "placeholderURL": ''
-                }
+                "image": true
             }) }}
         </div>
 
@@ -36,9 +32,7 @@
                 "title": 'Your data and security',
                 "url": '#0',
                 "text": 'How we keep your data safe and what happens to your personal information.',
-                "image": {
-                    "placeholderURL": ''
-                }
+                "image": true
             }) }}
         </div>
 


### PR DESCRIPTION
### What is the context of this PR?
fixes #2060 and #2238 and #2236 and #2061

This PR also cleans up the usage of the placeholder image. The existing macro required `image.placeholderURL`. `placeholderURL` is used to specify the base path for the placeholder image. So if you didn't need to specifiy this you would need to provide an empty string `''` as the value to show the place holder image. Not great. This has been change so that passing in `image: true` will show the placeholder image with no specified base path (`placeholderURL`).

### How to review
Ensure tests pass and the code is up to scratch