### PR TITLE
Modal - allow GA tracking on events

### DIFF
--- a/src/components/modal/_macro-options.md
+++ b/src/components/modal/_macro-options.md
@@ -1,8 +1,9 @@
-| Name       | Type   | Required | Description                                                                               |
-| ---------- | ------ | -------- | ----------------------------------------------------------------------------------------- |
-| id         | string | true     | The HTML `id` for the modal’s `<dialog>` element. Defaults to “dialog”.                   |
-| classes    | string | false    | Classes to add to the modal’s `<dialog>` element                                          |
-| attributes | object | false    | HTML attributes (for example, data attributes) to apply to the modal’s `<dialog>` element |
-| title      | string | true     | The text for the HTML `<h1>` heading for the modal                                        |
-| body       | string | false    | HTML contents of the body of the modal                                                    |
-| btnText    | string | false    | The text label for the primary button for the modal                                       |
+| Name       | Type    | Required | Description                                                                               |
+| ---------- | ------- | -------- | ----------------------------------------------------------------------------------------- |
+| id         | string  | true     | The HTML `id` for the modal’s `<dialog>` element. Defaults to “dialog”.                   |
+| classes    | string  | false    | Classes to add to the modal’s `<dialog>` element                                          |
+| attributes | object  | false    | HTML attributes (for example, data attributes) to apply to the modal’s `<dialog>` element |
+| title      | string  | true     | The text for the HTML `<h1>` heading for the modal                                        |
+| body       | string  | false    | HTML contents of the body of the modal                                                    |
+| btnText    | string  | false    | The text label for the primary button for the modal                                       |
+| enableGA   | boolean | false    | Adds GA attributes for events on the modal                                                |

--- a/src/components/modal/_macro.njk
+++ b/src/components/modal/_macro.njk
@@ -5,6 +5,7 @@
         role="dialog"
         aria-labelledby="ons-modal-title"
         {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %} {{attribute}}="{{value}}"{% endfor %}{% endif %}
+        {% if params.enableGA == true %}data-enable-ga='true'{% endif %}
     >
         <div class="ons-modal__content">
             <h2 id="ons-modal-title" class="ons-modal__title">

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -11,6 +11,8 @@ export default class Modal {
     this.setGaAttributes = component.getAttribute('data-enable-ga');
     this.lastFocusedEl = null;
     this.dialogCSSSupported = true;
+    this.modalType = this.component.classList.contains('ons-js-timeout-modal') ? 'Timeout' : 'Generic';
+
     this.initialise();
   }
 
@@ -70,7 +72,7 @@ export default class Modal {
           this.component.setAttribute('data-ga-action', 'Modal opened by timed event');
         }
         this.component.setAttribute('data-ga-label', 'Modal opened');
-        this.component.setAttribute('data-ga-category', 'modal');
+        this.component.setAttribute('data-ga-category', `${this.modalType} modal`);
       }
     }
   }
@@ -117,7 +119,7 @@ export default class Modal {
           this.component.setAttribute('data-ga-action', 'Modal closed by timed event');
         }
         this.component.setAttribute('data-ga-label', 'Modal closed');
-        this.component.setAttribute('data-ga-category', 'modal');
+        this.component.setAttribute('data-ga-category', `${this.modalType} modal`);
       }
     }
   }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -29,6 +29,10 @@ export default class Modal {
     if (this.closeButton) {
       this.closeButton.addEventListener('click', this.closeDialog.bind(this));
     }
+
+    if (this.modalType !== 'Timeout') {
+      window.addEventListener('keydown', this.escToClose.bind(this));
+    }
   }
 
   dialogSupported() {
@@ -66,12 +70,11 @@ export default class Modal {
 
       if (this.setGaAttributes) {
         if (event) {
-          this.component.setAttribute('data-ga', 'click');
           this.component.setAttribute('data-ga-action', `Modal opened by ${event.type} event`);
         } else {
           this.component.setAttribute('data-ga-action', 'Modal opened by timed event');
         }
-        this.component.setAttribute('data-ga-label', 'Modal opened');
+        this.component.setAttribute('data-ga-label', `${this.modalType} modal opened`);
         this.component.setAttribute('data-ga-category', `${this.modalType} modal`);
       }
     }
@@ -113,14 +116,19 @@ export default class Modal {
 
       if (this.setGaAttributes) {
         if (event) {
-          this.component.setAttribute('data-ga', 'click');
           this.component.setAttribute('data-ga-action', `Modal closed by ${event.type} event`);
         } else {
           this.component.setAttribute('data-ga-action', 'Modal closed by timed event');
         }
-        this.component.setAttribute('data-ga-label', 'Modal closed');
+        this.component.setAttribute('data-ga-label', `${this.modalType} modal closed`);
         this.component.setAttribute('data-ga-category', `${this.modalType} modal`);
       }
+    }
+  }
+
+  escToClose(event) {
+    if (this.isDialogOpen() && event.keyCode === 27) {
+      this.closeDialog(event);
     }
   }
 }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -8,6 +8,7 @@ export default class Modal {
     this.component = component;
     this.launcher = document.querySelector(`[data-modal-id=${component.id}]`);
     this.closeButton = component.querySelector('.ons-js-modal-btn');
+    this.setGaAttributes = component.getAttribute('data-enable-ga');
     this.lastFocusedEl = null;
     this.dialogCSSSupported = true;
     this.initialise();
@@ -60,6 +61,17 @@ export default class Modal {
       } else {
         this.component.showModal();
       }
+
+      if (this.setGaAttributes) {
+        if (event) {
+          this.component.setAttribute('data-ga', 'click');
+          this.component.setAttribute('data-ga-action', 'Modal opened by click event');
+        } else {
+          this.component.setAttribute('data-ga-action', 'Modal opened by timed event');
+        }
+        this.component.setAttribute('data-ga-label', 'Modal opened');
+        this.component.setAttribute('data-ga-category', 'modal');
+      }
     }
   }
 
@@ -96,6 +108,17 @@ export default class Modal {
 
       this.component.close();
       this.setFocusOnLastFocusedEl(this.lastFocusedEl);
+
+      if (this.setGaAttributes) {
+        if (event) {
+          this.component.setAttribute('data-ga', 'click');
+          this.component.setAttribute('data-ga-action', 'Modal closed by click event');
+        } else {
+          this.component.setAttribute('data-ga-action', 'Modal closed by timed event');
+        }
+        this.component.setAttribute('data-ga-label', 'Modal closed');
+        this.component.setAttribute('data-ga-category', 'modal');
+      }
     }
   }
 }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -65,7 +65,7 @@ export default class Modal {
       if (this.setGaAttributes) {
         if (event) {
           this.component.setAttribute('data-ga', 'click');
-          this.component.setAttribute('data-ga-action', 'Modal opened by click event');
+          this.component.setAttribute('data-ga-action', `Modal opened by ${event.type} event`);
         } else {
           this.component.setAttribute('data-ga-action', 'Modal opened by timed event');
         }
@@ -112,7 +112,7 @@ export default class Modal {
       if (this.setGaAttributes) {
         if (event) {
           this.component.setAttribute('data-ga', 'click');
-          this.component.setAttribute('data-ga-action', 'Modal closed by click event');
+          this.component.setAttribute('data-ga-action', `Modal closed by ${event.type} event`);
         } else {
           this.component.setAttribute('data-ga-action', 'Modal closed by timed event');
         }

--- a/src/components/modal/modal.spec.js
+++ b/src/components/modal/modal.spec.js
@@ -55,5 +55,81 @@ describe('script: modal', () => {
         expect(activeElementId).toBe('launcher');
       });
     });
+
+    describe('when the `esc` key is pressed', () => {
+      beforeEach(async () => {
+        await page.focus('.ons-js-modal-btn');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Escape');
+      });
+
+      it('closes the modal', async () => {
+        const modalIsVisible = await page.$eval('.ons-modal', node => node.classList.contains('ons-u-db'));
+        expect(modalIsVisible).toBe(false);
+      });
+    });
+  });
+
+  describe('when GA tracking is enabled', () => {
+    beforeEach(async () => {
+      const component = renderComponent('modal', { ...EXAMPLE_MODAL, enableGA: true });
+      const template = `
+        <div class="ons-page">
+          <button id="launcher" data-modal-id="dialog">Launcher</button> 
+          ${component}
+        </div>
+    `;
+      await setTestPage('/test', template);
+    });
+
+    describe('when the modal is launched by a click event', () => {
+      beforeEach(async () => {
+        await page.focus('#launcher');
+        await page.keyboard.press('Enter');
+      });
+
+      it('has the correct attributes set on the modal', async () => {
+        const gaLabel = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-label'));
+        const gaAction = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-action'));
+        const gaCategory = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-category'));
+        expect(gaLabel).toBe('Generic modal opened');
+        expect(gaAction).toBe('Modal opened by click event');
+        expect(gaCategory).toBe('Generic modal');
+      });
+    });
+
+    describe('when the modal is closed by a click event', () => {
+      beforeEach(async () => {
+        await page.focus('#launcher');
+        await page.keyboard.press('Enter');
+        await page.click('.ons-js-modal-btn');
+      });
+
+      it('has the correct attributes set on the modal', async () => {
+        const gaLabel = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-label'));
+        const gaAction = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-action'));
+        const gaCategory = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-category'));
+        expect(gaLabel).toBe('Generic modal closed');
+        expect(gaAction).toBe('Modal closed by click event');
+        expect(gaCategory).toBe('Generic modal');
+      });
+    });
+
+    describe('when the modal is closed by `escape` keypress event', () => {
+      beforeEach(async () => {
+        await page.focus('#launcher');
+        await page.keyboard.press('Enter');
+        await page.keyboard.press('Escape');
+      });
+
+      it('has the correct attributes set on the modal', async () => {
+        const gaLabel = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-label'));
+        const gaAction = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-action'));
+        const gaCategory = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-category'));
+        expect(gaLabel).toBe('Generic modal closed');
+        expect(gaAction).toBe('Modal closed by keydown event');
+        expect(gaCategory).toBe('Generic modal');
+      });
+    });
   });
 });

--- a/src/components/timeout-modal/_macro-options.md
+++ b/src/components/timeout-modal/_macro-options.md
@@ -14,3 +14,4 @@
 | secondsTextSingular         | string  | true     | Time unit displayed in countdown timer when the number of seconds remaining equals 1, for example “2 minutes 1 **second**”.                                                   |
 | secondsTextPlural           | string  | true     | Time unit displayed in countdown timer when more than 1 seconds are remaining, for example “1 minute 59 **seconds**”.                                                         |
 | endWithFullStop             | boolean | false    | Set to “true” to end the countdown timer text with full stop                                                                                                                  |
+| enableGA                    | boolean | false    | Adds GA attributes for events on the modal                                                                                                                                    |

--- a/src/components/timeout-modal/_macro.njk
+++ b/src/components/timeout-modal/_macro.njk
@@ -4,6 +4,7 @@
             "title": params.title,
             "btnText": params.btnText,
             "classes": "ons-js-timeout-modal",
+            "enableGA": params.enableGA,
             "attributes": {
                 "data-redirect-url": params.redirectUrl,
                 "data-server-session-expires-at": params.sessionExpiresAt,

--- a/src/components/timeout-modal/examples/timeout-modal/index.njk
+++ b/src/components/timeout-modal/examples/timeout-modal/index.njk
@@ -12,6 +12,5 @@
     "minutesTextPlural": "minutes",
     "secondsTextSingular": "second",
     "secondsTextPlural": "seconds",
-    "endWithFullStop": true,
-    "enableGA": true
+    "endWithFullStop": true
 }) }}

--- a/src/components/timeout-modal/examples/timeout-modal/index.njk
+++ b/src/components/timeout-modal/examples/timeout-modal/index.njk
@@ -1,7 +1,7 @@
 {% from "components/timeout-modal/_macro.njk" import onsTimeoutModal %}
 
 {{ onsTimeoutModal({
-    "showModalTimeInSeconds": 300,
+    "showModalTimeInSeconds": 55,
     "redirectUrl": "#!",
     "title": "You will be signed out soon",
     "textFirstLine": "It appears you have been inactive for a while.",
@@ -12,5 +12,6 @@
     "minutesTextPlural": "minutes",
     "secondsTextSingular": "second",
     "secondsTextPlural": "seconds",
-    "endWithFullStop": true
+    "endWithFullStop": true,
+    "enableGA": true
 }) }}

--- a/src/components/timeout-modal/examples/timeout-modal/index.njk
+++ b/src/components/timeout-modal/examples/timeout-modal/index.njk
@@ -1,7 +1,7 @@
 {% from "components/timeout-modal/_macro.njk" import onsTimeoutModal %}
 
 {{ onsTimeoutModal({
-    "showModalTimeInSeconds": 55,
+    "showModalTimeInSeconds": 58,
     "redirectUrl": "#!",
     "title": "You will be signed out soon",
     "textFirstLine": "It appears you have been inactive for a while.",

--- a/src/components/timeout-modal/index.njk
+++ b/src/components/timeout-modal/index.njk
@@ -96,6 +96,19 @@ The WCAG  guidelines state:
 | Hidden interval timer  | `role="status"`                             | To make sure the hidden interval timer is read out for iOS                                            |
 | Hidden interval timer  | `aria-live="polite"`                        | To make sure the hidden interval timer does not interrupt other content being read out                |
 
+## Google analytics
+Optionally pass event tracking `data` attributes for Google Analytics by providing `enableGA: true`. Data attributes will be dynamically set for the following events:
+
+- When the modal opens via timed or click event
+- When the modal is closed via timed or click event
+- When the modal is closed via `Escape` keypress
+
+The following attributes will be set 
+
+- `data-ga-category="{modalType} modal"`
+- `data-ga-action="Modal {action} by {eventType}"`
+- `data-ga-label="{modalType} modal {action}"`
+
 ## Help improve this pattern
 Let us know how we could improve this pattern or share your user research findings.
 {{

--- a/src/components/timeout-modal/timeout-modal.js
+++ b/src/components/timeout-modal/timeout-modal.js
@@ -73,7 +73,7 @@ export default class TimeoutModal {
       time = false;
     }
     if (this.modal.isDialogOpen()) {
-      this.modal.closeDialog();
+      this.modal.closeDialog(event);
     }
     await this.timeout.restartTimeout(time);
     this.startTimeout();

--- a/src/components/timeout-modal/timeout-modal.spec.js
+++ b/src/components/timeout-modal/timeout-modal.spec.js
@@ -223,4 +223,72 @@ describe('script: timeout modal', () => {
       });
     });
   });
+
+  describe('when GA tracking is enabled', () => {
+    beforeEach(async () => {
+      const component = renderComponent('timeout-modal', {
+        ...EXAMPLE_TIMEOUT_MODAL_BASIC,
+        showModalTimeInSeconds: 59,
+        enableGA: true,
+      });
+
+      const template = `
+          <div class="ons-page">
+            ${component}
+          </div>
+        `;
+
+      await setTestPage('/test', template);
+    });
+
+    describe('when the modal is open', () => {
+      beforeEach(async () => {
+        await page.waitForSelector('.ons-modal');
+        await page.waitForTimeout(1000);
+      });
+
+      it('has the correct attributes set on the modal', async () => {
+        const gaLabel = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-label'));
+        const gaAction = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-action'));
+        const gaCategory = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-category'));
+        expect(gaLabel).toBe('Timeout modal opened');
+        expect(gaAction).toBe('Modal opened by timed event');
+        expect(gaCategory).toBe('Timeout modal');
+      });
+    });
+
+    describe('when the modal is closed by a click event', () => {
+      beforeEach(async () => {
+        await page.waitForSelector('.ons-modal');
+        await page.waitForTimeout(1000);
+        await page.click('.ons-js-modal-btn');
+      });
+
+      it('has the correct attributes set on the modal', async () => {
+        const gaLabel = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-label'));
+        const gaAction = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-action'));
+        const gaCategory = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-category'));
+        expect(gaLabel).toBe('Timeout modal closed');
+        expect(gaAction).toBe('Modal closed by click event');
+        expect(gaCategory).toBe('Timeout modal');
+      });
+    });
+
+    describe('when the modal is closed by `escape` keypress event', () => {
+      beforeEach(async () => {
+        await page.waitForSelector('.ons-modal');
+        await page.waitForTimeout(1000);
+        await page.keyboard.press('Escape');
+      });
+
+      it('has the correct attributes set on the modal', async () => {
+        const gaLabel = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-label'));
+        const gaAction = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-action'));
+        const gaCategory = await page.$eval('.ons-modal', node => node.getAttribute('data-ga-category'));
+        expect(gaLabel).toBe('Timeout modal closed');
+        expect(gaAction).toBe('Modal closed by keydown event');
+        expect(gaCategory).toBe('Timeout modal');
+      });
+    });
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
Resolves #2403 

Adds the following GA tracking attributes when the parameter `enableGA: true` is provided:

- `data-ga-action:  Modal closed/opened by _event.type_ event`
- `data-ga-label: _modalType_ modal closed/open`
- `data-ga-category:  _modalType_ modal`

These attributes are set under the following scenarios:

- When the modal opens via timed or click event
- When the modal is closed via timed or click event
- When the modal is closed via escape keypress


### How to review
Add the parameter `enableGA: true` to the timeout modal example and test the attributes are set as per the spec.
The tests cover the scenarios.