### PR TITLE
Accessibility: Panel - set alert role when success or error type

### DIFF
--- a/src/components/panel/_macro.njk
+++ b/src/components/panel/_macro.njk
@@ -31,7 +31,7 @@
             <div class="ons-container">
     {% endif %}
 
-        <div {% if params is defined and params and params.type == 'error' and params.title is defined and params.title %}aria-labelledby="error-summary-title" role="alert" tabindex="-1" {% if params.dsExample != true %}autofocus="autofocus" {% endif %}{% endif %}class="ons-panel{{ typeClass }}{{ iconClass }}{{ noTitleClass }}{{ spaciousClass }}{{ classes }}"{% if params is defined and params and params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params is defined and params and params.attributes is mapping and params.attributes.items is defined and params.attributes.items else params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}{% if params is defined and params and params.id is defined and params.id %} id="{{params.id}}"{% endif %}>
+        <div {% if params is defined and params and (params.type == 'error' or params.type == 'success') %}aria-labelledby="alert" role="alert" tabindex="-1" {% if params.dsExample != true %}autofocus="autofocus" {% endif %}{% endif %}class="ons-panel{{ typeClass }}{{ iconClass }}{{ noTitleClass }}{{ spaciousClass }}{{ classes }}"{% if params is defined and params and params.attributes is defined and params.attributes %}{% for attribute, value in (params.attributes.items() if params is defined and params and params.attributes is mapping and params.attributes.items is defined and params.attributes.items else params.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}{% if params is defined and params and params.id is defined and params.id %} id="{{params.id}}"{% endif %}>
 
             {% if params is defined and params and params.type == "warn" or params.type == "warn-branded" %}
                 <span class="ons-panel__icon" aria-hidden="true">!</span>
@@ -59,16 +59,15 @@
                     {% endif %}
                     {% set titleTag = params.titleTag | default(defaultTitleTag) %}
                     <div class="ons-panel__header">
-                        <{{ titleTag }} id="error-summary-title" {% if params is defined and params and params.type is defined and params.type %}data-qa="{{ params.type }}-header"{% endif %} class="ons-panel__title ons-u-fs-r--b">{{ params.title | safe }}</{{ titleTag }}>
+                        <{{ titleTag }} id="alert" {% if params is defined and params and params.type is defined and params.type %}data-qa="{{ params.type }}-header"{% endif %} class="ons-panel__title ons-u-fs-r--b">{{ params.title | safe }}</{{ titleTag }}>
                     </div>
                 {% else %}
                     {% if params.type is not defined or params.type == "branded" or params.type == "info" %}
                         <span class="ons-panel__assistive-text ons-u-vh">{{ params.assistiveTextPrefix | default("Important information: ") }}</span>
                     {% else %}
-                        {% if params.type is defined and params.type == "success" %}
-                            <span class="ons-panel__assistive-text ons-u-vh">{{ params.assistiveTextPrefix | default("Completed: ") }}</span>
-                        {% elif params.type is defined and params.type == "error" %}
-                            <span class="ons-panel__assistive-text ons-u-vh">{{ params.assistiveTextPrefix | default("Error: ") }}</span>
+                        {% if params.type is defined and (params.type == "success" or params.type == "error") %}
+                            {% set defaultText = "Completed" if params.type == "success" else "Error" %}
+                            <span id="alert" class="ons-panel__assistive-text ons-u-vh">{{ params.assistiveTextPrefix | default(defaultText ~ ": ") }}</span>
                         {% endif %}
                     {% endif %}
                 {% endif %}

--- a/src/components/panel/_macro.spec.js
+++ b/src/components/panel/_macro.spec.js
@@ -186,50 +186,53 @@ describe('macro: panel', () => {
     });
   });
 
-  describe('mode: error', () => {
+  describe.each([
+    ['error', 'h2'],
+    ['success', 'div'],
+  ])('mode: %s', (panelType, tagEl) => {
     it('has the default id set', () => {
       const $ = cheerio.load(
         renderComponent('panel', {
           ...EXAMPLE_PANEL_BASIC,
-          title: 'Error title',
-          type: 'error',
+          title: 'Title',
+          type: panelType,
         }),
       );
 
-      expect($('#error-summary-title').length).toBe(1);
+      expect($('#alert').length).toBe(1);
     });
 
-    it('has H2 as the default title tag', () => {
+    it('has the correct default title tag', () => {
       const $ = cheerio.load(
         renderComponent('panel', {
           ...EXAMPLE_PANEL_BASIC,
-          title: 'Error title',
-          type: 'error',
+          title: 'Title',
+          type: panelType,
         }),
       );
 
       const titleTag = $('.ons-panel__title')[0].tagName;
-      expect(titleTag).toBe('h2');
+      expect(titleTag).toBe(tagEl);
     });
 
     it('has aria-labelledby attribute set with default value', () => {
       const $ = cheerio.load(
         renderComponent('panel', {
           ...EXAMPLE_PANEL_BASIC,
-          title: 'Error title',
-          type: 'error',
+          title: 'Title',
+          type: panelType,
         }),
       );
 
-      expect($('.ons-panel').attr('aria-labelledby')).toBe('error-summary-title');
+      expect($('.ons-panel').attr('aria-labelledby')).toBe('alert');
     });
 
     it('has the role attribute set to alert', () => {
       const $ = cheerio.load(
         renderComponent('panel', {
           ...EXAMPLE_PANEL_BASIC,
-          title: 'Error title',
-          type: 'error',
+          title: 'Title',
+          type: panelType,
         }),
       );
 
@@ -240,8 +243,8 @@ describe('macro: panel', () => {
       const $ = cheerio.load(
         renderComponent('panel', {
           ...EXAMPLE_PANEL_BASIC,
-          title: 'Error title',
-          type: 'error',
+          title: 'Title',
+          type: panelType,
         }),
       );
 
@@ -252,8 +255,8 @@ describe('macro: panel', () => {
       const $ = cheerio.load(
         renderComponent('panel', {
           ...EXAMPLE_PANEL_BASIC,
-          title: 'Error title',
-          type: 'error',
+          title: 'Title',
+          type: panelType,
         }),
       );
 
@@ -264,8 +267,8 @@ describe('macro: panel', () => {
       const $ = cheerio.load(
         renderComponent('panel', {
           ...EXAMPLE_PANEL_BASIC,
-          title: 'Error title',
-          type: 'error',
+          title: 'Title',
+          type: panelType,
           dsExample: true,
         }),
       );

--- a/src/components/panel/examples/success/index.njk
+++ b/src/components/panel/examples/success/index.njk
@@ -5,6 +5,7 @@
         "type": 'success',
         "id": 'success-id',
         "iconType": 'check',
-        "body": 'Information has been successfully submitted'
+        "body": 'Information has been successfully submitted',
+        "dsExample": isPatternLib
     })
 }}


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2340 

The existing logic would render the `role=alert` and `aria-labelledby` attributes if the panel type is `error`. This has now been extended to include the type `success`. The `success` type does not generally have a `title` property which is used for `aria-labelledby`. In it's absence the logic now uses the visually hidden text i,e, `Completed` to provide context.
