### PR TITLE
Accessbility: Sortable table icon colour contrast

### DIFF
--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -13,7 +13,7 @@
   &__cell {
     @include nth-element(1, 0);
 
-    border-bottom: 2px solid $color-grey-100;
+    border-bottom: 2px solid $color-grey-75;
     overflow: hidden;
     padding: 0.5rem 0 0.5rem 1rem;
     text-align: left;
@@ -65,7 +65,7 @@
       }
 
       .ons-table__body .ons-table__row {
-        border-bottom: 2px solid $color-grey-100;
+        border-bottom: 2px solid $color-grey-75;
         display: block;
         margin-bottom: 1rem;
       }
@@ -148,7 +148,7 @@
     [aria-sort='descending'].ons-table__header {
       .ons-svg-icon {
         .ons-topTriangle {
-          fill: $color-grey-35;
+          fill: $color-grey-75;
         }
         .ons-bottomTriangle {
           fill: $color-text;
@@ -169,7 +169,7 @@
           fill: $color-text;
         }
         .ons-bottomTriangle {
-          fill: $color-grey-35;
+          fill: $color-grey-75;
         }
       }
       .ons-table__sort-button:focus {
@@ -205,7 +205,7 @@
         }
 
         .ons-svg-icon {
-          fill: $color-grey-35;
+          fill: $color-grey-75;
           height: 0.8rem;
           padding-bottom: 0.1rem;
           width: 0.8rem;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -148,7 +148,7 @@
     [aria-sort='descending'].ons-table__header {
       .ons-svg-icon {
         .ons-topTriangle {
-          fill: $color-grey-75;
+          fill: $color-grey-35;
         }
         .ons-bottomTriangle {
           fill: $color-text;
@@ -169,7 +169,7 @@
           fill: $color-text;
         }
         .ons-bottomTriangle {
-          fill: $color-grey-75;
+          fill: $color-grey-35;
         }
       }
       .ons-table__sort-button:focus {


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2247 

Colour contrast on inactive sort icons was too low.