### PR TITLE
Hide native browser search input clear button

### DIFF
--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -156,3 +156,11 @@
     }
   }
 }
+
+// Search type inputs - removes the 'X' clear button from webkit browsers
+input[type='search']::-webkit-search-decoration,
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-results-button,
+input[type='search']::-webkit-search-results-decoration {
+  display: none;
+}


### PR DESCRIPTION
### What is the context of this PR?
Removes the native browser pseudo element rendered on `input[type=search]` following text entry, because it is not keyboard accessible.

Fixes #2237 

### How to review
Check search type inputs across supported browsers to confirm clear button is not longer present.

