### PR TITLE
Remove space from checkbox label class list

### DIFF
--- a/src/components/checkboxes/_checkbox-macro.njk
+++ b/src/components/checkboxes/_checkbox-macro.njk
@@ -20,7 +20,7 @@
             "for": params.id,
             "inputType": "checkbox",
             "text": params.label.text,
-            "classes": "ons-checkbox__label " + params.label.classes | default(''),
+            "classes": "ons-checkbox__label" + ( ' ' + params.label.classes if params.label.classes else ""),
             "description": params.label.description
         }) }}
 


### PR DESCRIPTION
### What is the context of this PR?
Currently there is a space added at the end of checkbox label class lists when a custom class isn't specified

### How to review
Compare this branch against master and see that space is removed after `ons-checkbox__label` in html
