### PR TITLE
Address input - fix error when manual input is `null`

### DIFF
--- a/src/components/address-input/autosuggest.address.setter.js
+++ b/src/components/address-input/autosuggest.address.setter.js
@@ -104,14 +104,18 @@ export default class AddressSetter {
 
   clearManualInputs() {
     this.manualInputs.forEach(input => {
-      input.value = '';
+      if (input !== null) {
+        input.value = '';
+      }
     });
   }
 
   checkManualInputsValues(onLoad) {
     if (onLoad) {
       this.originalValues = this.manualInputs.map(input => {
-        return input.value;
+        if (input !== null) {
+          return input.value;
+        }
       });
     } else if (this.uprn.value !== '' && this.originalValues.length) {
       this.newValues = this.manualInputs.map(input => {

--- a/src/components/address-input/autosuggest.address.setter.js
+++ b/src/components/address-input/autosuggest.address.setter.js
@@ -104,7 +104,7 @@ export default class AddressSetter {
 
   clearManualInputs() {
     this.manualInputs.forEach(input => {
-      if (input !== null) {
+      if (input) {
         input.value = '';
       }
     });
@@ -113,7 +113,7 @@ export default class AddressSetter {
   checkManualInputsValues(onLoad) {
     if (onLoad) {
       this.originalValues = this.manualInputs.map(input => {
-        if (input !== null) {
+        if (input) {
           return input.value;
         }
       });


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2285 

When a manual input field is not provided the `addressSetter` would error when attempting to check or clear the field value.

### How to review
Check there are no errors on the editable address input. There should only be the error for not being able to connect to the AIMS endpoint