### PR TITLE
Accessibility: High contrast mode fixes

### DIFF
--- a/src/components/autosuggest/_autosuggest.scss
+++ b/src/components/autosuggest/_autosuggest.scss
@@ -15,6 +15,7 @@
     border-radius: $input-radius;
     display: none;
     margin: 0.5rem 0 0;
+    outline: 1px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
     overflow: hidden;
     padding: 0;
     width: 100%;

--- a/src/components/autosuggest/_autosuggest.scss
+++ b/src/components/autosuggest/_autosuggest.scss
@@ -15,7 +15,6 @@
     border-radius: $input-radius;
     display: none;
     margin: 0.5rem 0 0;
-    outline: 1px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
     overflow: hidden;
     padding: 0;
     width: 100%;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -63,8 +63,11 @@ $button-shadow-size: 3px;
   }
 
   // When focused
-  &:focus & {
+  &:focus,
+  &:focus-visible {
+    // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
     outline: 3px solid transparent;
+    outline-offset: 1px;
   }
 
   &:focus &__inner {
@@ -89,11 +92,6 @@ $button-shadow-size: 3px;
 
   &:active {
     top: ems($button-shadow-size);
-  }
-
-  &:focus,
-  &:focus:hover {
-    outline: none;
   }
 
   // Small buttons
@@ -170,6 +168,8 @@ $button-shadow-size: 3px;
 
   &--link:focus:not(:active):not(&--secondary) &,
   &--link:focus:hover:not(:active):not(&--secondary) & {
+    outline: inherit;
+
     &__inner {
       .ons-svg-icon {
         fill: $color-text;

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -9,10 +9,8 @@ $checkbox-padding: 11px;
 
   &__input {
     appearance: none;
-    background: url(#{$static}/img/icons--check.svg) no-repeat center center;
-    background-color: $color-white;
-    background-size: 0;
-    border: 2px solid $color-input;
+    background-color: $color-input-bg;
+    border: 2px solid $color-input-border;
     border-radius: 0.2rem;
     box-sizing: border-box;
     height: $checkbox-input-width;
@@ -22,13 +20,30 @@ $checkbox-padding: 11px;
     width: $checkbox-input-width;
     z-index: 1;
 
+    // Check icon
+    &::after {
+      border: solid $color-input-border;
+      border-radius: 1px;
+      border-top-color: $color-input-bg;
+      border-width: 0 0 3px 3px;
+      box-sizing: border-box;
+      content: '';
+      height: 7px;
+      left: 2px;
+      opacity: 0;
+      position: absolute;
+      top: 4px;
+      transform: rotate(-45deg);
+      width: 14px;
+    }
+
     &:focus,
     &:checked {
       outline: none;
     }
 
-    &:checked {
-      background-size: 14px;
+    &:checked::after {
+      opacity: 1;
     }
 
     &:disabled {

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -195,7 +195,7 @@ $checkbox-padding: 11px;
   &--toggle & {
     &__input {
       left: 0;
-      top: 0.1rem;
+      top: 0.25rem;
 
       &:focus {
         box-shadow: 0 0 0 3px $color-focus;

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -55,7 +55,7 @@ $checkbox-padding: 11px;
       border-color: $color-border-disabled;
     }
 
-    &:disabled + label {
+    &:disabled + .ons-checkbox__label {
       color: $color-grey-35;
       cursor: not-allowed;
     }

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -146,10 +146,18 @@ $checkbox-padding: 11px;
       bottom: 0;
       content: '';
       left: 0;
+
+      // High Contrast mode adjustments
+      outline: 2px solid transparent;
+      outline-offset: 1px;
       position: absolute;
       right: 0;
       top: 0;
       z-index: -1;
+
+      @media screen and (forced-colors: active) {
+        outline-color: Highlight;
+      }
     }
 
     * {

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -55,9 +55,20 @@ $checkbox-padding: 11px;
       border-color: $color-border-disabled;
     }
 
-    &:disabled + .ons-checkbox__label {
-      color: $color-grey-35;
+    &:disabled + .ons-checkbox__label,
+    &:disabled:checked + .ons-checkbox__label {
+      color: $color-border-disabled;
       cursor: not-allowed;
+
+      &::before {
+        border: 1px solid $color-border-disabled;
+      }
+    }
+
+    &:disabled:checked + .ons-checkbox__label {
+      &::before {
+        box-shadow: 0 0 0 1px $color-border-disabled;
+      }
     }
   }
 
@@ -66,9 +77,9 @@ $checkbox-padding: 11px;
       padding: 0 0 0 1.85rem;
 
       &::before {
-        background: none;
-        border: none;
-        box-shadow: none;
+        background: none !important;
+        border: none !important;
+        box-shadow: none !important;
       }
 
       & > .ons-checkbox__label--with-description {
@@ -173,6 +184,7 @@ $checkbox-padding: 11px;
   &__input:checked + &__label::before {
     background: $color-grey-5;
     box-shadow: 0 0 0 1px $color-input-border;
+    outline: 1px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
   }
 
   .ons-panel--error .ons-radio__input:checked ~ &__other > .ons-input--text:required:not(:focus) {

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -146,6 +146,10 @@ $checkbox-padding: 11px;
       bottom: 0;
       content: '';
       left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+      z-index: -1;
     }
 
     * {
@@ -180,12 +184,8 @@ $checkbox-padding: 11px;
     @extend %ons-input-focus;
 
     // Add outline because Windows High Contrast mode removes box-shadows so focus is lost
-    outline: 3px solid transparent;
+    outline: 2px solid transparent;
     outline-offset: 1px;
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: -1;
   }
 
   &__input:not(:checked) ~ &__other {

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -51,6 +51,10 @@ $checkbox-padding: 11px;
       cursor: not-allowed;
     }
 
+    &:disabled:checked::after {
+      border-color: $color-border-disabled;
+    }
+
     &:disabled + label {
       color: $color-grey-35;
       cursor: not-allowed;

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -195,7 +195,7 @@ $checkbox-padding: 11px;
   &--toggle & {
     &__input {
       left: 0;
-      top: 0.25rem;
+      top: 0.2rem;
 
       &:focus {
         @extend %ons-input-focus;

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -146,18 +146,6 @@ $checkbox-padding: 11px;
       bottom: 0;
       content: '';
       left: 0;
-
-      // High Contrast mode adjustments
-      outline: 2px solid transparent;
-      outline-offset: 1px;
-      position: absolute;
-      right: 0;
-      top: 0;
-      z-index: -1;
-
-      @media screen and (forced-colors: active) {
-        outline-color: Highlight;
-      }
     }
 
     * {
@@ -190,6 +178,14 @@ $checkbox-padding: 11px;
 
   &__input:focus + &__label::before {
     @extend %ons-input-focus;
+
+    // Add outline because Windows High Contrast mode removes box-shadows so focus is lost
+    outline: 3px solid transparent;
+    outline-offset: 1px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: -1;
   }
 
   &__input:not(:checked) ~ &__other {

--- a/src/components/checkboxes/_checkbox.scss
+++ b/src/components/checkboxes/_checkbox.scss
@@ -88,6 +88,7 @@ $checkbox-padding: 11px;
           background: none;
           border: none;
           box-shadow: none;
+          outline: none;
         }
       }
 
@@ -182,10 +183,6 @@ $checkbox-padding: 11px;
 
   &__input:focus + &__label::before {
     @extend %ons-input-focus;
-
-    // Add outline because Windows High Contrast mode removes box-shadows so focus is lost
-    outline: 2px solid transparent;
-    outline-offset: 1px;
   }
 
   &__input:not(:checked) ~ &__other {

--- a/src/components/checkboxes/examples/checkboxes-disabled/index.njk
+++ b/src/components/checkboxes/examples/checkboxes-disabled/index.njk
@@ -28,7 +28,7 @@
                     },
                     "value": "areas",
                     "disabled": true
-                }       
+                }
             ]
         })
     }}

--- a/src/components/checkboxes/examples/checkboxes-hidden-label/index.njk
+++ b/src/components/checkboxes/examples/checkboxes-hidden-label/index.njk
@@ -22,6 +22,9 @@
                             <span>Survey Data Collection area</span>
                         </th>
                         <th scope="col" class="ons-table__header">
+                            <span>View</span>
+                        </th>
+                        <th scope="col" class="ons-table__header">
                             <span>Edit</span>
                         </th>
                         <th scope="col" class="ons-table__header">
@@ -34,6 +37,20 @@
                         <td class="ons-table__cell">
                             Surveys
                         </td>
+                        <td class="ons-table__cell">
+                            {{
+                                onsCheckbox({
+                                    "id": "surveys-view",
+                                    "hideLabel": true,
+                                    "label": {
+                                        "text": "View surveys"
+                                    },
+                                    "value": "y",
+                                    "checked": true,
+                                    "disabled": true
+                                })
+                            }}
+                        </td>
                         <td class="ons-table__cell" colspan="2">
                             {{
                                 onsCheckbox({
@@ -42,7 +59,7 @@
                                     "label": {
                                         "text": "Edit surveys"
                                     },
-                                    "value": "y"
+                                    "value": "n"
                                 })
                             }}
                         </td>
@@ -50,6 +67,20 @@
                     <tr class="ons-table__row">
                         <td class="ons-table__cell">
                             Reporting units
+                        </td>
+                        <td class="ons-table__cell">
+                            {{
+                                onsCheckbox({
+                                    "id": "reporting-units-view",
+                                    "hideLabel": true,
+                                    "label": {
+                                        "text": "View reporting units"
+                                    },
+                                    "value": "y",
+                                    "checked": true,
+                                    "disabled": true
+                                })
+                            }}
                         </td>
                         <td class="ons-table__cell" colspan="2">
                             {{
@@ -59,7 +90,7 @@
                                     "label": {
                                         "text": "Edit reporting units"
                                     },
-                                    "value": "y"
+                                    "value": "n"
                                 })
                             }}
                         </td>
@@ -71,12 +102,27 @@
                         <td class="ons-table__cell">
                             {{
                                 onsCheckbox({
+                                    "id": "respondents-view",
+                                    "hideLabel": true,
+                                    "label": {
+                                        "text": "View respondents"
+                                    },
+                                    "value": "y",
+                                    "checked": true,
+                                    "disabled": true
+                                })
+                            }}
+                        </td>
+                        <td class="ons-table__cell">
+                            {{
+                                onsCheckbox({
                                     "id": "respondents-edit",
                                     "hideLabel": true,
                                     "label": {
                                         "text": "Edit respondents"
                                     },
-                                    "value": "y"
+                                    "value": "y",
+                                    "checked": true
                                 })
                             }}
                         </td>
@@ -88,7 +134,7 @@
                                     "label": {
                                         "text": "Delete respondents"
                                     },
-                                    "value": "y"
+                                    "value": "n"
                                 })
                             }}
                         </td>
@@ -96,6 +142,20 @@
                     <tr class="ons-table__row">
                         <td class="ons-table__cell">
                             Messages
+                        </td>
+                        <td class="ons-table__cell">
+                            {{
+                                onsCheckbox({
+                                    "id": "messages-view",
+                                    "hideLabel": true,
+                                    "label": {
+                                        "text": "View messages"
+                                    },
+                                    "value": "y",
+                                    "checked": true,
+                                    "disabled": true
+                                })
+                            }}
                         </td>
                         <td class="ons-table__cell" colspan="2">
                             {{
@@ -105,7 +165,8 @@
                                     "label": {
                                         "text": "Edit messages"
                                     },
-                                    "value": "y"
+                                    "value": "y",
+                                    "checked": true
                                 })
                             }}
                         </td>

--- a/src/components/document-list/document-list.scss
+++ b/src/components/document-list/document-list.scss
@@ -120,6 +120,8 @@
       background-color: $color-banner-bg;
       border-bottom: none;
       display: block;
+      outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
+      outline-offset: -2px;
       padding: 2rem;
 
       @include mq(m) {

--- a/src/components/document-list/index.njk
+++ b/src/components/document-list/index.njk
@@ -53,7 +53,7 @@ A featured search result to place at the top of the search results list to add e
 }}
 
 ### News articles
-Use this variant to build an list of articles for an index in the [news pattern](/patterns/news).
+Use this variant to build a list of articles for an index in the [news pattern](/patterns/news).
 {{
     patternlibExample({"path": "components/document-list/examples/document-list-articles/index.njk"})
 }}

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -17,6 +17,7 @@
 
   &__warning {
     background-color: $color-banner-bg-dark;
+    outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
   }
 
   &__license {

--- a/src/components/input/_input-type.scss
+++ b/src/components/input/_input-type.scss
@@ -23,6 +23,7 @@
     &.ons-input--error:not(:focus) {
       border-right: $input-border-width solid $color-input-border;
       box-shadow: none;
+      outline: none;
     }
   }
 
@@ -102,6 +103,7 @@
     content: '';
     display: block;
     left: 0;
+    outline: 1px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
     position: absolute;
     right: 0;
     top: 0;

--- a/src/components/input/_input-type.scss
+++ b/src/components/input/_input-type.scss
@@ -16,6 +16,7 @@
     &:focus {
       // Overide default input focus so it can wrap prefix/suffix too
       box-shadow: none;
+      outline: none;
     }
 
     // Overide default input error style so it can wrap prefix/suffix too

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -81,7 +81,9 @@
 
 .ons-input--select {
   appearance: none;
-  background: $color-input-bg url('#{$static}/img/icons--chevron-down.svg') no-repeat center right 10px;
+  background: $color-input-bg
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 11.75 7.7'%3E%3Cpath fill='currentColor' d='m1.37.15 4.5 5.1 4.5-5.1a.37.37 0 0 1 .6 0l.7.7a.45.45 0 0 1 0 .5l-5.5 6.2a.37.37 0 0 1-.6 0l-5.5-6.1a.64.64 0 0 1 0-.6l.7-.7a.64.64 0 0 1 .6 0Z'/%3E%3C/svg%3E")
+    no-repeat center right 10px;
   background-size: 1rem;
   line-height: 1.3rem;
   padding: 0.39rem 2rem 0.39rem $input-padding-horizontal;

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -1,6 +1,14 @@
 %ons-input-focus {
   box-shadow: 0 0 0 $input-border-width $color-input-border, 0 0 0 4px $color-focus;
-  outline: none;
+
+  // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
+  outline: 3px solid transparent;
+  outline-offset: 1px;
+
+  @media screen and (forced-colors: active) {
+    // To better match the focus states of native controls
+    outline-color: Highlight;
+  }
 }
 
 .ons-input {

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -55,6 +55,7 @@
   &--error:not(:focus) {
     border: $input-border-width solid $color-errors;
     box-shadow: 0 0 0 $input-border-width $color-errors;
+    outline: 1px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
   }
 
   &--with-description {

--- a/src/components/label/_label.scss
+++ b/src/components/label/_label.scss
@@ -19,7 +19,7 @@
   &--placeholder {
     font-size: 1rem;
     font-weight: $font-weight-regular;
-    left: 8px;
+    left: 10px;
     position: absolute;
     top: 6px;
   }

--- a/src/components/message/_message.scss
+++ b/src/components/message/_message.scss
@@ -3,6 +3,7 @@
 .ons-message {
   border-radius: math.div($grid-gutters, 2);
   margin-bottom: 2rem;
+  outline: 1px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
 
   &--sent {
     background: $color-info-tint;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -8,6 +8,7 @@ $backdrop-colour: rgba(0, 0, 0, 0.8);
   margin-left: 2rem;
   margin-right: 2rem;
   max-width: 500px;
+  outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
   padding: 2rem;
   position: relative;
   width: auto;

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -45,6 +45,7 @@ $pagination-item-width: 2.5rem;
   &__item--current &__link {
     background: $color-text-link-hover;
     color: $color-white;
+    outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show backgrounds
     text-decoration: none;
   }
 

--- a/src/components/panel/_macro.njk
+++ b/src/components/panel/_macro.njk
@@ -15,7 +15,7 @@
     {% endif %}
 
     {% if params is defined and params.type == "warn-branded" %}
-        {% set containerClass = 'ons-census-warning' %}
+        {% set containerClass = 'ons-branded-warning' %}
     {% endif %}
 
     {% if params is defined and params.type == "announcement" %}

--- a/src/components/panel/_macro.spec.js
+++ b/src/components/panel/_macro.spec.js
@@ -352,7 +352,7 @@ describe('macro: panel', () => {
         }),
       );
 
-      expect($('.ons-census-warning').length).toBe(1);
+      expect($('.ons-branded-warning').length).toBe(1);
       expect($('.ons-container').length).toBe(1);
     });
 

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -3,6 +3,7 @@
     &--#{$name} {
       background: $color-bg;
       border-color: $color;
+      outline: 1px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
     }
 
     &--#{$name} & {
@@ -13,7 +14,7 @@
   }
 }
 
-.ons-census-warning {
+.ons-branded-warning {
   background: $color-branded-tertiary;
 }
 
@@ -21,7 +22,7 @@
   background-color: $color-black;
 }
 
-.ons-census-warning,
+.ons-branded-warning,
 .ons-announcement {
   outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
 }
@@ -47,7 +48,7 @@
 
   &__header {
     border-radius: 0;
-    color: $color-white;
+    color: $color-text-inverse;
     margin: 0;
     padding: 0.75rem 1rem;
   }
@@ -116,6 +117,7 @@
   &--warn {
     border: 0 !important;
     margin-bottom: 1rem;
+    outline: none !important;
     padding: 0;
 
     &--footer {
@@ -130,6 +132,7 @@
     border: 0 !important;
     color: $color-white;
     margin-bottom: 0;
+    outline: none !important;
     padding: 1rem 0 !important;
     a {
       color: inherit;
@@ -251,6 +254,6 @@
 @include panel-type(success, $color-success, $color-success-tint);
 @include panel-type(info, $color-info, $color-info-tint);
 @include panel-type(branded, $color-branded, $color-branded-tint);
-@include panel-type(warn, $color-white, $color-white);
+@include panel-type(warn, transparent, transparent);
 @include panel-type(warn-branded, $color-branded-tertiary, $color-branded-tertiary);
 @include panel-type(announcement, $color-black, $color-black);

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -21,6 +21,11 @@
   background-color: $color-black;
 }
 
+.ons-census-warning,
+.ons-announcement {
+  outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
+}
+
 .ons-panel {
   border-radius: 0;
   position: relative;
@@ -178,6 +183,7 @@
       line-height: 2rem;
       min-height: 2rem;
       min-width: 2rem;
+      outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
       text-align: center;
     }
   }

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -43,7 +43,6 @@
   &:focus {
     box-shadow: none;
     outline: 4px solid $color-focus !important;
-    outline-offset: 0;
   }
 
   &__header {
@@ -145,7 +144,7 @@
 
   &--announcement {
     a:focus {
-      box-shadow: 0 -2px #fd0, 0 4px #fd0 !important; // Override focus style because the black border is not visible on a black background
+      box-shadow: 0 -2px $color-focus, 0 4px $color-text-inverse-link !important; // Override focus style because the black border is not visible on a black background
     }
   }
 

--- a/src/components/panel/index.njk
+++ b/src/components/panel/index.njk
@@ -58,7 +58,7 @@ A request to get the current expiry time will be sent when the following happens
 If the response status does not have a successful `200` code, the component will handle the response as a session expiry and redirect the user to the URL set in the `redirectUrl` parameter.
 
 ### Warning branded
-This example is a warning variant designed only for the census respond phase. It is to warn users that they must complete the census by law.
+This warning variant can be used when a panel is required to fill the full width of the viewport and ensure contrast with the primary brand colour. For example, this was used beneath the [hero component](/components/hero#campaign-happening-now) to warn census users that they must complete the census by law.
 {{
     patternlibExample({"path": "components/panel/examples/warn-branded/index.njk"})
 }}

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -8,6 +8,7 @@
     font-size: 0.85rem;
     line-height: 1em;
     margin: 0 0.5rem 0 0;
+    outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
     padding: 0.4rem;
     text-transform: uppercase;
   }

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -6,20 +6,22 @@
 
     background: $color-grey-5;
     border-radius: 50%;
-    box-shadow: inset 0 0 0 3px $color-white;
+    box-shadow: inset 0 0 0 3px $color-input-bg;
 
     &::after {
-      // Remove checkbox check icon
-      border: none;
-    }
-
-    &:checked {
-      background: $color-input-border;
+      border-radius: 50%;
+      border-top-color: inherit;
+      border-width: 6px;
+      height: 0;
+      left: 3px;
+      top: 3px;
+      width: 0;
     }
   }
 
   &.ons-radio--no-border {
     @extend .ons-checkbox--no-border;
+
     & > .ons-radio__input {
       @extend .ons-radio__input;
       &:focus,

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -30,6 +30,7 @@
           background: none;
           border: none;
           box-shadow: none;
+          outline: none;
         }
       }
 

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -8,6 +8,11 @@
     border-radius: 50%;
     box-shadow: inset 0 0 0 3px $color-white;
 
+    &::after {
+      // Remove checkbox check icon
+      border: none;
+    }
+
     &:checked {
       background: $color-input;
     }

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -9,8 +9,8 @@
     box-shadow: inset 0 0 0 3px $color-input-bg;
 
     &::after {
+      border-color: $color-input-border;
       border-radius: 50%;
-      border-top-color: inherit;
       border-width: 6px;
       height: 0;
       left: 3px;

--- a/src/components/skip-to-content/_skip.scss
+++ b/src/components/skip-to-content/_skip.scss
@@ -21,7 +21,8 @@
     height: auto;
     margin: inherit;
     max-height: 20em;
-    outline: none;
+    outline: 3px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
+    outline-offset: -4px;
     overflow: visible;
     padding: 1rem;
     position: static;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -108,7 +108,8 @@
       width: 100%;
       &:focus {
         box-shadow: 0 0 0 3px $color-page-light, 0 0 0 5px $color-text-link-focus, 0 0 0 8px $color-focus;
-        outline: none;
+        outline: 3px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
+        outline-offset: 1px;
       }
       .ons-table__header,
       .ons-table__cell {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -71,7 +71,10 @@
       inset -17px 0 0 0 $color-button-secondary,
       inset 0 -13px 0 0 $color-text-link-focus;
     color: $color-text-link-focus;
-    outline: none;
+
+    // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
+    outline: 3px solid transparent;
+    outline-offset: 1px;
     text-decoration: underline solid $color-text 2px;
   }
 
@@ -86,7 +89,6 @@
 
     &:focus {
       background-color: $color-focus;
-      border-bottom: 1px solid $color-page-light;
       box-shadow: inset 0 0 0 9px $color-page-light,
         inset 17px 0 0 0 $color-page-light,
         inset -17px 0 0 0 $color-page-light,
@@ -108,7 +110,7 @@
 
   &:focus {
     box-shadow: 0 0 0 3px $color-page-light, 0 0 0 5px $color-text-link-focus, 0 0 0 8px $color-focus;
-    outline: none;
+    outline: 3px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show box-shadows
     z-index: 1;
   }
 }

--- a/src/scss/base/_global.scss
+++ b/src/scss/base/_global.scss
@@ -34,6 +34,7 @@ hr {
   box-shadow: 0 -2px $color-focus, 0 4px $color-text-link-focus;
   color: $color-text-link-focus;
   outline: 3px solid transparent;
+  outline-offset: 1px;
   text-decoration: none;
 }
 

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -101,4 +101,18 @@
     border-color: ButtonText !important;
     color: ButtonText;
   }
+
+  // Add borders to divide banners
+  .ons-skip-link,
+  .ons-browser-banner,
+  .ons-cookies-banner,
+  .ons-header,
+  .ons-header__top,
+  .ons-phase-banner {
+    border-bottom: 1px solid currentColor;
+  }
+
+  .ons-navigation--sub {
+    border-top: 1px solid currentColor;
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -198,7 +198,7 @@
 
   // Highlighting
   .ons-highlight {
-    background-color: Highlight;
-    color: HighlightText;
+    background-color: mark;
+    color: marktext;
   }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -66,7 +66,8 @@
 
   // Logos
   .ons-header__org-logo,
-  .ons-header__title-logo {
+  .ons-header__title-logo,
+  .ons-footer {
     & .ons-svg-logo {
       fill: currentColor !important;
       forced-color-adjust: auto;
@@ -127,6 +128,10 @@
   .ons-hero,
   .ons-phase-banner {
     border-bottom: 1px solid currentColor;
+  }
+
+  .ons-footer {
+    border-top: 1px solid currentColor;
   }
 
   @include mq(m) {

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -118,12 +118,13 @@
     color: ButtonText;
   }
 
-  // Add borders to divide banners
+  // Add borders to separate banners with no backgrounds
   .ons-skip-link,
   .ons-browser-banner,
   .ons-cookies-banner,
   .ons-header,
   .ons-header__top,
+  .ons-hero,
   .ons-phase-banner {
     border-bottom: 1px solid currentColor;
   }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -230,4 +230,11 @@
   .ons-feedback::after {
     content: none;
   }
+
+  // Message – indicate sent vs received
+  .ons-message {
+    &--sent {
+      outline-color: mark;
+    }
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -25,24 +25,6 @@
     text-decoration: underline;
   }
 
-  .ons-radio__input:checked + .ons-radio__label {
-    position: relative;
-
-    // These off pixels are not nice, but due to the way the form controls have been built I have had no choice
-    // I would strongly revisit doing the checkboxes and radios again and fix these non-whole pixel values
-    &::after {
-      border: 6px solid currentColor;
-      border-radius: 50%;
-      content: '';
-      height: 12.5px;
-      left: 16px;
-      position: absolute;
-      top: 18.5px;
-      width: 12.5px;
-      z-index: 1;
-    }
-  }
-
   // Had to do this without messing with the existing SVG
   .ons-input--select {
     background-image: url('data:image/svg+xml;base64,PHN2ZyBpZD0iY2hldnJvbi1kb3duIiBjbGFzcz0ic3ZnLWljb24iIHZpZXdCb3g9IjAgMCAxMiA4IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMS4yIDBMNiA1LjQgMTAuOCAwIDEyIDEuMyA2IDggMCAxLjN6Ii8+Cjwvc3ZnPgo=');

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -60,7 +60,7 @@
   .ons-panel,
   .ons-btn__inner,
   .ons-external-link {
-    &.ons-svg-icon {
+    & .ons-svg-icon {
       fill: currentColor !important;
       forced-color-adjust: auto;
     }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -53,4 +53,11 @@
   .ons-hero__pre-title {
     filter: brightness(0) invert(1);
   }
+
+  // Buttons - Overrides adjustment to make button shadow selectable
+  .ons-btn {
+    &::after {
+      bottom: 0 !important;
+    }
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -223,4 +223,10 @@
       }
     }
   }
+
+  // Feedback – Remove speech bubble border because hcm doesn't support transparent borders
+  .ons-feedback::before,
+  .ons-feedback::after {
+    content: none;
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -60,4 +60,25 @@
       bottom: 0 !important;
     }
   }
+
+  .ons-input,
+  .ons-btn .ons-btn__inner,
+  .ons-tab--row {
+    &:focus,
+    &:focus-visible {
+      // Focus states – To better match the focus states of native controls
+      outline-color: Highlight;
+    }
+  }
+
+  // Tabs – prevent tab border colour change
+  .ons-tabs__list--row::after {
+    bottom: 1px;
+    forced-color-adjust: none;
+  }
+
+  .ons-tab--row[aria-selected='true'] {
+    border-color: ButtonText;
+    color: ButtonText;
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -193,6 +193,7 @@
   }
 
   // Highlighting
+  h1 em,
   .ons-highlight {
     background-color: mark;
     color: marktext;

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -8,14 +8,10 @@
     filter: brightness(0) invert(1);
   }
 
-  // Adds a border to container error warning panel
+  // Panels – add border to replace backgrounds
   .ons-panel {
     border-color: currentColor;
     border-left-width: 8px !important;
-
-    .ons-panel__header {
-      border-bottom: 1px solid currentColor;
-    }
   }
 
   // Adds some style adjustments to the focused item to make it obvious something is selected
@@ -200,5 +196,31 @@
   .ons-highlight {
     background-color: mark;
     color: marktext;
+  }
+
+  // Errors
+  .ons-panel--error {
+    border-color: mark;
+    outline-color: mark;
+
+    & .ons-panel__header {
+      border-bottom: 1px solid mark;
+    }
+  }
+
+  .ons-input {
+    &--error:not(:focus) {
+      border-color: mark;
+      outline-color: mark;
+
+      & + .ons-input-type__type,
+      & + .ons-input-type__type[title] {
+        border-color: mark;
+      }
+
+      & + .ons-input-type__type::after {
+        outline-color: mark;
+      }
+    }
   }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -22,7 +22,7 @@
   // Adds some style adjustments to the focused item to make it obvious something is selected
   .ons-autosuggest-input {
     &__results {
-      outline: 1px solid Highlight !important;
+      border: 1px solid Highlight !important;
     }
 
     .ons-autosuggest-input__option {

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -2,7 +2,6 @@
 @media screen and (-ms-high-contrast: active), (forced-colors: active) {
   // Brightness makes all images black, except transparent parts, which remain transparent
   // Then, invert(1) makes the black parts white
-  .ons-header__logo,
   .ons-footer__ogl-img,
   .ons-quote .ons-svg-icon,
   .ons-collapsible__icon .ons-svg-icon,
@@ -44,6 +43,15 @@
   .ons-btn__inner,
   .ons-external-link {
     & .ons-svg-icon {
+      fill: currentColor !important;
+      forced-color-adjust: auto;
+    }
+  }
+
+  // Logos
+  .ons-header__org-logo,
+  .ons-header__title-logo {
+    & .ons-svg-logo {
       fill: currentColor !important;
       forced-color-adjust: auto;
     }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -38,10 +38,12 @@
     }
   }
 
-  // Had to do this without messing with the existing SVG
+  // Select - Overrides custom background image icon
   .ons-input--select {
-    background-image: url('data:image/svg+xml;base64,PHN2ZyBpZD0iY2hldnJvbi1kb3duIiBjbGFzcz0ic3ZnLWljb24iIHZpZXdCb3g9IjAgMCAxMiA4IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogICAgPHBhdGggZmlsbD0iY3VycmVudENvbG9yIiBkPSJNMS4yIDBMNiA1LjQgMTAuOCAwIDEyIDEuMyA2IDggMCAxLjN6Ii8+Cjwvc3ZnPgo=');
-    background-size: 12px 8px;
+    background: $color-input-bg
+      url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='ons-svg-icon' viewBox='0 0 12 8'%3E%3Cpath fill='%23fff' d='M1.5.3 6 5.4 10.5.3c.2-.2.4-.2.6 0l.7.7c.1.2.1.4 0 .5L6.3 7.7c-.2.2-.4.2-.6 0L.2 1.6C.1 1.4.1 1.2.2 1L.9.3c.2-.1.4-.1.6 0z'/%3E%3C/svg%3E")
+      no-repeat center right 10px;
+    background-size: 1rem;
   }
 
   // I would have approached the mark differently, but without changing the existing approach this fixes it

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -52,11 +52,4 @@
   .ons-hero__pre-title {
     filter: brightness(0) invert(1);
   }
-
-  // Inputs – to better match the focus states of native controls
-  .ons-checkbox {
-    &__input:focus + &__label::before {
-      outline-color: Highlight;
-    }
-  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -78,7 +78,19 @@
   }
 
   .ons-tab--row[aria-selected='true'] {
-    border-color: ButtonText;
+    border-color: ButtonText !important;
+    color: ButtonText;
+  }
+
+  // Navigation and section nav – item border
+  .ons-section-nav:not(.ons-section-nav--vertical) .ons-section-nav__item,
+  .ons-navigation__item {
+    border-color: canvas;
+  }
+
+  .ons-section-nav:not(.ons-section-nav--vertical) .ons-section-nav__item--active,
+  .ons-navigation__item--active {
+    border-color: ButtonText !important;
     color: ButtonText;
   }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -126,6 +126,12 @@
     border-bottom: 1px solid currentColor;
   }
 
+  @include mq(m) {
+    .ons-header__main {
+      border-bottom: 1px solid currentColor;
+    }
+  }
+
   .ons-navigation--sub {
     border-top: 1px solid currentColor;
   }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -10,21 +10,6 @@
     filter: brightness(0) invert(1);
   }
 
-  // IE11 fallback
-  .ons-collapsible__icon .ons-svg-icon,
-  .ons-breadcrumb__item .ons-svg-icon,
-  .ons-panel .ons-svg-icon,
-  .ons-list--icons .ons-svg-icon {
-    fill: currentColor;
-  }
-
-  // Matches icon with the link colour
-  .ons-external-link {
-    svg {
-      fill: currentColor !important;
-    }
-  }
-
   // Adds a border to container error warning panel
   .ons-panel--error {
     border: 1px solid currentColor;
@@ -69,9 +54,16 @@
     border: 2px solid currentColor;
   }
 
-  // Buttons
-  .ons-btn__inner .ons-svg-icon {
-    fill: currentColor !important;
+  // Element icons – matches icon with the link colour
+  .ons-collapsible__icon,
+  .ons-breadcrumb__item,
+  .ons-panel,
+  .ons-btn__inner,
+  .ons-external-link {
+    &.ons-svg-icon {
+      fill: currentColor !important;
+      forced-color-adjust: auto;
+    }
   }
 
   // Hero pre title

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -157,4 +157,23 @@
       outline-color: ButtonText !important;
     }
   }
+
+  // Radios and Checkboxes – disabled
+  .ons-checkbox__input {
+    &:disabled {
+      border-color: grayText;
+    }
+    &:disabled:checked::after {
+      border-color: grayText;
+    }
+    &:disabled + .ons-checkbox__label,
+    &:disabled:checked + .ons-checkbox__label {
+      color: grayText;
+
+      &::before {
+        border-color: grayText;
+        outline-color: grayText;
+      }
+    }
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -158,8 +158,10 @@
     }
   }
 
-  // Radios and Checkboxes – disabled
+  // Radios and Checkboxes – disabled and checked
   .ons-checkbox__input {
+    border-color: canvastext;
+
     &:disabled {
       border-color: grayText;
     }
@@ -173,6 +175,18 @@
       &::before {
         border-color: grayText;
         outline-color: grayText;
+      }
+    }
+
+    &:checked:not(:disabled):not(:visited),
+    &:checked:not(:disabled):not(:visited)::after {
+      border-color: Highlight;
+    }
+
+    &:checked + .ons-checkbox__label {
+      &::before {
+        border-color: Highlight;
+        outline-color: Highlight;
       }
     }
   }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -54,7 +54,8 @@
   .ons-breadcrumb__item,
   .ons-panel,
   .ons-btn__inner,
-  .ons-external-link {
+  .ons-external-link,
+  .ons-list--icons {
     & .ons-svg-icon {
       fill: currentColor !important;
       forced-color-adjust: auto;

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -176,4 +176,9 @@
       }
     }
   }
+
+  // Colour swatch – prevent colour adjustment
+  .ons-patternlib-swatch__color {
+    forced-color-adjust: none;
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -145,4 +145,12 @@
   .ons-input-search--icon:valid:not(:placeholder-shown) {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='%23ffffff'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M11.86 10.23 8.62 6.99a4.63 4.63 0 1 0-6.34 1.64 4.55 4.55 0 0 0 2.36.64 4.65 4.65 0 0 0 2.33-.65l3.24 3.23a.46.46 0 0 0 .65 0l1-1a.48.48 0 0 0 0-.62Zm-5-3.32a3.28 3.28 0 0 1-2.31.93 3.22 3.22 0 1 1 2.35-.93Z'/%3E%3C/svg%3E");
   }
+
+  // Pagination – current page state
+  .ons-pagination {
+    &__item--current &__link {
+      color: ButtonText;
+      outline-color: ButtonText !important;
+    }
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -181,4 +181,10 @@
   .ons-patternlib-swatch__color {
     forced-color-adjust: none;
   }
+
+  // Highlighting
+  .ons-highlight {
+    background-color: Highlight;
+    color: HighlightText;
+  }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -4,7 +4,6 @@
   // Then, invert(1) makes the black parts white
   .ons-footer__ogl-img,
   .ons-quote .ons-svg-icon,
-  .ons-collapsible__icon .ons-svg-icon,
   .ons-footer img {
     filter: brightness(0) invert(1);
   }
@@ -52,7 +51,7 @@
   }
 
   // Element icons – matches icon with the link colour
-  .ons-collapsible__icon,
+  .ons-collapsible,
   .ons-breadcrumb__item,
   .ons-panel,
   .ons-btn__inner,

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -9,9 +9,9 @@
   }
 
   // Adds a border to container error warning panel
-  .ons-panel--error {
-    border: 1px solid currentColor;
-    border-left-width: 8px;
+  .ons-panel {
+    border-color: currentColor;
+    border-left-width: 8px !important;
 
     .ons-panel__header {
       border-bottom: 1px solid currentColor;

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -20,9 +20,22 @@
   }
 
   // Adds some style adjustments to the focused item to make it obvious something is selected
-  .ons-js-autosuggest .ons-autosuggest-input__option--focused {
-    padding-left: 1.5rem;
-    text-decoration: underline;
+  .ons-autosuggest-input {
+    &__results {
+      outline: 1px solid Highlight !important;
+    }
+
+    .ons-autosuggest-input__option {
+      &:focus,
+      &:hover,
+      &:hover .ons-autosuggest-input__category,
+      &--focused,
+      &--focused .ons-autosuggest-input__category {
+        background: Highlight !important;
+        color: HighlightText !important;
+        forced-color-adjust: none;
+      }
+    }
   }
 
   // Had to do this without messing with the existing SVG
@@ -114,5 +127,12 @@
 
   .ons-navigation--sub {
     border-top: 1px solid currentColor;
+  }
+
+  // Search – override focus state background image
+  .ons-input-search--icon:focus,
+  .ons-input-search--icon:active,
+  .ons-input-search--icon:valid:not(:placeholder-shown) {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='%23ffffff'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M11.86 10.23 8.62 6.99a4.63 4.63 0 1 0-6.34 1.64 4.55 4.55 0 0 0 2.36.64 4.65 4.65 0 0 0 2.33-.65l3.24 3.23a.46.46 0 0 0 .65 0l1-1a.48.48 0 0 0 0-.62Zm-5-3.32a3.28 3.28 0 0 1-2.31.93 3.22 3.22 0 1 1 2.35-.93Z'/%3E%3C/svg%3E");
   }
 }

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -13,6 +13,7 @@
   // Adds a border to container error warning panel
   .ons-panel--error {
     border: 1px solid currentColor;
+    border-left-width: 8px;
 
     .ons-panel__header {
       border-bottom: 1px solid currentColor;

--- a/src/scss/overrides/hcm.scss
+++ b/src/scss/overrides/hcm.scss
@@ -52,4 +52,11 @@
   .ons-hero__pre-title {
     filter: brightness(0) invert(1);
   }
+
+  // Inputs – to better match the focus states of native controls
+  .ons-checkbox {
+    &__input:focus + &__label::before {
+      outline-color: Highlight;
+    }
+  }
 }

--- a/src/scss/patternlib.scss
+++ b/src/scss/patternlib.scss
@@ -154,6 +154,7 @@
   font-weight: 700;
   letter-spacing: 0.1rem;
   margin-right: 0.5rem;
+  outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show background
   padding: 0.3rem 0.5rem;
   text-transform: uppercase;
 }

--- a/src/scss/vars/_colors.scss
+++ b/src/scss/vars/_colors.scss
@@ -93,6 +93,8 @@ $color-placeholder: $color-grey-15 !default;
 $color-button: $color-leaf-green !default;
 $color-button-secondary: $color-grey-15 !default;
 $color-input: $color-black !default;
+$color-input-border: $color-black !default;
+$color-input-bg: $color-white !default;
 
 // Panels and status
 $color-info: $color-ocean-blue !default;

--- a/src/tests/visual/percy.snapshots.js
+++ b/src/tests/visual/percy.snapshots.js
@@ -33,7 +33,7 @@ PercyScript.run(async (page, percySnapshot) => {
   // Accordions
   await page.goto(`${testURL}/build/components/accordion/examples/accordion/index.html`);
   page.waitForSelector('.ons-collapsible--initialised');
-  let buttonAll = '.ons-js-collapsible-all';
+  let buttonAll = '.ons-js-accordion-all';
   await page.evaluate(buttonAll => document.querySelector(buttonAll).click(), buttonAll);
   await percySnapshot('Accordion - all open', { widths: [1300] });
 


### PR DESCRIPTION
### What is the context of this PR?
Ensures all elements render correctly in high contrast mode. 

Fixes #2248, fixes #2251, and fixes #2334 to ensure input icons are visible in high contrast mode.
Additionally fixes #2295 

### What is the mark-up change?
- Panel (warning branded) – Developers using the HTML markup for the '**warning branded**' variant of the panel component, will need to change the class `ons-census-warning` to `ons-branded-warning`

### How to review
Check the following elements render correctly in Windows High Contrast Mode:
- autosuggest
- button
- collapsible
- cookies
- checkboxes
- document-list
- errors
- external link
- feedback
- footer
- header
- hero
- highlighting
- input
- label
- list
- message
- modal
- navigation
- pagination
- panel
- phase-banner
- radios
- search
- section nav
- select
- skip link
- table
- tabs
