### PR TITLE
Accessibility: Add DS example page title and heading

### DIFF
--- a/src/views/layouts/_example.njk
+++ b/src/views/layouts/_example.njk
@@ -1,10 +1,12 @@
 {% extends "./_master.njk" %}
 {% set example = true %}
+{% set pageTitle = "Example: " ~ pageInfo.title | replace("-", " ") | capitalize %}
 
-{% set pageConfig = {"lang": pageInfo.lang, "title": "Example" } %}
+{% set pageConfig = {"lang": pageInfo.lang, "title": pageTitle } %}
 
 {% block pageContent %}
     <main class="ons-patternlib-page__example">
+        <h1 class="ons-u-vh">{{ pageTitle }}</h1>
         {% block main %}
         {% endblock %}
     </main>


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #2254 

This change alters the current hard coded "Example" used for the `title` `head` tag for the example template (viewed when a component example is opened in its own tab). It now creates a pattern of "Example: _Component name_"

A new `h1` is also included in the example template which uses the same pattern and is visually hidden so screen readers can still read and understand the context of the page.

This change will require some DAC testing as some components render their own `h1` i.e. when the component is used with the question macro. This will render two `h1` elements. It needs to be tested to understand from an accessibility perspective that the occasional output of two `h1` elements creates less confusion than no output on components that don't render an `h1` as part of the example.

We could work around this by having a frontmatter property that allows us to exclude the visually hidden `h1` manually but this could prove prone to error (not using the property).

### How to review
- View a component page
- Click to open the component example in a new tab
- Observe the `title` and hidden `h1`