### PR TITLE
Fix: Hero - remove regex and replace with simple solution

### DIFF
--- a/src/components/hero/_macro.njk
+++ b/src/components/hero/_macro.njk
@@ -25,7 +25,7 @@
 
             <header>
                 {% if params.preTitleImage is defined and params.preTitleImage %}
-                    {% set preTitleImageWithModifier = params.preTitleImage.name|replace(r/(\.[^\.]+)$/, "--" + skinName + "$1") %}
+                    {% set preTitleImageWithModifier = params.preTitleImage.name ~ "--" ~ skinName ~ ".svg" %}
                     <img class="ons-hero__pre-title" src="{{ params.placeholderURL }}/img/{{ preTitleImageWithModifier }}" alt="{{ params.preTitleImage.alt }}">
                 {% endif %}
                 {% if params.title is defined and params.title %}

--- a/src/components/hero/_macro.spec.js
+++ b/src/components/hero/_macro.spec.js
@@ -36,7 +36,7 @@ const EXAMPLE_HERO_WITH_BUTTON = {
 const EXAMPLE_HERO_WITH_PRETITLE_IMAGE = {
   ...EXAMPLE_HERO_MINIMAL,
   preTitleImage: {
-    name: 'example.svg',
+    name: 'example',
     alt: 'svg alt text',
   },
 };

--- a/src/components/hero/examples/pre-title-image-dark/index.njk
+++ b/src/components/hero/examples/pre-title-image-dark/index.njk
@@ -8,7 +8,7 @@
         "detailsColumns": '6',
         "variants": ['census', 'dark'],
         "preTitleImage": {
-            "name": 'its-about-us.svg',
+            "name": 'its-about-us',
             "alt": 'It’s about us'
         },
         "title": 'Start your legacy',

--- a/src/components/hero/examples/pre-title-image-light/index.njk
+++ b/src/components/hero/examples/pre-title-image-light/index.njk
@@ -8,7 +8,7 @@
         "variants": 'census',
         "detailsColumns": '6',
         "preTitleImage": {
-            "name": 'its-about-us.svg',
+            "name": 'its-about-us',
             "alt": 'It’s about us'
         },
         "title": 'Start your legacy',


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2386 

### Breaking changes

To simplify the code and remove the regex the `.svg`  extension is now not required when using the `preTitleImage.name` property e.g. `'its-about-us.svg'` should be replaced with `'its-about-us'`


### How to review
- Check the examples on the hero component page that use the `preTitleImage` property still work as expected.
- Tests have been updated to reflect the macro change