### PR TITLE
Fix: Sortable table headers missing when javascript off

### DIFF
--- a/src/components/icons/_macro.njk
+++ b/src/components/icons/_macro.njk
@@ -62,7 +62,7 @@
             <path d="M11.86 10.23 8.62 6.99a4.63 4.63 0 1 0-6.34 1.64 4.55 4.55 0 0 0 2.36.64 4.65 4.65 0 0 0 2.33-.65l3.24 3.23a.46.46 0 0 0 .65 0l1-1a.48.48 0 0 0 0-.62Zm-5-3.32a3.28 3.28 0 0 1-2.31.93 3.22 3.22 0 1 1 2.35-.93Z"/>
         </svg>
     {% elif params.iconType == "sort-sprite" %}
-        <svg id="sort-sprite{% if params.id is defined and params.id %}-{{ params.id | lower }}{% endif %}" class="ons-svg-icon {{ iconClasses }}" viewBox="0 0 12 19" xmlns="http://www.w3.org/2000/svg" focusable="false" fill="currentColor">
+        <svg id="sort-sprite{% if params.id is defined and params.id %}-{{ params.id | lower }}{% endif %}" class="ons-svg-icon{{ iconClasses }}" viewBox="0 0 12 19" xmlns="http://www.w3.org/2000/svg" focusable="false" fill="currentColor">
             <path class="ons-topTriangle"  d="M6 0l6 7.2H0L6 0zm0 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z"/>
             <path class="ons-bottomTriangle" d="M6 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z"/>
         </svg>

--- a/src/components/table/_macro.njk
+++ b/src/components/table/_macro.njk
@@ -16,12 +16,13 @@
                     <tr class="ons-table__row">
                         {% for th in params.ths %}
                         <th scope="col" class="ons-table__header{{ ' ' + th.thClasses if th.thClasses is defined and th.thClasses }}{{ " ons-table__header--numeric" if th.numeric is defined and th.numeric }}"{% if 'sortable' in variants %} aria-sort="{{- th.ariaSort | default('none') -}}"{% endif %}>
-                            <span {% if 'sortable' in variants %}class="ons-u-vh"{% endif %}>{{- th.value -}}</span>
+                            <span>{{- th.value -}}</span>
                             {% if 'sortable' in variants %}
                                 {{
                                     onsIcon({
                                         "iconType": "sort-sprite",
-                                        "id": th.value
+                                        "id": th.value,
+                                        "classes": 'ons-u-d-no'
                                     })
                                 }}
                             {% endif %}

--- a/src/components/table/_macro.spec.js
+++ b/src/components/table/_macro.spec.js
@@ -480,26 +480,6 @@ describe('macro: table', () => {
 
       expect($('.ons-table').attr('data-aria-desc')).toBe('descending');
     });
-
-    it('renders "sort-sprite" icon for each column header', () => {
-      const faker = templateFaker();
-      const iconsSpy = faker.spy('icons');
-
-      faker.renderComponent('table', params);
-
-      expect(iconsSpy.occurrences[0]).toEqual({
-        iconType: 'sort-sprite',
-        id: 'Column 1',
-      });
-      expect(iconsSpy.occurrences[1]).toEqual({
-        iconType: 'sort-sprite',
-        id: 'Column 2',
-      });
-      expect(iconsSpy.occurrences[2]).toEqual({
-        iconType: 'sort-sprite',
-        id: 'Column 3',
-      });
-    });
   });
 
   describe('table caption', () => {

--- a/src/components/table/_macro.spec.js
+++ b/src/components/table/_macro.spec.js
@@ -481,13 +481,6 @@ describe('macro: table', () => {
       expect($('.ons-table').attr('data-aria-desc')).toBe('descending');
     });
 
-    it('adds visually hidden class to column headers', () => {
-      const $ = cheerio.load(renderComponent('table', params));
-
-      const hasClass = mapAll($('.ons-table__header > span'), node => node.hasClass('ons-u-vh'));
-      expect(hasClass).toEqual([true, true, true]);
-    });
-
     it('renders "sort-sprite" icon for each column header', () => {
       const faker = templateFaker();
       const iconsSpy = faker.spy('icons');

--- a/src/components/table/sortable-table.js
+++ b/src/components/table/sortable-table.js
@@ -28,6 +28,7 @@ export default class TableSort {
   createHeadingButtons(heading, i) {
     const text = heading.textContent.trim();
     heading.childNodes[1].remove();
+    heading.childNodes[2].classList.remove('ons-u-d-no');
     const button = document.createElement('button');
     button.setAttribute('aria-label', this.table.getAttribute('data-aria-sort') + ' ' + text);
     button.setAttribute('type', 'button');


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2118 

- Removed visually hidden class on header title `span` – appeared to be irrelevant because the JS was replacing the whole `span` anyway
- Added `ons-u-d-no` class to sort icon, which is removed when JS initialises
- Removed macro tests that were checking for these two elements

### How to review
- Check sortable table renders as a regular table when no js
- Check tests pass