### PR TITLE
Fix: Cookies settings - check for missing cookie type

### DIFF
--- a/src/js/cookies-settings.js
+++ b/src/js/cookies-settings.js
@@ -33,12 +33,14 @@ export default class CookiesSettings {
       let radioButton;
 
       if (currentConsentCookieJSON[cookieType]) {
-        radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=on]');
+        radioButton = document.querySelector(`input[name=cookies-${cookieType}][value=on]`);
       } else {
-        radioButton = document.querySelector('input[name=cookies-' + cookieType + '][value=off]');
+        radioButton = document.querySelector(`input[name=cookies-${cookieType}][value=off]`);
       }
 
-      radioButton.checked = true;
+      if (radioButton) {
+        radioButton.checked = true;
+      }
     }
   }
 

--- a/src/js/cookies-settings.spec.js
+++ b/src/js/cookies-settings.spec.js
@@ -22,6 +22,20 @@ const EXAMPLE_COOKIES_SETTINGS_PAGE = `
   </div>
 `;
 
+const EXAMPLE_PART_COOKIES_SETTINGS_PAGE = `
+  <form data-module="cookie-settings">
+    <input type="radio" class="ons-js-radio" name="cookies-settings" value="on">
+    <input type="radio" class="ons-js-radio" name="cookies-settings" value="off">
+    <input type="radio" class="ons-js-radio" name="cookies-campaigns" value="on">
+    <input type="radio" class="ons-js-radio" name="cookies-campaigns" value="off">
+    <button id="submit-button" type="submit">Submit</button>
+  </form>
+
+  <div class="ons-cookies-confirmation-message ons-u-d-no">
+    <a class="ons-js-return-link" href="#0">Return to previous page</a>
+  </div>
+`;
+
 describe('script: cookies-settings', () => {
   beforeEach(async () => {
     const client = await page.target().createCDPSession();
@@ -43,7 +57,7 @@ describe('script: cookies-settings', () => {
     });
   });
 
-  it('sets all radio buttons to the default values', async () => {
+  it('sets all radio buttons to the default values of every `cookieType`', async () => {
     await setTestPage('/test', EXAMPLE_COOKIES_SETTINGS_PAGE);
 
     const cookiesSettingsOffRadio = await page.$eval('input[name=cookies-settings][value=off]', node => node.checked);
@@ -52,6 +66,16 @@ describe('script: cookies-settings', () => {
 
     expect(cookiesSettingsOffRadio).toBe(true);
     expect(cookiesUsageOffRadio).toBe(true);
+    expect(cookiesCampaignsOffRadio).toBe(true);
+  });
+
+  it('sets the provided radio buttons to the default values of every matched `cookieType`', async () => {
+    await setTestPage('/test', EXAMPLE_PART_COOKIES_SETTINGS_PAGE);
+
+    const cookiesSettingsOffRadio = await page.$eval('input[name=cookies-settings][value=off]', node => node.checked);
+    const cookiesCampaignsOffRadio = await page.$eval('input[name=cookies-campaigns][value=off]', node => node.checked);
+
+    expect(cookiesSettingsOffRadio).toBe(true);
     expect(cookiesCampaignsOffRadio).toBe(true);
   });
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes https://github.com/ONSdigital/ons-ids-website/issues/37

The cookie settings page JS required each `cookieType` to have a corresponding set of `radios`.

This PR fixes this by checking for a matching radio before setting it to `checked`

### How to review
Remove a set of radios from the settings page and check there are no console errors and that all other radios are checked.