### PR TITLE
Accessibility: Grouped buttons

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -480,3 +480,17 @@ $button-shadow-size: 3px;
     }
   }
 }
+
+.ons-btn-group {
+  @extend .ons-u-mb-m;
+
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+
+  & .ons-btn,
+  & a {
+    margin: 0 1rem 1rem 0;
+  }
+}

--- a/src/components/button/examples/button-group/index.njk
+++ b/src/components/button/examples/button-group/index.njk
@@ -1,10 +1,11 @@
 {% from "components/button/_macro.njk" import onsButton %}
+
+<div class="ons-btn-group">
     {{
         onsButton({
             "text": 'Continue'
         })
     }}
-
     {{
         onsButton({
             "type": 'button',
@@ -12,3 +13,4 @@
             "variants": 'secondary'
         })
     }}
+</div>

--- a/src/components/reply/_macro.njk
+++ b/src/components/reply/_macro.njk
@@ -12,7 +12,7 @@
             })
         }}
         <div class="ons-grid ons-grid--flex ons-grid--gutterless ons-grid--vertical-center ons-grid--no-wrap@s ons-u-mt-m ons-u-mb-m">
-            <div class="ons-grid__col">
+            <div class="ons-grid__col ons-u-mr-m ons-u-mb-s">
                 {{
                     onsButton({
                         "id": params.button.id,
@@ -22,7 +22,7 @@
                     })
                 }}
             </div>
-            <div class="ons-grid__col ons-u-ml-m">
+            <div class="ons-grid__col ons-u-mb-s">
                 <a class="ons-reply__link" href="{{ params.closeLinkUrl }}">{{ params.closeLinkText }}</a>
             </div>
         </div>

--- a/src/tests/visual/percy.snapshots.js
+++ b/src/tests/visual/percy.snapshots.js
@@ -33,7 +33,7 @@ PercyScript.run(async (page, percySnapshot) => {
   // Accordions
   await page.goto(`${testURL}/build/components/accordion/examples/accordion/index.html`);
   page.waitForSelector('.ons-collapsible--initialised');
-  let buttonAll = '.ons-js-collapsible-all';
+  let buttonAll = '.ons-js-accordion-all';
   await page.evaluate(buttonAll => document.querySelector(buttonAll).click(), buttonAll);
   await percySnapshot('Accordion - all open', { widths: [1300] });
 


### PR DESCRIPTION
### What is the context of this PR?
Added a `ons-btn-group` class with flexbox layout which should be applied to a `div` wrapping any buttons within a group, to ensure the layout is appropriate.

Fixes #2339 

### How to review
Check grouped buttons example.
