### PR TITLE
Page config requires variants header property

### DIFF
--- a/src/foundations/layout/page-template/index.njk
+++ b/src/foundations/layout/page-template/index.njk
@@ -120,7 +120,8 @@ Variables can be set with:
 | ---------------- | ------ | ------------------------------------ | ------------------------------------------------------------------------------------------ |
 | title            | string | false                                | Title for the page header. If not specified this will default to `page.title`              |
 | classes          | string | false                                | CSS classes to be added to the header                                                      |
-| noMasthead       | boolean | false                                | Does not render a masthead with organisation logo, service or language link. Language link will be rendered in the main header. Service links are not available when using this option |
+| noMasthead       | boolean | false                               | Does not render a masthead with organisation logo, service or language link. Language link will be rendered in the main header. Service links are not available when using this option |
+| variants         | array or string                               | false | An array of values or single value (string) to adjust the component using available variants: “internal”, "neutral" and “description” |
 | orgLogo          | string | false                                | URL for the page header logo                                                               |
 | orgMobileLogo    | string | false                                | URL for image to use for small screens instead of a title string                           |
 | orgLogoAlt       | string | false                                | Alt tag for the page header logo                                                           |

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -149,6 +149,7 @@
                             onsHeader({
                                 "title": pageConfig.header.title | default(pageConfig.title),
                                 "classes": pageConfig.header.classes,
+                                "variants": pageConfig.header.variants,
                                 "wide": pageConfig.wide,
                                 "language": pageConfig.language,
                                 "button": pageConfig.signoutButton,


### PR DESCRIPTION
### What is the context of this PR?
`variants` is missing from `pageConfig.header`

