### PR TITLE
Updated heading level semantics of examples using collapsibles

### DIFF
--- a/src/components/collapsible/index.njk
+++ b/src/components/collapsible/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Collapsible
-synonyms: Accordion, details, twisty, expandable
+synonyms: Accordion, details, twisty, expandable, definition, justification
 ---
 
 +++

--- a/src/patterns/help-users-to/cookies-settings/examples/cookie-settings-page/index.njk
+++ b/src/patterns/help-users-to/cookies-settings/examples/cookie-settings-page/index.njk
@@ -107,6 +107,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     "id": "cookies-measure-website-use-details",
                     "classes": "ons-u-mb-s",
                     "title": "Learn more about these Google Analytics cookies",
+                    "titleTag": 'h4',
                     "button": {
                         "close": "Hide this"
                     }
@@ -204,6 +205,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     "id": "cookies-measure-website-comms-details",
                     "classes": "ons-u-mb-s",
                     "title": "Learn more about these YouTube cookies",
+                    "titleTag": 'h5',
                     "button": {
                         "close": "Hide this"
                     }
@@ -310,11 +312,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     "id": "cookies-essential-details",
                     "classes": "ons-u-mb-l",
                     "title": "Learn more about these essential cookies",
+                    "titleTag": 'h4',
                     "button": {
                         "close": "Hide this"
                     }
                 }) %}
-                    <h4>Your progress when filling in a survey or questionnaire</h4>
+                    <h5 class="ons-u-fs-r--b">Your progress when filling in a survey or questionnaire</h5>
                     <p>We’ll set a cookie to remember your progress through a survey or questionnaire. These cookies do not store your personal data and are deleted once you’ve completed the survey or questionnaire.</p>
                     {{
                         onsTable({
@@ -346,7 +349,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                             ]
                         })
                     }}
-                    <h4>Cookie message</h4>
+                    <h5 class="ons-u-fs-r--b">Cookie message</h5>
                     <p>You may see a banner when you visit ons.gov.uk inviting you to accept cookies or review your settings. We’ll set cookies so that your computer knows you’ve seen it and not to show it again, and also to store your settings.</p>
                     {{
                         onsTable({

--- a/src/patterns/help-users-to/find-a-support-centre/examples/results/index.njk
+++ b/src/patterns/help-users-to/find-a-support-centre/examples/results/index.njk
@@ -75,12 +75,13 @@ layout: none
         {% call onsCollapsible({
             "id": 'collapsible-1',
             "title": 'Opening times and facilities',
+            "titleTag": 'h3',
             "button": {
                 "close": 'Hide this'
             }
         }) %}
 
-        <h3 class="ons-u-fs-r--b ons-u-mb-xs">Opening times</h3>
+        <h4 class="ons-u-fs-r--b ons-u-mb-xs">Opening times</h4>
 
         {{
             onsList({
@@ -101,7 +102,7 @@ layout: none
             })
         }}
         
-        <h3 class="ons-u-fs-r--b ons-u-mb-xs">Centre facilities</h3>
+        <h4 class="ons-u-fs-r--b ons-u-mb-xs">Centre facilities</h4>
 
         {{
             onsList({
@@ -160,16 +161,17 @@ layout: none
         {% call onsCollapsible({
             "id": 'collapsible-2',
             "title": 'Opening times and facilities',
+            "titleTag": 'h3',
             "button": {
                 "close": 'Hide this'
             }
         }) %}
 
-        <h3 class="ons-u-fs-r--b ons-u-mb-xs">Opening times</h3>
+        <h4 class="ons-u-fs-r--b ons-u-mb-xs">Opening times</h4>
 
         <p>Monday to Friday, 8am to 6pm</p>
         
-        <h3 class="ons-u-fs-r--b ons-u-mb-xs">Centre facilities</h3>
+        <h4 class="ons-u-fs-r--b ons-u-mb-xs">Centre facilities</h4>
 
         {{
             onsList({

--- a/src/tests/visual/percy.snapshots.js
+++ b/src/tests/visual/percy.snapshots.js
@@ -33,7 +33,7 @@ PercyScript.run(async (page, percySnapshot) => {
   // Accordions
   await page.goto(`${testURL}/build/components/accordion/examples/accordion/index.html`);
   page.waitForSelector('.ons-collapsible--initialised');
-  let buttonAll = '.ons-js-collapsible-all';
+  let buttonAll = '.ons-js-accordion-all';
   await page.evaluate(buttonAll => document.querySelector(buttonAll).click(), buttonAll);
   await percySnapshot('Accordion - all open', { widths: [1300] });
 


### PR DESCRIPTION
### What is the context of this PR?
Temporarily fixes #2368 – **Note:** A new solution to override the `h2` heading level styles in `page__body` is still required.

Updated the heading level semantics where collapsibles are used.

### How to review
Check heading level semantics of updated examples.