### PR TITLE
Fix: Autosuggest - z-index on results

### DIFF
--- a/src/components/autosuggest/_autosuggest.scss
+++ b/src/components/autosuggest/_autosuggest.scss
@@ -131,7 +131,7 @@
       box-shadow: 0 0 5px 0 rgba($color-black, 0.6);
       left: 0;
       position: absolute;
-      z-index: 1;
+      z-index: 10;
     }
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
fixes #2328 

The autosuggest results would float behind the hero for the search in the header of the DS website (homepage).
 
### How to review
Observe that this does not happen.