### PR TITLE
Accessibility: Skip to content - move after preHeader

### DIFF
--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -101,7 +101,6 @@
                                                 "attributes": {
                                                     "aria-label": params.serviceLinks.toggleServicesButton.ariaLabel | default("Toggle menu"),
                                                     "aria-controls": params.serviceLinks.id,
-                                                    "aria-haspopup": "true",
                                                     "aria-expanded": "false"
                                                 }
                                             }) }}
@@ -225,7 +224,6 @@
                                         "attributes": {
                                             "aria-label": "Toggle search" ,
                                             "aria-controls": "ons-site-search",
-                                            "aria-haspopup": "true",
                                             "aria-expanded": "false"
                                         }
                                     }) }}
@@ -245,7 +243,6 @@
                                     "attributes": {
                                         "aria-label": params.navigation.toggleNavigationButton.ariaLabel | default("Toggle main menu") ,
                                         "aria-controls": params.navigation.id,
-                                        "aria-haspopup": "true",
                                         "aria-expanded": "false"
                                     }
                                 }) }}

--- a/src/components/header/_macro.spec.js
+++ b/src/components/header/_macro.spec.js
@@ -445,7 +445,6 @@ describe('macro: header', () => {
         attributes: {
           'aria-label': 'Toggle services menu',
           'aria-controls': 'service-links',
-          'aria-haspopup': 'true',
           'aria-expanded': 'false',
         },
       });
@@ -558,7 +557,6 @@ describe('macro: header', () => {
         attributes: {
           'aria-label': 'Toggle main menu',
           'aria-controls': 'main-nav',
-          'aria-haspopup': 'true',
           'aria-expanded': 'false',
         },
       });
@@ -601,7 +599,6 @@ describe('macro: header', () => {
         attributes: {
           'aria-label': 'Toggle search',
           'aria-controls': 'ons-site-search',
-          'aria-haspopup': 'true',
           'aria-expanded': 'false',
         },
       });

--- a/src/components/navigation/_macro.njk
+++ b/src/components/navigation/_macro.njk
@@ -69,7 +69,6 @@
                 "attributes": {
                     "aria-label": "Toggle section navigation",
                     "aria-controls": params.navigation.subNavigation.id,
-                    "aria-haspopup": "true",
                     "aria-expanded": "false"
                 }
             }) }}

--- a/src/components/navigation/_macro.spec.js
+++ b/src/components/navigation/_macro.spec.js
@@ -211,7 +211,6 @@ describe('macro: navigation', () => {
         attributes: {
           'aria-label': 'Toggle section navigation',
           'aria-controls': 'sub-nav',
-          'aria-haspopup': 'true',
           'aria-expanded': 'false',
         },
       });

--- a/src/components/skip-to-content/index.njk
+++ b/src/components/skip-to-content/index.njk
@@ -27,7 +27,9 @@ All ONS pages must use the skip to content component above the header.
 ## How to use this component
 The skip to content link component is visually hidden until it is brought into focus with a keyboard press.
 
-It should be the first element of the page content, and link to the page's `#main` div.
+It should be the first element of the page content if not using the [cookies banner](/patterns/cookies-settings/). If your service does use the cookies banner, then it should immediately follow.  It should link to the page's main content `div` using `#id` (`id` matching the `id` attribute if the `div`).
+
+If using the [page template](/foundations/page-template) the skip to content component is automatically included in the correct place and will link to a `div` with an `id` of `main-content`. To override this you can manually add it using the `skipLink` block.
 
 ## Help improve this component
 Let us know how we could improve this component or share your user research findings.

--- a/src/components/skip-to-content/index.njk
+++ b/src/components/skip-to-content/index.njk
@@ -29,7 +29,7 @@ The skip to content link component is visually hidden until it is brought into f
 
 It should be the first element of the page content if not using the [cookies banner](/patterns/cookies-settings/). If your service does use the cookies banner, then it should immediately follow.  It should link to the page's main content `div` using `#id` (`id` matching the `id` attribute if the `div`).
 
-If using the [page template](/foundations/page-template) the skip to content component is automatically included in the correct place and will link to a `div` with an `id` of `main-content`. To override this you can manually add it using the `skipLink` block.
+If using the [base page template](/foundations/page-template) the skip to content component is automatically included in the correct place and will link to a `div` with an `id` of `main-content`. To override this you can manually add it using the `skipLink` block.
 
 ## Help improve this component
 Let us know how we could improve this component or share your user research findings.

--- a/src/foundations/layout/page-template/examples/block-areas/index.njk
+++ b/src/foundations/layout/page-template/examples/block-areas/index.njk
@@ -24,6 +24,10 @@ layout: example
     <div class="ons-pattern-lib-block__label">block: body</div>
 
     <div class="ons-pattern-lib-block">
+        <div class="ons-pattern-lib-block__label">block: preHeader</div>
+    </div>
+
+    <div class="ons-pattern-lib-block">
         <div class="ons-pattern-lib-block__label">block: skipLink</div>
         {{
             onsSkipToContent({
@@ -33,15 +37,14 @@ layout: example
     </div>
 
     <div class="ons-pattern-lib-block">
-        <div class="ons-pattern-lib-block__label">block: preHeader</div>
-    </div>
-
-    <div class="ons-pattern-lib-block">
         <div class="ons-pattern-lib-block__label">block: header</div>
         {{
             onsHeader({
                 "title": "Design system",
                 "orgLogoHref": "#0",
+                "phase": {
+                    "html": 'This is a new service – to help improve it please <a href="#feedback">give us your feedback</a>'
+                },
                 "navigation": {
                     "id": "main-nav",
                     "ariaLabel": "Main menu",

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -128,14 +128,6 @@
         {% block body %}
             <div class="ons-page">
                 <div class="ons-page__content">
-                    {% block skipLink %}
-                        {{
-                            onsSkipToContent({
-                                "url": "#main-content",
-                                "text": "Skip to main content"
-                            })
-                        }}
-                    {% endblock %}
                     {% if form is defined and form and form.attributes is defined and form.attributes %}
                         <form
                             {% if form.classes is defined and form.classes %}class="{{ form.classes }}"{% endif %}
@@ -144,6 +136,14 @@
                         >
                     {% endif %}
                     {% block preHeader %}{% endblock %}
+                    {% block skipLink %}
+                        {{
+                            onsSkipToContent({
+                                "url": "#main-content",
+                                "text": "Skip to main content"
+                            })
+                        }}
+                    {% endblock %}
                     {% block header %}
                         {{
                             onsHeader({

--- a/src/patterns/help-users-to/cookies-settings/index.njk
+++ b/src/patterns/help-users-to/cookies-settings/index.njk
@@ -21,7 +21,7 @@ There are two parts to implementing cookies control within a service; cookies ba
     patternlibExample({ "path": "components/cookies-banner/examples/cookies-banner/index.njk" })
 }}
 ## How to use
-The cookies banner must be placed directly above the ONS [header](/components/header) at the very top of the page. If using the [page template](/foundations/page-template) it should be placed inside the `preHeader` block. This will ensure that it is displayed before the [skip to content](/components/skip-to-content) link.
+The cookies banner must be placed directly above the ONS [header](/components/header) at the very top of the page. If using the [base page template](/foundations/page-template) it should be placed inside the `preHeader` block. This will ensure that it is displayed before the [skip to content](/components/skip-to-content) link.
 
 It will display if the user hasn’t accepted any ONS cookies via the banner or the cookie preferences page.
 

--- a/src/patterns/help-users-to/cookies-settings/index.njk
+++ b/src/patterns/help-users-to/cookies-settings/index.njk
@@ -21,7 +21,7 @@ There are two parts to implementing cookies control within a service; cookies ba
     patternlibExample({ "path": "components/cookies-banner/examples/cookies-banner/index.njk" })
 }}
 ## How to use
-The cookies banner must be placed directly above the ONS [header](/components/header) at the very top of the page.
+The cookies banner must be placed directly above the ONS [header](/components/header) at the very top of the page. If using the [page template](/foundations/page-template) it should be placed inside the `preHeader` block. This will ensure that it is displayed before the [skip to content](/components/skip-to-content) link.
 
 It will display if the user hasn’t accepted any ONS cookies via the banner or the cookie preferences page.
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2337 

The issue linked above also requested the following changes:

- Add Cookie banner, phase banner etc in the blocks exploded view to users can see what they should be used for
- Add a page example to the skip link component docs to see where it's positioned, how it links to main etc.
- Add cookie banner to base page template?

Changes:

- Skip link component placement in page template has been moved to after `preHeader` block (where the cookie banner should be placed)
- The documentation for cookie banner and skip to content have been updated to provide guidance on placement. I feel this is better than creating yet more examples.
- I don't think adding the cookies banner to the page template is the right thing to do. It will just cause bloat of an already complicated macro.
