### PR TITLE
Accessible focus styles

### DIFF
--- a/src/components/autosuggest/_autosuggest.scss
+++ b/src/components/autosuggest/_autosuggest.scss
@@ -11,7 +11,7 @@
   }
 
   &__results {
-    border: 1px solid $color-input;
+    border: 1px solid $color-input-border;
     border-radius: $input-radius;
     display: none;
     margin: 0.5rem 0 0;
@@ -27,7 +27,7 @@
 
   &__results-title {
     background: $color-grey-15;
-    border-bottom: 1px solid $color-input;
+    border-bottom: 1px solid $color-input-border;
     padding: 0.25rem 0.5rem;
   }
 
@@ -48,7 +48,7 @@
     padding: $input-padding-horizontal;
 
     &:not(:last-child) {
-      border-bottom: 1px solid $color-input;
+      border-bottom: 1px solid $color-input-border;
     }
 
     &:not(&--no-results):not(&--more-results):hover,
@@ -87,7 +87,7 @@
     padding-left: 0.5rem;
 
     &:not(:last-child) {
-      border-bottom: 1px solid $color-input;
+      border-bottom: 1px solid $color-input-border;
     }
   }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -386,10 +386,17 @@ $button-shadow-size: 3px;
   &--ghost-dark:focus &,
   &--dropdown:focus & {
     &__inner {
-      box-shadow: none;
+      border-color: $color-text-link-focus;
+      box-shadow: 0 0 0 1px $color-text-link-focus;
       .ons-svg-icon {
         fill: $color-black;
       }
+    }
+  }
+
+  &--dropdown:focus & {
+    &__inner {
+      box-shadow: inset 0 -4px 0 0 $color-text-link-focus;
     }
   }
 

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -10,7 +10,7 @@ $checkbox-padding: 11px;
   &__input {
     appearance: none;
     background: url(#{$static}/img/icons--check.svg) no-repeat center center;
-    background-color: $color-white;
+    background-color: $color-input-bg;
     background-size: 0;
     border: 2px solid $color-input-border;
     border-radius: 0.2rem;
@@ -101,7 +101,7 @@ $checkbox-padding: 11px;
       }
 
       &:focus {
-        box-shadow: 0 0 0 3px $color-focus;
+        @extend %ons-input-focus;
       }
 
       & + .ons-checkbox__label {
@@ -179,7 +179,7 @@ $checkbox-padding: 11px;
       top: 0.1rem;
 
       &:focus {
-        box-shadow: 0 0 0 3px $color-focus;
+        @extend %ons-input-focus;
       }
     }
 

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -12,7 +12,7 @@ $checkbox-padding: 11px;
     background: url(#{$static}/img/icons--check.svg) no-repeat center center;
     background-color: $color-white;
     background-size: 0;
-    border: 2px solid $color-input;
+    border: 2px solid $color-input-border;
     border-radius: 0.2rem;
     box-sizing: border-box;
     height: $checkbox-input-width;
@@ -73,7 +73,7 @@ $checkbox-padding: 11px;
       }
 
       &:focus {
-        box-shadow: 0 0 0 3px $color-focus;
+        @extend %ons-input-focus;
       }
     }
 
@@ -122,7 +122,7 @@ $checkbox-padding: 11px;
 
     &::before {
       background: $color-white;
-      border: 1px solid $color-input;
+      border: 1px solid $color-input-border;
       border-radius: 3px;
       bottom: 0;
       content: '';
@@ -152,7 +152,7 @@ $checkbox-padding: 11px;
 
   &__input:checked + &__label::before {
     background: $color-grey-5;
-    box-shadow: 0 0 0 1px $color-input;
+    box-shadow: 0 0 0 1px $color-input-border;
   }
 
   .ons-panel--error .ons-radio__input:checked ~ &__other > .ons-input--text:required:not(:focus) {

--- a/src/components/input/_input-type.scss
+++ b/src/components/input/_input-type.scss
@@ -14,7 +14,8 @@
     z-index: 1;
 
     &:focus {
-      box-shadow: inset 0 0 0 1px $color-input;
+      // Overide default input focus so it can wrap prefix/suffix too
+      box-shadow: none;
     }
   }
 
@@ -36,19 +37,26 @@
 
   &__type,
   &__type[title] {
-    border: 1px solid $color-input;
+    border: 1px solid $color-input-border;
   }
 
   &__input:focus + &__type::after {
+    // Style input + prefix/suffix on focus
+    @extend %ons-input-focus;
+
     border-radius: $input-radius;
     bottom: 0;
-    box-shadow: 0 0 0 3px $color-focus;
     content: '';
     display: block;
     left: 0;
     position: absolute;
     right: 0;
     top: 0;
+  }
+
+  &--error:not(:focus) {
+    border: $input-border-width solid $color-errors;
+    box-shadow: 0 0 0 $input-border-width $color-errors;
   }
 
   &:not(&--prefix) & {

--- a/src/components/input/_input-type.scss
+++ b/src/components/input/_input-type.scss
@@ -17,6 +17,12 @@
       // Overide default input focus so it can wrap prefix/suffix too
       box-shadow: none;
     }
+
+    // Overide default input error style so it can wrap prefix/suffix too
+    &.ons-input--error:not(:focus) {
+      border-right: $input-border-width solid $color-input-border;
+      box-shadow: none;
+    }
   }
 
   &__type {
@@ -54,11 +60,6 @@
     top: 0;
   }
 
-  &--error:not(:focus) {
-    border: $input-border-width solid $color-errors;
-    box-shadow: 0 0 0 $input-border-width $color-errors;
-  }
-
   &:not(&--prefix) & {
     &__type {
       border-left: 0;
@@ -81,5 +82,26 @@
       border-radius: 0 $input-radius $input-radius 0;
       order: 1;
     }
+  }
+}
+
+// Errors
+.ons-input--error:not(:focus) {
+  & + .ons-input-type__type,
+  & + .ons-input-type__type[title] {
+    border-color: $color-errors;
+  }
+
+  & + .ons-input-type__type::after {
+    border-radius: $input-radius;
+    bottom: 0;
+    // Style input + prefix/suffix for errors
+    box-shadow: 0 0 0 1px $color-errors;
+    content: '';
+    display: block;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
   }
 }

--- a/src/components/input/_input-type.scss
+++ b/src/components/input/_input-type.scss
@@ -95,6 +95,7 @@
   & + .ons-input-type__type::after {
     border-radius: $input-radius;
     bottom: 0;
+
     // Style input + prefix/suffix for errors
     box-shadow: 0 0 0 1px $color-errors;
     content: '';

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -1,10 +1,10 @@
 %ons-input-focus {
-  box-shadow: 0 0 0 3px $color-focus, inset 0 0 0 1px $color-input;
+  box-shadow: 0 0 0 $input-border-width $color-input-border, 0 0 0 4px $color-focus;
   outline: none;
 }
 
 .ons-input {
-  border: $input-border-width solid $color-input;
+  border: $input-border-width solid $color-input-border;
   border-radius: $input-radius;
   color: inherit;
   display: block;
@@ -45,8 +45,8 @@
   }
 
   &--error:not(:focus) {
-    border: 1px solid $color-errors;
-    box-shadow: inset 0 0 0 1px $color-errors;
+    border: $input-border-width solid $color-errors;
+    box-shadow: 0 0 0 $input-border-width $color-errors;
   }
 
   &--with-description {
@@ -73,7 +73,7 @@
 
 .ons-input--select {
   appearance: none;
-  background: $color-white url('#{$static}/img/icons--chevron-down.svg') no-repeat center right 10px;
+  background: $color-input-bg url('#{$static}/img/icons--chevron-down.svg') no-repeat center right 10px;
   background-size: 1rem;
   line-height: 1.3rem;
   padding: 0.39rem 2rem 0.39rem $input-padding-horizontal;
@@ -100,10 +100,10 @@
     color: transparent;
   }
   &:valid:not(:placeholder-shown) {
-    background-color: $color-white;
+    background-color: $color-input-bg;
   }
   &:focus {
-    background-color: $color-white;
+    background-color: $color-input-bg;
   }
 }
 
@@ -122,7 +122,7 @@
 .ons-input--ghost {
   border: 2px solid rgba(255, 255, 255, 0.6);
   &:focus {
-    border: 2px solid $color-input;
+    border: 2px solid $color-input-border;
   }
 }
 

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -27,7 +27,7 @@
       }
 
       &:focus {
-        box-shadow: 0 0 0 3px $color-focus, inset 0 0 0 3px $color-white;
+        box-shadow: inset 0 0 0 3px $color-input-bg, 0 0 0 $input-border-width $color-input-border, 0 0 0 4px $color-focus;
       }
     }
   }

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -9,7 +9,7 @@
     box-shadow: inset 0 0 0 3px $color-white;
 
     &:checked {
-      background: $color-input;
+      background: $color-input-border;
     }
   }
 

--- a/src/components/relationships/_relationships.scss
+++ b/src/components/relationships/_relationships.scss
@@ -1,7 +1,7 @@
 .ons-relationships {
   &__playback {
-    border-bottom: 1px solid $color-input;
-    border-top: 1px solid $color-input;
+    border-bottom: 1px solid $color-input-border;
+    border-top: 1px solid $color-input-border;
     margin: 2rem 0 0;
     padding: 1rem 0;
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -107,8 +107,8 @@
       overflow-x: scroll;
       width: 100%;
       &:focus {
-        outline: 3px solid $color-focus;
-        outline-offset: 3px;
+        box-shadow: 0 0 0 3px $color-white, 0 0 0 5px $color-black, 0 0 0 8px $color-focus;
+        outline: none;
       }
       .ons-table__header,
       .ons-table__cell {
@@ -119,6 +119,7 @@
       .ons-table__right-shadow,
       .ons-table__left-shadow {
         height: 100%;
+        padding: 2px;
         position: absolute;
         top: 0;
         width: 5px;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -107,7 +107,7 @@
       overflow-x: scroll;
       width: 100%;
       &:focus {
-        box-shadow: 0 0 0 3px $color-white, 0 0 0 5px $color-black, 0 0 0 8px $color-focus;
+        box-shadow: 0 0 0 3px $color-page-light, 0 0 0 5px $color-text-link-focus, 0 0 0 8px $color-focus;
         outline: none;
       }
       .ons-table__header,

--- a/src/components/tabs/_macro-options.md
+++ b/src/components/tabs/_macro-options.md
@@ -1,7 +1,7 @@
-| Name  | Type         | Required | Description                                                                                                       |
-| ----- | ------------ | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| title | string       | true     | The visually hidden `h2` level heading for the tabs `section` element required to give context for screen readers |
-| tabs  | array`<tab>` | true     | An array of [tabs](#tab)                                                                                          |
+| Name  | Type         | Required | Description                                                                                                                               |
+| ----- | ------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| title | string       | true     | The `h2` level heading for the tabs `section` element required to give context for screen readers. Visually hidden when tabs are visible. |
+| tabs  | array`<tab>` | true     | An array of [tabs](#tab)                                                                                                                  |
 
 ## Tab
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -20,6 +20,7 @@
       &::after {
         background: $color-borders;
         bottom: 0;
+        box-shadow: 0 1px 0 0 $color-page-light;
         content: '';
         height: 1px;
         left: 0;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -1,17 +1,32 @@
 .ons-tabs {
   margin-bottom: 1rem;
-}
 
-// Tabs - list
-.ons-tabs__list {
-  border-bottom: 0;
-  margin: 0 0 1rem;
-  overflow: visible;
-  padding: 0;
+  &__title {
+    @extend .ons-u-fs-r--b;
+  }
 
-  &--row {
-    border-bottom: 1px solid $color-borders;
-    margin: 0;
+  // Anchor links list
+  &__list {
+    border-bottom: 0;
+    margin: 0 0 1rem;
+    overflow: visible;
+    padding: 0;
+
+    // Tabs
+    &--row {
+      margin: 0;
+      position: relative;
+
+      &::after {
+        background: $color-borders;
+        bottom: 0;
+        content: '';
+        height: 1px;
+        left: 0;
+        position: absolute;
+        width: 100%;
+      }
+    }
   }
 }
 
@@ -32,7 +47,7 @@
   border-radius: 3px 3px 0 0;
   color: $color-text;
   display: inline-block;
-  height: 2.5rem;
+  height: 2.55rem;
   line-height: 2.3rem;
   margin: 0 0.1rem 0 0;
   overflow: visible;
@@ -47,47 +62,52 @@
     text-decoration: underline solid $color-text 2px;
   }
 
-  &[aria-selected='true'] {
-    background-color: $color-white;
-    border-color: $color-borders;
-    // Tab when selected
-    border-radius: 3px 3px 0 0;
-    font-weight: 700;
-    text-decoration: none;
-
-    &::after {
-      background: $color-white;
-      bottom: -2px;
-      box-shadow: none;
-      content: '';
-      height: 0.09rem;
-      left: 0;
-      // hides the lower border of the active tab.
-      position: absolute;
-      right: 0;
-      z-index: 3;
-    }
-  }
-
   &:focus {
     background-color: $color-focus;
+    border-bottom: 1px solid $color-borders;
+    box-shadow: inset 0 0 0 9px $color-button-secondary,
+      inset 17px 0 0 0 $color-button-secondary,
+      inset -17px 0 0 0 $color-button-secondary,
+      inset 0 -13px 0 0 $color-text-link-focus;
     color: $color-text-link-focus;
     outline: none;
+    text-decoration: underline solid $color-text 2px;
+  }
+
+  // Tab when selected
+  &[aria-selected='true'] {
+    background-color: $color-page-light;
+    border-bottom: none;
+    border-color: $color-borders;
+    border-radius: 3px 3px 0 0;
+    text-decoration: none;
+    z-index: 1;
+
+    &:focus {
+      background-color: $color-focus;
+      border-bottom: 1px solid $color-page-light;
+      box-shadow: inset 0 0 0 9px $color-page-light,
+        inset 17px 0 0 0 $color-page-light,
+        inset -17px 0 0 0 $color-page-light,
+        inset 0 -13px 0 0 $color-text-link-focus;
+      text-decoration: none;
+    }
   }
 }
 
 // Tabs - Panels
 .ons-tabs__panel {
-  margin-bottom: 1rem;
+  padding-bottom: 1rem;
   padding-top: 1rem;
   position: relative;
-  z-index: 10;
 
   &--hidden {
     display: none;
   }
 
   &:focus {
-    outline: 4px solid $color-focus;
+    box-shadow: 0 0 0 3px $color-page-light, 0 0 0 5px $color-text-link-focus, 0 0 0 8px $color-focus;
+    outline: none;
+    z-index: 1;
   }
 }

--- a/src/components/tabs/examples/tabs/index.njk
+++ b/src/components/tabs/examples/tabs/index.njk
@@ -2,7 +2,7 @@
 
 {{
     onsTabs({
-        "title": 'Tabs',
+        "title": 'Contents',
         "tabs": [
             {
                 "title": 'UKIS',
@@ -10,18 +10,18 @@
                 <p class="ons-u-fs-r">The aim of the UK Innovation Survey (UKIS) is to collect data from businesses about various aspects of their innovation related activities. Using this data we can measure the level, types and trends in innovation.</p>
                 <h3>How we’ll use this data</h3>
                 <p class="ons-u-fs-r">The UKIS data is a major source of evidence to inform government policy. It is used to promote innovation activities among businesses to boost economic growth. It is an important contribution to the European-wide Community Innovation Survey (CIS). The CIS is used for international benchmarking and comparison purposes.</p>
-                <p><a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/ukinnovationsurvey">More information on the UKIS survey</a> can be found on the ONS website.</p>'
+                <p>You can <a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/ukinnovationsurvey">find more information on the UKIS survey on the ONS website</a>.</p>'
             },
             {
                 "title": 'Vacancy survey',
                 "content": '<h3>Purpose</h3>
                 <p class="ons-u-fs-r">The Vacancy Survey is a regular survey of businesses, which provides an accurate and comprehensive measure of the total number of vacancies across the economy and fills a gap in the information available regarding the demand for labour. Before the Vacancy Survey was introduced, the only information available nationally about vacancies was from records of vacancies notified to Job Centres by employers. This provided only a partial picture, possibly less than half of all vacancies, because employers are under no obligation to notify vacancies to Job Centres. This business based survey has a more complete coverage and is included in the monthly ONS Labour Market Statistical Bulletin.</p>
-                <p><a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/vacancysurvey">More information on the Vacancy Survey</a> can be found on the ONS website.</p>'
+                <p>You can <a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/vacancysurvey">find more information on the Vacancy Survey on the ONS website</a>.</p>'
             },
             {
                 "title": 'Monthly Business Survey',
                 "content": '<h3>Aim of this survey</h3>
-                <p class="ons-u-fs-r">The Quarterly Business Survey (QBS) collects quarterly information on employment of businesses in Great Britain. Your response contributes to Labour Market Statistics.</p>
+                <p class="ons-u-fs-r">The Monthly Business Survey (MBS) collects monthly information on employment of businesses in Great Britain. Your response contributes to Labour Market Statistics.</p>
                 <h4>What you need to know</h4>
                 <p class="ons-u-fs-r">To complete the survey, you will need the following information to answer the survey questions:</p>
                 <ul>
@@ -29,7 +29,7 @@
                     <li>number of full-time/part-time female employees</li>
                     <li>total number of employees for the business</li>
                 </ul>
-                <p><a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/vacancysurvey">More information on the Vacancy Survey</a> can be found on the ONS website.</p>'
+                <p>You can <a href="https://www.ons.gov.uk/surveys/informationforbusinesses/businesssurveys/monthlybusinesssurveyretailsalesindex">find more information on the Monthly Business Survey on the ONS website</a>.</p>'
             }
         ]
     })

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -30,8 +30,6 @@ export default class Tabs {
     this.jsTabItemAsRowClass = 'ons-tab__list-item--row';
     this.jsTabAsListClass = 'ons-tab--row';
 
-    this.tabsTitle.classList.add('ons-u-vh');
-
     if (matchMediaUtil.hasMatchMedia()) {
       this.setupViewportChecks();
     } else {
@@ -61,6 +59,8 @@ export default class Tabs {
     this.tabList[0].setAttribute('role', 'tablist');
     this.tabList[0].classList.add(this.jsTabListAsRowClass);
 
+    this.tabsTitle.classList.add('ons-u-vh');
+
     this.tabPanels.forEach(panel => {
       panel.setAttribute('tabindex', '0');
     });
@@ -89,6 +89,8 @@ export default class Tabs {
   makeList() {
     this.tabList[0].removeAttribute('role');
     this.tabList[0].classList.remove(this.jsTabListAsRowClass);
+
+    this.tabsTitle.classList.remove('ons-u-vh');
 
     this.tabPanels.forEach(panel => {
       panel.removeAttribute('tabindex', '0');

--- a/src/components/upload/_upload.scss
+++ b/src/components/upload/_upload.scss
@@ -1,6 +1,6 @@
 .ons-input--upload {
   background: $color-white;
-  border: 1px solid $color-input;
+  border: 1px solid $color-input-border;
   border-radius: $input-radius;
   font-size: 1rem;
   padding: 0;
@@ -9,7 +9,7 @@
     background: $color-button-secondary;
     border: 0;
     border-bottom-right-radius: 0;
-    border-right: 1px solid $color-input;
+    border-right: 1px solid $color-input-border;
     border-top-right-radius: 0;
     color: $color-text;
     font-size: 1rem;

--- a/src/foundations/style/colours/_template.njk
+++ b/src/foundations/style/colours/_template.njk
@@ -3,7 +3,7 @@
         <div class="ons-patternlib-swatch ons-grid ons-grid--flex ons-grid--gutterless ons-grid--no-wrap@s">
             <div class="ons-patternlib-swatch__color ons-u-flex-no-shrink"
                 style="{% if item.bg2 is defined and item.bg2 %}background: linear-gradient(to bottom left, {{ item.bg }} 0%, {{ item.bg2 }} 100%);{% else %}background-color:{{ item.bg }};{% endif -%}{% if item.border is defined and item.border -%} border:1px solid #707071;{% endif -%}{% if item.shadow is defined and item.shadow %}border-radius:0; -webkit-box-shadow: 0 -2px {{ item.bg }}, 0 4px {{ item.fore }};
-                box-shadow: 0 -2px {{ item.bg }}, 0 4px {{ item.fore }};{% endif -%}">
+                box-shadow: 0 -2px {{ item.bg }}, 0 4px #222;{% endif -%}">
             {% if item.char is defined and item.char -%}<span class="ons-patternlib-swatch__char" style="color:{{ item.fore }}">{{ item.char }}</span>{% endif -%}
             </div>
             <div class="ons-patternlib-swatch__codes ons-u-flex-no-grow">

--- a/src/foundations/style/colours/index.njk
+++ b/src/foundations/style/colours/index.njk
@@ -242,6 +242,7 @@ The colour variables are assigned to elements by using variables to provide cont
                 'fore': '#ffffff',
                 'bg': '#0f8243',
                 'char': 'A',
+                'shadow': true,
                 'var': '$color-button',
                 'info': 'Primary action buttons use a green background colour and white text.',
                 'hideSwatchDetail': true
@@ -256,6 +257,7 @@ The colour variables are assigned to elements by using variables to provide cont
                 'fore': '#222222',
                 'bg': '#e2e2e3',
                 'char': 'A',
+                'shadow': true,
                 'var': '$color-button-secondary',
                 'info': 'Secondary buttons use a light grey background colour and black text. This prevents interference with the primary action.',
                 'hideSwatchDetail': true
@@ -287,8 +289,9 @@ The colour variables are assigned to elements by using variables to provide cont
                 'fore': '#222222',
                 'bg': '#f0f762',
                 'char': 'A',
+                'shadow': true,
                 'var': '$color-highlight',
-                'info': 'Bright yellow is used to <a href="/foundations/typography#highlighting">highlight important information in headings</a>.',
+                'info': 'Bright yellow is used with a <code>4px</code> black offset <code>box-shadow</code> to <a href="/foundations/typography#highlighting">highlight important information in headings</a>.',
                 'hideSwatchDetail': true
             }
         ]
@@ -427,6 +430,13 @@ To meet the WCAG 2.1 level AA guideline “1.4.3 Contrast (Minimum)”, all text
                 'fore': '#222222',
                 'bg': '#ffffff',
                 'contrastRatio': '15.91',
+                'char': 'A',
+                'border': true
+            },
+            {
+                'fore': '#206095',
+                'bg': '#ffffff',
+                'contrastRatio': '6.63',
                 'char': 'A',
                 'border': true
             },

--- a/src/foundations/style/typography/highlighting/_highlight.scss
+++ b/src/foundations/style/typography/highlighting/_highlight.scss
@@ -1,5 +1,6 @@
 .ons-highlight {
   background-color: $color-highlight;
+  box-shadow: 0 4px 0 0 $color-text-link-focus;
   font-style: normal;
   padding: 0 2px;
 }

--- a/src/scss/patternlib.scss
+++ b/src/scss/patternlib.scss
@@ -86,62 +86,6 @@
     }
   }
 
-  .ons-table-scrollable {
-    position: relative;
-    ::-webkit-scrollbar {
-      height: 7px;
-    }
-    ::-webkit-scrollbar-thumb {
-      background: $color-grey-75;
-      border-radius: 20px;
-    }
-    &--on {
-      th,
-      td {
-        white-space: nowrap;
-      }
-    }
-    &__content {
-      overflow: visible;
-      overflow-x: scroll;
-      width: 100%;
-      &:focus {
-        outline: 3px solid $color-focus;
-        outline-offset: 3px;
-      }
-      th,
-      td {
-        @include mq(xxs, m) {
-          white-space: nowrap;
-        }
-      }
-      .ons-table__right-shadow,
-      .ons-table__left-shadow {
-        height: 100%;
-        position: absolute;
-        top: 0;
-        width: 5px;
-        z-index: 200;
-
-        &.ons-with-transition {
-          transition: box-shadow 0.4s ease-out;
-        }
-      }
-      .ons-table__right-shadow {
-        right: 0;
-        &.ons-visible {
-          box-shadow: inset -1px 0 0 0 #bfc1c3, inset -5px 0 0 0 rgba(191, 193, 195, 0.4);
-        }
-      }
-      .ons-table__left-shadow {
-        left: 0;
-        &.ons-visible {
-          box-shadow: inset 1px 0 0 0 #bfc1c3, inset -5px 0 0 0 rgba(191, 193, 195, 0.4);
-        }
-      }
-    }
-  }
-
   &__content,
   &__sub-nav {
     > {

--- a/src/scss/vars/_colors.scss
+++ b/src/scss/vars/_colors.scss
@@ -92,7 +92,8 @@ $color-placeholder: $color-grey-15 !default;
 // Form elements
 $color-button: $color-leaf-green !default;
 $color-button-secondary: $color-grey-15 !default;
-$color-input: $color-black !default;
+$color-input-border: $color-black !default;
+$color-input-bg: $color-white !default;
 
 // Panels and status
 $color-info: $color-ocean-blue !default;


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2246 

- Updated focus styles for the following elements, so the focus always has enough contrast against the background:
  - Tables
  - Tabs
    - also made ToC heading visible under 400px vp, and updated example
    - also fixes #1727 #1690 #1677 
  - Highlighting
  - Borderless checkboxes and radios
  - Ghost buttons
  - Password checkbox
- Updated input focus style so all inputs now consistently add outer box-shadows, to increase the border thickness and add 3px yellow box-shadow.
- Focus style now surrounds the prefix/suffixes of inputs too
- Updated colour usage to use variables for input borders/backgrounds. 
- Update colour docs

### How to review
- Check all elements focus styles don't rely on the yellow colour alone, as the contrast is not sufficient against white backgrounds
- Check updated colour docs