### PR TITLE
Fix: Checkboxes - open other tab order

### DIFF
--- a/src/components/radios/check-radios.js
+++ b/src/components/radios/check-radios.js
@@ -3,12 +3,13 @@ export default class CheckRadios {
     this.radio = radio;
     this.openOther = openOther;
     this.input = this.openOther.querySelector('.ons-input');
+    this.input.tabIndex = -1;
 
     this.setInputBlurAttributes();
     this.input.addEventListener('focus', this.checkRadio.bind(this));
     this.radio.addEventListener('change', this.setInputFocusAttributes.bind(this));
     if (this.radio.type == 'radio') {
-      this.radio.addEventListener('blur', this.setInputBlurAttributes.bind(this));
+      this.input.addEventListener('blur', this.setInputBlurAttributes.bind(this));
     }
   }
 

--- a/src/components/radios/check-radios.js
+++ b/src/components/radios/check-radios.js
@@ -8,6 +8,7 @@ export default class CheckRadios {
     this.setInputBlurAttributes();
     this.input.addEventListener('focus', this.checkRadio.bind(this));
     this.radio.addEventListener('change', this.setInputFocusAttributes.bind(this));
+    this.radio.addEventListener('focus', this.setInputFocusAttributes.bind(this));
     if (this.radio.type == 'radio') {
       this.input.addEventListener('blur', this.setInputBlurAttributes.bind(this));
     }

--- a/src/components/radios/check-radios.js
+++ b/src/components/radios/check-radios.js
@@ -7,7 +7,9 @@ export default class CheckRadios {
     this.setInputBlurAttributes();
     this.input.addEventListener('focus', this.checkRadio.bind(this));
     this.radio.addEventListener('change', this.setInputFocusAttributes.bind(this));
-    this.radio.addEventListener('blur', this.setInputBlurAttributes.bind(this));
+    if (this.radio.type == 'radio') {
+      this.radio.addEventListener('blur', this.setInputBlurAttributes.bind(this));
+    }
   }
 
   checkRadio() {


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2375 

An event to handle tabindex occurs when the checkbox is blurred which caused this issue. The event should only execute when using radios.

