### PR TITLE
Accessibility: Document list - opens in new tab and context

### DIFF
--- a/src/components/document-list/_macro-options.md
+++ b/src/components/document-list/_macro-options.md
@@ -1,10 +1,11 @@
-| Name       | Type              | Required | Description                                                                                                                                          |
-| ---------- | ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id         | string            | false    | The HTML `id` attribute for the document list element                                                                                                |
-| classes    | string            | false    | Classes for the document list element                                                                                                                |
-| attributes | object            | false    | HTML attributes (for example, data attributes) to add to the document list element                                                                   |
-| documents  | `Array<Document>` | true     | An array of [document items](#document) in the documents list                                                                                        |
-| titleTag   | string            | false    | The HTML heading tag to wrap each document list item’s title to make sure the headings have the correct semantic order on the page. Defaults to `h2` |
+| Name                 | Type              | Required | Description                                                                                                                                          |
+| -------------------- | ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id                   | string            | false    | The HTML `id` attribute for the document list element                                                                                                |
+| classes              | string            | false    | Classes for the document list element                                                                                                                |
+| attributes           | object            | false    | HTML attributes (for example, data attributes) to add to the document list element                                                                   |
+| documents            | `Array<Document>` | true     | An array of [document items](#document) in the documents list                                                                                        |
+| titleTag             | string            | false    | The HTML heading tag to wrap each document list item’s title to make sure the headings have the correct semantic order on the page. Defaults to `h2` |
+| newWindowDescription | string            | false    | Use to set context after each document title link for screen readers. Defaults to “opens in a new tab”                                               |
 
 ## Document
 

--- a/src/components/document-list/_macro.njk
+++ b/src/components/document-list/_macro.njk
@@ -29,19 +29,17 @@
                             {% set titleTag = params.titleTag | default("h2") %}
 
                             <{{ titleTag }} class="ons-document-list__item-title ons-u-fs-m ons-u-mt-no ons-u-mb-xs">
-                                <a href="{{ document.url }}">{{ document.title }}
-                                {%- if document.metadata is defined and document.metadata and document.metadata.file is defined and document.metadata.file %}
-                                <span class="ons-u-vh">
-                                    {% set fileMetadataItems = [] %}
-                                    {% if document.metadata.file.fileType is defined and document.metadata.file.fileType %}{% set fileMetadataItems = (fileMetadataItems.push(document.metadata.file.fileType + ' document download'), fileMetadataItems) %}{% endif %}
-                                    {% if document.metadata.file.fileSize is defined and document.metadata.file.fileSize %}{% set fileMetadataItems = (fileMetadataItems.push(document.metadata.file.fileSize), fileMetadataItems) %}{% endif %}
-                                    {% if document.metadata.file.filePages is defined and document.metadata.file.filePages %}{% set fileMetadataItems = (fileMetadataItems.push(document.metadata.file.filePages), fileMetadataItems) %}{% endif %}
+                                <a href="{{ document.url }}" target="_blank"><span class="ons-document-list__item-title-text">{{ document.title }}</span>
+                                    <span class="ons-u-vh">
+                                        {%- if document.metadata is defined and document.metadata and document.metadata.file is defined and document.metadata.file %}
+                                            {% set fileMetadataItems = [] %}
+                                            {% if document.metadata.file.fileType is defined and document.metadata.file.fileType %}{% set fileMetadataItems = (fileMetadataItems.push(document.metadata.file.fileType + ' document download'), fileMetadataItems) %}{% endif %}
+                                            {% if document.metadata.file.fileSize is defined and document.metadata.file.fileSize %}{% set fileMetadataItems = (fileMetadataItems.push(document.metadata.file.fileSize), fileMetadataItems) %}{% endif %}
+                                            {% if document.metadata.file.filePages is defined and document.metadata.file.filePages %}{% set fileMetadataItems = (fileMetadataItems.push(document.metadata.file.filePages), fileMetadataItems) %}{% endif %}
 
-                                    , {{ fileMetadataItems | join(', ') }}
-
-                                {% endif %}
-
-                                </span></a>
+                                            , {{ fileMetadataItems | join(', ') }}{% endif %} ({{- params.newWindowDescription | default("opens in a new tab") -}})
+                                    </span>
+                                </a>
                             </{{ titleTag }}>
 
                             {%- if document.metadata is defined and document.metadata %}

--- a/src/components/document-list/_macro.spec.js
+++ b/src/components/document-list/_macro.spec.js
@@ -167,7 +167,7 @@ describe('macro: document list', () => {
 
     it('has expected `title`', () => {
       const $ = cheerio.load(renderComponent('document-list', { documents: [EXAMPLE_DOCUMENT_LIST_BASIC] }));
-      const title = $('.ons-document-list__item-title a')
+      const title = $('.ons-document-list__item-title .ons-document-list__item-title-text')
         .html()
         .trim();
       expect(title).toBe('Crime and justice');
@@ -176,6 +176,24 @@ describe('macro: document list', () => {
     it('has expected `url` for the title', () => {
       const $ = cheerio.load(renderComponent('document-list', { documents: [EXAMPLE_DOCUMENT_LIST_BASIC] }));
       expect($('.ons-document-list__item-title a').attr('href')).toBe('#0');
+    });
+
+    it('has the default visually hidden `newWindowDescription` text for the title', () => {
+      const $ = cheerio.load(renderComponent('document-list', { documents: [EXAMPLE_DOCUMENT_LIST_BASIC] }));
+      const content = $('.ons-document-list__item-title a .ons-u-vh')
+        .html()
+        .trim();
+      expect(content).toEqual(expect.stringContaining('(opens in a new tab)'));
+    });
+
+    it('has the provided visually hidden `newWindowDescription` text for the title', () => {
+      const $ = cheerio.load(
+        renderComponent('document-list', { documents: [EXAMPLE_DOCUMENT_LIST_BASIC], newWindowDescription: 'provided text' }),
+      );
+      const content = $('.ons-document-list__item-title a .ons-u-vh')
+        .html()
+        .trim();
+      expect(content).toEqual(expect.stringContaining('(provided text)'));
     });
 
     it('has expected `description`', () => {
@@ -247,7 +265,7 @@ describe('macro: document list', () => {
       const hiddenText = $('.ons-document-list__item-title a .ons-u-vh')
         .text()
         .trim();
-      expect(hiddenText).toBe(', PDF document download, 499KB, 1 page');
+      expect(hiddenText).toBe(', PDF document download, 499KB, 1 page (opens in a new tab)');
     });
 
     it('has `file` information displayed', () => {

--- a/src/components/download-resources/download-resources.spec.js
+++ b/src/components/download-resources/download-resources.spec.js
@@ -627,9 +627,9 @@ async function getFilterSelectionLabels(page) {
 }
 
 async function getHiddenDocumentTitles(page) {
-  return await getTextContent(page, '.ons-js-filter__item.ons-u-hidden .ons-document-list__item-title');
+  return await getTextContent(page, '.ons-js-filter__item.ons-u-hidden .ons-document-list__item-title-text');
 }
 
 async function getShownDocumentTitles(page) {
-  return await getTextContent(page, '.ons-js-filter__item:not(.ons-u-hidden) .ons-document-list__item-title');
+  return await getTextContent(page, '.ons-js-filter__item:not(.ons-u-hidden) .ons-document-list__item-title-text');
 }


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #2252 

### How to review
- Ensure links in document list examples open in a new tab and contain default visually hidden text
- Check new tests
- Check documentation (macro options)
