### PR TITLE
Fix summary spacing bug

### DIFF
--- a/src/components/section-navigation/examples/section-navigation-vertical/index.njk
+++ b/src/components/section-navigation/examples/section-navigation-vertical/index.njk
@@ -8,7 +8,6 @@
             {
                 "title": "Section 1",
                 "url": "#section-1"
-
             },
             {
                 "title": "Section 2",
@@ -17,11 +16,11 @@
                     {
                         "title": "Sub section 1",
                         "url": "#sub-section-1"
-                    },                    
+                    },
                     {
                         "title": "Sub section 2",
                         "url": "#sub-section-2"
-                    },                    
+                    },
                     {
                         "title": "Sub section 3",
                         "url": "#sub-section-3"

--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -51,10 +51,10 @@ $hub-row-spacing: 1.3rem;
   &__row-title {
     padding: $summary-row-spacing 0;
     text-align: left;
-
-    &--no-group-title {
-      padding-top: 0;
-    }
+  }
+  // reduces the gap between row title and summary title when there is no group title
+  &__title + &__group &__row-title--no-group-title {
+    padding-top: 0.5rem;
   }
 
   &__item-title,

--- a/src/foundations/layout/page-template/examples/base-page-template-block-areas/index.njk
+++ b/src/foundations/layout/page-template/examples/base-page-template-block-areas/index.njk
@@ -116,7 +116,6 @@ layout: example
                                 {
                                     "title": "Access codes",
                                     "url": "#0"
-
                                 },
                                 {
                                     "title": "Addresses",


### PR DESCRIPTION
### What is the context of this PR?
![Screenshot 2022-09-21 at 13 58 31](https://user-images.githubusercontent.com/42928680/191510318-37df0377-e7d0-44f2-a48f-313fe3a733ad.png)
A recent change to the spacing in summaries with row titles but no group titles has introduced this bug if the row title isn't on the first row. This PR will fix this. This will reduce the space to 2rem in all instances which matches other spaces in summaries 

Also removes some spaces left over in some of the code

### How to review
- Tests pass
- Changes make sense
- Summaries still work as expected, there should be no change to any of the DS examples

Describe the steps required to test the changes (include screenshots if appropriate).
