### PR TITLE
Accessibility - Label/Legend description change

### DIFF
--- a/src/components/collapsible/_collapsible.scss
+++ b/src/components/collapsible/_collapsible.scss
@@ -10,7 +10,8 @@ $collapsible-caret-width: 1.5rem;
     pointer-events: initial;
     position: relative;
 
-    &::marker {
+    &::marker,
+    &::-webkit-details-marker {
       display: none;
     }
 

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -1,11 +1,13 @@
 .ons-fieldset {
   &__legend {
     font-weight: $font-weight-bold;
-    margin: 0 0 0.6rem;
+    margin: 0;
   }
 
   &__description:not(&__description--title) {
     @extend .ons-label__description;
+
+    margin-bottom: 0.55rem;
   }
 
   &__description--title {

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -6,6 +6,7 @@
       margin-bottom: 0.55rem;
     }
     &-title {
+      display: block;
       margin: 0;
       padding: 0 0 1.5rem;
     }

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -5,6 +5,10 @@
     &:not(&--with-description) {
       margin-bottom: 0.55rem;
     }
+    &-title {
+      margin: 0;
+      padding: 0 0 1.5rem;
+    }
   }
 
   &__description:not(&__description--title) {

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -2,6 +2,9 @@
   &__legend {
     font-weight: $font-weight-bold;
     margin: 0;
+    &:not(&--with-description) {
+      margin-bottom: 0.55rem;
+    }
   }
 
   &__description:not(&__description--title) {

--- a/src/components/fieldset/_macro.njk
+++ b/src/components/fieldset/_macro.njk
@@ -15,7 +15,7 @@
             >
                 <legend{% if params.description %} aria-describedBy="{{ descriptionID }}"{% endif %} class="ons-fieldset__legend{% if params.legendClasses is defined and params.legendClasses %} {{ params.legendClasses }}{% endif %}{% if params.description %} ons-fieldset__legend--with-description{% endif %}">
                     {%- if params.legendIsQuestionTitle -%}
-                        <h1 id="fieldset-legend-title" class="ons-fieldset__legend-title ons-u-mb-no ons-u-pb-m{% if params.legendTitleClasses is defined and params.legendTitleClasses %} {{ params.legendTitleClasses }}{% endif %}">
+                        <h1 id="fieldset-legend-title" class="ons-fieldset__legend-title{% if params.legendTitleClasses is defined and params.legendTitleClasses %} {{ params.legendTitleClasses }}{% endif %}">
                             {{- params.legend | safe -}}
                         </h1>
                     {%- else -%}

--- a/src/components/fieldset/_macro.njk
+++ b/src/components/fieldset/_macro.njk
@@ -13,13 +13,13 @@
                 class="ons-fieldset{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
                 {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
             >
-                <legend{% if params.description %} aria-describedBy="{{ descriptionID }}"{% endif %} class="ons-fieldset__legend{% if params.legendClasses is defined and params.legendClasses %} {{ params.legendClasses }}{% endif %}{% if params.description %} ons-fieldset__legend--with-description{% endif %}">
+                <legend{% if params.description %} aria-describedBy="{{ descriptionID }}"{% endif %} class="ons-fieldset__legend{% if params.legendIsQuestionTitle %} ons-u-mb-no{% endif %}{% if params.legendClasses is defined and params.legendClasses %} {{ params.legendClasses }}{% endif %}{% if params.description %} ons-fieldset__legend--with-description{% endif %}">
                     {%- if params.legendIsQuestionTitle -%}
                         <h1 id="fieldset-legend-title" class="ons-fieldset__legend-title{% if params.legendTitleClasses is defined and params.legendTitleClasses %} {{ params.legendTitleClasses }}{% endif %}">
                             {{- params.legend | safe -}}
                         </h1>
                     {%- else -%}
-                        <span class="ons-fieldset__legend-title">{{- params.legend | safe -}}</span>
+                        <span class="ons-fieldset__legend-title ons-u-pb-no">{{- params.legend | safe -}}</span>
                     {%- endif -%}
                 </legend>
                 {%- if params.description -%}

--- a/src/components/fieldset/_macro.njk
+++ b/src/components/fieldset/_macro.njk
@@ -13,9 +13,9 @@
                 class="ons-fieldset{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
                 {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
             >
-                <legend{% if params.description %} aria-describedBy="{{ descriptionID }}"{% endif %} class="ons-fieldset__legend {% if params.legendClasses is defined and params.legendClasses %} {{ params.legendClasses }}{% endif %}">
+                <legend{% if params.description %} aria-describedBy="{{ descriptionID }}"{% endif %} class="ons-fieldset__legend{% if params.legendClasses is defined and params.legendClasses %} {{ params.legendClasses }}{% endif %}{% if params.description %} ons-fieldset__legend--with-description{% endif %}">
                     {%- if params.legendIsQuestionTitle -%}
-                        <h1 id="fieldset-legend-title" class="ons-fieldset__legend-title ons-u-mb-m{% if params.legendTitleClasses is defined and params.legendTitleClasses %} {{ params.legendTitleClasses }}{% endif %}">
+                        <h1 id="fieldset-legend-title" class="ons-fieldset__legend-title ons-u-mb-no ons-u-pb-m{% if params.legendTitleClasses is defined and params.legendTitleClasses %} {{ params.legendTitleClasses }}{% endif %}">
                             {{- params.legend | safe -}}
                         </h1>
                     {%- else -%}

--- a/src/components/fieldset/_macro.njk
+++ b/src/components/fieldset/_macro.njk
@@ -1,6 +1,7 @@
 {% from "components/error/_macro.njk" import onsError %}
 
 {% macro onsFieldset(params) %}
+    {% set descriptionID = (params.id ~ "-" if params.id else "") ~ "legend-description" %}
     {% set fieldset -%}
         {% if params.dontWrap is defined and params.dontWrap -%}
             <div class="ons-input-items">
@@ -12,7 +13,7 @@
                 class="ons-fieldset{% if params.classes is defined and params.classes %} {{ params.classes }}{% endif %}"
                 {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %} {% endfor %}{% endif %}
             >
-                <legend class="ons-fieldset__legend{% if params.legendIsQuestionTitle is defined and params.legendIsQuestionTitle %} ons-u-mb-no{% endif %}{% if params.legendClasses is defined and params.legendClasses %} {{ params.legendClasses }}{% endif %}">
+                <legend{% if params.description %} aria-describedBy="{{ descriptionID }}"{% endif %} class="ons-fieldset__legend {% if params.legendClasses is defined and params.legendClasses %} {{ params.legendClasses }}{% endif %}">
                     {%- if params.legendIsQuestionTitle -%}
                         <h1 id="fieldset-legend-title" class="ons-fieldset__legend-title ons-u-mb-m{% if params.legendTitleClasses is defined and params.legendTitleClasses %} {{ params.legendTitleClasses }}{% endif %}">
                             {{- params.legend | safe -}}
@@ -20,12 +21,12 @@
                     {%- else -%}
                         <span class="ons-fieldset__legend-title">{{- params.legend | safe -}}</span>
                     {%- endif -%}
-                    {%- if params.description is defined and params.description -%}
-                        <div class="ons-fieldset__description{% if params.legendIsQuestionTitle %} ons-fieldset__description--title ons-u-mb-m{% endif %}">
-                            {{- params.description | safe -}}
-                        </div>
-                    {%- endif -%}
                 </legend>
+                {%- if params.description -%}
+                    <div id="{{ descriptionID }}" class="ons-fieldset__description{% if params.legendIsQuestionTitle %} ons-fieldset__description--title ons-u-mb-m{% endif %}">
+                        {{- params.description | safe -}}
+                    </div>
+                {%- endif -%}
                 {{- caller() if caller -}}
             </fieldset>
         {%- endif %}

--- a/src/components/fieldset/_macro.spec.js
+++ b/src/components/fieldset/_macro.spec.js
@@ -32,6 +32,13 @@ describe('macro: fieldset', () => {
     expect(title).toBe('Fieldset legend');
   });
 
+  it('has correct `aria-decribedby` value', () => {
+    const $ = cheerio.load(renderComponent('fieldset', EXAMPLE_FIELDSET_BASIC));
+
+    const ariaDescByVal = $('.ons-fieldset__legend').attr('aria-describedby');
+    expect(ariaDescByVal).toBe('example-fieldset-legend-description');
+  });
+
   it('has the `description` text', () => {
     const $ = cheerio.load(renderComponent('fieldset', EXAMPLE_FIELDSET_BASIC));
 
@@ -39,6 +46,20 @@ describe('macro: fieldset', () => {
       .html()
       .trim();
     expect(title).toBe('A fieldset description');
+  });
+
+  it('has the correct `description` `id` when no `fieldset `id` is provided', () => {
+    const $ = cheerio.load(renderComponent('fieldset', { ...EXAMPLE_FIELDSET_BASIC, id: undefined }));
+
+    const id = $('.ons-fieldset__description').attr('id');
+    expect(id).toBe('legend-description');
+  });
+
+  it('has the correct `description` `id` when `fieldset `id` is provided', () => {
+    const $ = cheerio.load(renderComponent('fieldset', EXAMPLE_FIELDSET_BASIC));
+
+    const id = $('.ons-fieldset__description').attr('id');
+    expect(id).toBe('example-fieldset-legend-description');
   });
 
   it('has additionally provided style classes', () => {
@@ -121,11 +142,6 @@ describe('macro: fieldset', () => {
 
       const results = await axe($.html());
       expect(results).toHaveNoViolations();
-    });
-
-    it('has the correct class', () => {
-      const $ = cheerio.load(renderComponent('fieldset', { ...EXAMPLE_FIELDSET_BASIC, legendIsQuestionTitle: true }));
-      expect($('.ons-fieldset__legend').hasClass('ons-u-mb-no')).toBe(true);
     });
 
     it('renders the legend in a H1', () => {

--- a/src/components/fieldset/_macro.spec.js
+++ b/src/components/fieldset/_macro.spec.js
@@ -32,7 +32,7 @@ describe('macro: fieldset', () => {
     expect(title).toBe('Fieldset legend');
   });
 
-  it('has correct `aria-decribedby` value', () => {
+  it('has the correct `aria-decribedby` value', () => {
     const $ = cheerio.load(renderComponent('fieldset', EXAMPLE_FIELDSET_BASIC));
 
     const ariaDescByVal = $('.ons-fieldset__legend').attr('aria-describedby');

--- a/src/components/fieldset/_macro.spec.js
+++ b/src/components/fieldset/_macro.spec.js
@@ -62,6 +62,12 @@ describe('macro: fieldset', () => {
     expect(id).toBe('example-fieldset-legend-description');
   });
 
+  it('has the correct `legend` class when `description` is provided', () => {
+    const $ = cheerio.load(renderComponent('fieldset', EXAMPLE_FIELDSET_BASIC));
+
+    expect($('.ons-fieldset__legend').hasClass('ons-fieldset__legend--with-description')).toBe(true);
+  });
+
   it('has additionally provided style classes', () => {
     const $ = cheerio.load(
       renderComponent('fieldset', {

--- a/src/components/label/_macro.njk
+++ b/src/components/label/_macro.njk
@@ -1,32 +1,44 @@
 {% macro onsLabel(params) %}
-    {% set field -%}
-        <span
-          {% if params.id is defined and params.id %} id="{{ params.id }}-description-hint"{% else %}id="description-hint"{% endif %}
-          class="ons-label__description {% if params.inputType is defined and params.inputType %}ons-{{ params.inputType }}__label--with-description{% else %} ons-input--with-description{% endif %}">
+    {% if params.id %}
+        {% set descriptionID = params.id ~ "-description-hint" %}  
+    {% else %}
+        {% set descriptionID = "description-hint" %}  
+    {% endif %}
+
+    {% if params.inputType == "checkbox" or params.inputType == "radio" %}
+        {% set isCheckboxOrRadio = true %}
+    {% else %}
+        {% set isCheckboxOrRadio = false %}
+    {% endif %}
+
+    {% set description -%}
+        <span{% if isCheckboxOrRadio == false %} id="{{ descriptionID }}"{% endif %} class="ons-label__description {% if params.inputType %}ons-{{ params.inputType }}__label--with-description{% else %} ons-input--with-description{% endif %}">
               {{- params.description -}}
         </span>
     {%- endset %}
 
     <label
-        class="{% if params.inputType is not defined -%}ons-label{%- endif %}{{- ' ' + params.classes if params.classes else "" -}}{%- if params.description is defined and params.description %} ons-label--with-description{%- endif %} {{- ' ons-label--placeholder' if params.accessiblePlaceholder else "" -}}"
-        {% if params.for is defined and params.for %} for="{{ params.for }}"{% endif %}
-        {% if params.id is defined and params.id %} id="{{ params.id }}"{% endif %}
-        {% if params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}
+        class="{% if params.inputType is not defined -%}ons-label{%- endif %}{{- ' ' + params.classes if params.classes else "" -}}{%- if params.description %} ons-label--with-description{%- endif %} {{- ' ons-label--placeholder' if params.accessiblePlaceholder else "" -}}"
+        {% if params.description %}aria-labelledby="{{ descriptionID }}"{% endif %}
+        {% if params.for %} for="{{ params.for }}"{% endif %}
+        {% if params.id %} id="{{ params.id }}"{% endif %}
+        {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}
     >
 
         {{- params.text | safe -}}
 
-        {%- if params.inputType is defined and params.inputType -%}
-            {% if params.inputType == "checkbox" or params.inputType == "radio" -%}
-                {%- if params.description is defined and params.description -%}
-                    {{- field | safe -}}
-                {%- endif -%}
+        {%- if isCheckboxOrRadio == true -%}
+            {%- if params.description -%}
+                <span class="ons-label__aria-hidden-description" aria-hidden="true">{{- description | safe -}}</span>
             {%- endif -%}
             </label>
+            {% if isCheckboxOrRadio == true and params.description -%}
+                <span class="ons-label__visually-hidden-description ons-u-vh" id="{{ descriptionID }}">{{- params.description -}}</span>
+            {%- endif -%}
         {%- else -%}
             </label>
-            {%- if params.description is defined and params.description -%}
-                {{- field | safe -}}
+            {%- if params.description -%}
+                {{- description | safe -}}
             {%- endif -%}
         {%- endif %}
 {% endmacro %}

--- a/src/components/label/_macro.njk
+++ b/src/components/label/_macro.njk
@@ -19,7 +19,7 @@
 
     <label
         class="{% if params.inputType is not defined -%}ons-label{%- endif %}{{- ' ' + params.classes if params.classes else "" -}}{%- if params.description %} ons-label--with-description{%- endif %} {{- ' ons-label--placeholder' if params.accessiblePlaceholder else "" -}}"
-        {% if params.description %}aria-labelledby="{{ descriptionID }}"{% endif %}
+        {% if params.description %}aria-describedby="{{ descriptionID }}"{% endif %}
         {% if params.for %} for="{{ params.for }}"{% endif %}
         {% if params.id %} id="{{ params.id }}"{% endif %}
         {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ attribute }}{% if value is defined and value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}

--- a/src/components/label/_macro.spec.js
+++ b/src/components/label/_macro.spec.js
@@ -53,6 +53,12 @@ describe('macro: label', () => {
     expect($('.ons-label').attr('for')).toBe('some-input');
   });
 
+  it('has `aria-labelledby` and correct value when description is provided', () => {
+    const $ = cheerio.load(renderComponent('label', EXAMPLE_LABEL_WITH_DESCRIPTION));
+
+    expect($('.ons-label').attr('aria-labelledby')).toBe('example-label-description-hint');
+  });
+
   it.each([
     ['`inputType` parameter is not provided', EXAMPLE_LABEL, true],
     ['`inputType` parameter is provided', EXAMPLE_LABEL_WITH_INPUT_TYPE, false],
@@ -185,5 +191,30 @@ describe('macro: label', () => {
       expect($('.ons-label__description').hasClass(expectedInputSpecificModifier)).toBe(true);
       expect($('.ons-label__description').hasClass('ons-input--with-description')).toBe(false);
     });
+
+    it.each([['checkbox'], ['radio']])('has the description in an `aria-hidden` element when "%s" `inputType` is provided', inputType => {
+      const $ = cheerio.load(
+        renderComponent('label', {
+          ...EXAMPLE_LABEL_WITH_DESCRIPTION,
+          inputType,
+        }),
+      );
+
+      expect($('.ons-label__aria-hidden-description').attr('aria-hidden')).toBe('true');
+    });
+
+    it.each([['checkbox'], ['radio']])(
+      'has a duplicate description in a visually hidden element when "%s" `inputType` is provided',
+      inputType => {
+        const $ = cheerio.load(
+          renderComponent('label', {
+            ...EXAMPLE_LABEL_WITH_DESCRIPTION,
+            inputType,
+          }),
+        );
+
+        expect($('.ons-label__visually-hidden-description').hasClass('ons-u-vh')).toBe(true);
+      },
+    );
   });
 });

--- a/src/components/label/_macro.spec.js
+++ b/src/components/label/_macro.spec.js
@@ -53,10 +53,10 @@ describe('macro: label', () => {
     expect($('.ons-label').attr('for')).toBe('some-input');
   });
 
-  it('has `aria-labelledby` and correct value when description is provided', () => {
+  it('has `aria-describedby` and correct value when description is provided', () => {
     const $ = cheerio.load(renderComponent('label', EXAMPLE_LABEL_WITH_DESCRIPTION));
 
-    expect($('.ons-label').attr('aria-labelledby')).toBe('example-label-description-hint');
+    expect($('.ons-label').attr('aria-describedby')).toBe('example-label-description-hint');
   });
 
   it.each([

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -15,6 +15,7 @@
 
   &.ons-radio--no-border {
     @extend .ons-checkbox--no-border;
+
     & > .ons-radio__input {
       @extend .ons-radio__input;
       &:focus,
@@ -29,6 +30,10 @@
       &:focus {
         box-shadow: inset 0 0 0 3px $color-input-bg, 0 0 0 $input-border-width $color-input-border, 0 0 0 4px $color-focus;
       }
+    }
+
+    .ons-radio__label--with-description {
+      padding: 0;
     }
   }
 

--- a/src/tests/visual/percy.snapshots.js
+++ b/src/tests/visual/percy.snapshots.js
@@ -33,7 +33,7 @@ PercyScript.run(async (page, percySnapshot) => {
   // Accordions
   await page.goto(`${testURL}/build/components/accordion/examples/accordion/index.html`);
   page.waitForSelector('.ons-collapsible--initialised');
-  let buttonAll = '.ons-js-collapsible-all';
+  let buttonAll = '.ons-js-accordion-all';
   await page.evaluate(buttonAll => document.querySelector(buttonAll).click(), buttonAll);
   await percySnapshot('Accordion - all open', { widths: [1300] });
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2348  and #2259 

In addition to moving the description out of the `legend` tag it made sense to do this for checkboxes and radios. Currently, if a description is provided for a checkbox label it is rendered inside the `label` which would in theory give the same issue; label + description is often too long for screen readers.

The reason the description lived inside the `label` was so that the entire text was clickable. For this to remain I have added `aria-hidden` to the visible description and added a secondary visually hidden description outside of the `label`.

The `label` and description are related in both `label` and `legend` uses by `aria-describedby`.

Tests have been updated to include these new changes.

### How to review
Ensure the different scenarios are adhered to, in particular:

- When a description is provided with a checkbox/radio it renders the visually hidden description and has the aria-hidden attribute on the visible description BUT confirm that this doesn't happen when the implementation is not checkboxes or radios
- All components render as previously - some css has changed to accomodate the `legend` description being moved.