### PR TITLE
Fix mutually exclusive bug for runner

### DIFF
--- a/src/components/mutually-exclusive/_macro.njk
+++ b/src/components/mutually-exclusive/_macro.njk
@@ -52,7 +52,7 @@
                             "dontWrap": true,
                             "radios": params.exclusiveOptions,
                             "inputClasses": "ons-js-exclusive-option",
-                            "name": "mutuallyExclusiveRadio",
+                            "name": params.exclusiveOptions[0].name,
                             "deselectMessage": params.deselectMessage
                         })
                     }}

--- a/src/components/mutually-exclusive/_macro.njk
+++ b/src/components/mutually-exclusive/_macro.njk
@@ -52,7 +52,7 @@
                             "dontWrap": true,
                             "radios": params.exclusiveOptions,
                             "inputClasses": "ons-js-exclusive-option",
-                            "name": params.exclusiveOptions[0].name,
+                            "name": params.exclusiveOptions[0].name | default("mutuallyExclusiveRadio"),
                             "deselectMessage": params.deselectMessage
                         })
                     }}

--- a/src/components/mutually-exclusive/_macro.spec.js
+++ b/src/components/mutually-exclusive/_macro.spec.js
@@ -45,6 +45,7 @@ const EXAMPLE_MUTUALLY_EXCLUSIVE_RADIOS = {
   exclusiveOptions: [
     {
       id: 'house',
+      name: 'mutuallyExclusiveRadio',
       label: {
         text: 'House or bungalow',
       },
@@ -52,6 +53,7 @@ const EXAMPLE_MUTUALLY_EXCLUSIVE_RADIOS = {
     },
     {
       id: 'flat',
+      name: 'mutuallyExclusiveRadio',
       label: {
         text: 'Flat, maisonette or apartment',
       },

--- a/src/components/mutually-exclusive/examples/multiple-options/index.njk
+++ b/src/components/mutually-exclusive/examples/multiple-options/index.njk
@@ -42,6 +42,7 @@
                 "exclusiveOptions": [
                     {
                         "id": "no-central-heating",
+                        "name": "no central heating",
                         "label": {
                             "text": "No central heating"
                         },
@@ -49,6 +50,7 @@
                     },
                     {
                         "id": "other",
+                        "name": "other",
                         "label": {
                             "text": "Other"
                         },


### PR DESCRIPTION
### What is the context of this PR?
This change will allow mutually exclusive radio buttons to be no longer hardcoded  to `mutuallyExclusiveRadio` which fixes a bug in runner. The bug in runner is stopping the clicked answer being picked up because it uses the mutually exclusive options name to find it.

### How to review
Check that multiple mutually exclusive options still work and look as expected
