### PR TITLE
Fix font weight on fieldset legends

### DIFF
--- a/src/components/checkboxes/_macro.njk
+++ b/src/components/checkboxes/_macro.njk
@@ -85,7 +85,7 @@
                                     "text": checkbox.other.label.text
                                 },
                                 "legend": checkbox.other.legend,
-                                "legendClasses": checkbox.other.legendClasses | default('') + ' ons-u-mb-xs',
+                                "legendClasses": checkbox.other.legendClasses,
                                 "value": checkbox.other.value,
                                 "autoSelect": checkbox.other.autoSelect,
                                 "selectAllChildren": checkbox.other.selectAllChildren,

--- a/src/components/checkboxes/examples/checkboxes-other-radios/index.njk
+++ b/src/components/checkboxes/examples/checkboxes-other-radios/index.njk
@@ -31,7 +31,7 @@
                     "otherType": "radios",
                     "id": "phone-time",
                     "name": "phone-time",
-                    "legend":  "Choose preferred time of day",
+                    "legend": "Choose preferred time of day",
                     "radios": [
                         {
                             "value": "anytime",

--- a/src/components/duration/_macro.njk
+++ b/src/components/duration/_macro.njk
@@ -84,7 +84,7 @@
             "id": params.id,
             "legend": params.legendOrLabel,
             "description": params.description,
-            "legendClasses": 'ons-u-mb-xs ' + (params.legendClasses if params.legendClasses else ''),
+            "legendClasses": params.legendClasses,
             "error": params.error,
             "legendIsQuestionTitle": params.legendIsQuestionTitle,
             "dontWrap": params.dontWrap

--- a/src/components/duration/_macro.spec.js
+++ b/src/components/duration/_macro.spec.js
@@ -127,7 +127,7 @@ describe('macro: duration', () => {
         id: 'duration',
         legend: 'How long have you lived at this address?',
         description: 'Enter “0” into the years field if you have lived at this address for less than a year',
-        legendClasses: 'ons-u-mb-xs custom-legend-class',
+        legendClasses: 'custom-legend-class',
         dontWrap: true,
         legendIsQuestionTitle: true,
         error: false,

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -15,6 +15,7 @@
     .ons-fieldset {
       &__legend {
         font-weight: normal;
+        margin: 0;
       }
     }
   }

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -11,12 +11,13 @@
     font-weight: normal;
   }
 
-  .ons-fieldset {
+  > * .ons-fieldset {
     &__legend {
       margin: 0 0 0.6rem;
     }
     .ons-fieldset {
       &__legend {
+        font-weight: normal;
         margin: 0;
       }
     }

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -17,7 +17,6 @@
     }
     .ons-fieldset {
       &__legend {
-        font-weight: normal;
         margin: 0;
       }
     }

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -1,6 +1,6 @@
 .ons-fieldset {
   &__legend {
-    @extend .ons-label;
+    margin: 0 0 0.6rem;
   }
 
   &__description:not(&__description--title) {
@@ -15,7 +15,6 @@
     .ons-fieldset {
       &__legend {
         font-weight: normal;
-        margin: 0;
       }
     }
   }

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -12,13 +12,9 @@
   }
 
   > * .ons-fieldset {
-    &__legend {
-      margin: 0 0 0.6rem;
-    }
     .ons-fieldset {
       &__legend {
         font-weight: normal;
-        margin: 0;
       }
     }
   }

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -1,5 +1,6 @@
 .ons-fieldset {
   &__legend {
+    font-weight: $font-weight-bold;
     margin: 0 0 0.6rem;
   }
 

--- a/src/components/label/_label.scss
+++ b/src/components/label/_label.scss
@@ -2,7 +2,8 @@
   color: inherit;
   display: block;
   font-weight: $font-weight-bold;
-  margin-bottom: 0.4rem;
+
+  @extend .ons-u-mb-xs;
 
   &__description {
     @extend .ons-u-fs-s;

--- a/src/components/label/_label.scss
+++ b/src/components/label/_label.scss
@@ -2,8 +2,7 @@
   color: inherit;
   display: block;
   font-weight: $font-weight-bold;
-
-  @extend .ons-u-mb-xs;
+  margin: 0 0 0.6rem;
 
   &__description {
     @extend .ons-u-fs-s;

--- a/src/components/radios/examples/radios-other-checkboxes/index.njk
+++ b/src/components/radios/examples/radios-other-checkboxes/index.njk
@@ -31,7 +31,7 @@
                     "selectAllChildren": true,
                     "id": "phone-time",
                     "name": "phone-time",
-                    "legend":  "Select preferred times of day",
+                    "legend": "Select preferred times of day",
                     "checkboxes": [
                         {
                             "value": "anytime",

--- a/src/components/radios/examples/radios-other-radios/index.njk
+++ b/src/components/radios/examples/radios-other-radios/index.njk
@@ -30,7 +30,7 @@
                     "otherType": "radios",
                     "id": "phone-time",
                     "name": "phone-time",
-                    "legend":  "Choose preferred time of day",
+                    "legend": "Choose preferred time of day",
                     "radios": [
                         {
                             "value": "anytime",


### PR DESCRIPTION
### What is the context of this PR?
There is a difference in font weight between fieldsets and labels. The fieldset css is inherited from label but is then overridden by a `font-weight: normal;` line. This PR removes that line.

![Screenshot 2022-07-15 at 10 47 35](https://user-images.githubusercontent.com/42928680/179201588-54f03453-b51e-4479-bef9-dfcd45edc0e9.png)

### How to review
Test the duration example on master and on this branch with these params set to see the difference
```   
"dontWrap": false,
"legendOrLabel": "label",
```

