### PR TITLE
Fix: Checkboxes and radios with other inner fieldset

### DIFF
--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -67,7 +67,7 @@ describe('script: accordion', () => {
       }),
     );
 
-    const ariaExpanded = await page.$eval('button[data-test-trigger]', element => element.getAttribute('aria-expanded'));
+    const ariaExpanded = await page.$eval('button[data-test-trigger]', element => element.ribute('aria-expanded'));
     expect(ariaExpanded).toBe('true');
   });
 

--- a/src/components/accordion/accordion.spec.js
+++ b/src/components/accordion/accordion.spec.js
@@ -67,7 +67,7 @@ describe('script: accordion', () => {
       }),
     );
 
-    const ariaExpanded = await page.$eval('button[data-test-trigger]', element => element.ribute('aria-expanded'));
+    const ariaExpanded = await page.$eval('button[data-test-trigger]', element => element.getAttribute('aria-expanded'));
     expect(ariaExpanded).toBe('true');
   });
 

--- a/src/components/checkboxes/_checkbox-macro.njk
+++ b/src/components/checkboxes/_checkbox-macro.njk
@@ -76,7 +76,7 @@
                             "legend": params.other.legend,
                             "legendClasses": params.other.legendClasses,
                             "attributes": params.other.attributes,
-                            "classes": "ons-js-other-fieldset",
+                            "classes": "ons-js-other-fieldset-checkbox",
                             "checkboxes": params.other.checkboxes,
                             "autoSelect": params.other.autoSelect
                         })
@@ -91,7 +91,7 @@
                             "legend": params.other.legend,
                             "legendClasses": params.other.legendClasses,
                             "attributes": params.other.attributes,
-                            "classes": "ons-js-other-fieldset",
+                            "classes": "ons-js-other-fieldset-checkbox",
                             "radios": params.other.radios
                         })
                     }}

--- a/src/components/checkboxes/_checkbox-macro.spec.js
+++ b/src/components/checkboxes/_checkbox-macro.spec.js
@@ -390,7 +390,7 @@ describe('macro: checkboxes/checkbox', () => {
       legend: 'Select preferred times of day',
       legendClasses: 'extra-legend-class',
       attributes: { a: 42 },
-      classes: 'ons-js-other-fieldset',
+      classes: 'ons-js-other-fieldset-checkbox',
       checkboxes: EXAMPLE_CHECKBOXES_ITEM_CHECKBOXES.other.checkboxes,
       autoSelect: EXAMPLE_CHECKBOXES_ITEM_CHECKBOXES.other.autoSelect,
     });
@@ -412,7 +412,7 @@ describe('macro: checkboxes/checkbox', () => {
       legend: 'Select preferred times of day',
       legendClasses: 'extra-legend-class',
       attributes: { a: 42 },
-      classes: 'ons-js-other-fieldset',
+      classes: 'ons-js-other-fieldset-checkbox',
       radios: EXAMPLE_CHECKBOXES_ITEM_RADIOS.other.radios,
     });
   });

--- a/src/components/checkboxes/checkboxes.dom.js
+++ b/src/components/checkboxes/checkboxes.dom.js
@@ -15,12 +15,12 @@ domready(async () => {
       new CheckCheckbox(checkboxInput, openOther);
     }
 
-    const otherFieldsets = [...document.querySelectorAll('.ons-js-other-fieldset')];
+    const otherFieldsets = [...document.querySelectorAll('.ons-js-other-fieldset-checkbox')];
     if (otherFieldsets) {
       const CheckboxWithInnerFieldset = (await import('./checkbox-with-fieldset')).default;
-
       otherFieldsets.forEach(otherFieldset => {
-        new CheckboxWithInnerFieldset(otherFieldset, checkboxes);
+        const context = otherFieldset.closest('.ons-checkbox');
+        new CheckboxWithInnerFieldset(context);
       });
     }
 

--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -94,7 +94,7 @@
                                             "legend": radio.other.legend,
                                             "legendClasses": radio.other.legendClasses,
                                             "attributes": radio.other.attributes,
-                                            "classes": "ons-js-other-fieldset",
+                                            "classes": "ons-js-other-fieldset-radio",
                                             "checkboxes": radio.other.checkboxes,
                                             "autoSelect": radio.other.autoSelect,
                                             "selectAllChildren": radio.other.selectAllChildren
@@ -110,7 +110,7 @@
                                             "legend": radio.other.legend,
                                             "legendClasses": radio.other.legendClasses | default('') + ' ons-u-mb-xs',
                                             "attributes": radio.other.attributes,
-                                            "classes": "ons-js-other-fieldset",
+                                            "classes": "ons-js-other-fieldset-radio",
                                             "radios": radio.other.radios
                                         })
                                     }}

--- a/src/components/radios/_macro.spec.js
+++ b/src/components/radios/_macro.spec.js
@@ -512,7 +512,7 @@ describe('macro: radios', () => {
         legend: 'Select preferred times of day',
         legendClasses: 'extra-legend-class',
         attributes: { a: 42 },
-        classes: 'ons-js-other-fieldset',
+        classes: 'ons-js-other-fieldset-radio',
         checkboxes: EXAMPLE_RADIO_ITEM_CHECKBOXES.other.checkboxes,
         autoSelect: EXAMPLE_RADIO_ITEM_CHECKBOXES.other.autoSelect,
         selectAllChildren: true,
@@ -535,7 +535,7 @@ describe('macro: radios', () => {
         legend: 'Select preferred times of day',
         legendClasses: 'extra-legend-class ons-u-mb-xs',
         attributes: { a: 42 },
-        classes: 'ons-js-other-fieldset',
+        classes: 'ons-js-other-fieldset-radio',
         radios: EXAMPLE_RADIO_ITEM_RADIOS.other.radios,
       });
     });

--- a/src/components/radios/radio-with-fieldset.js
+++ b/src/components/radios/radio-with-fieldset.js
@@ -1,14 +1,14 @@
-export default class CheckboxWithFieldset {
+export default class RadioWithFieldset {
   constructor(context) {
     this.context = context;
-    this.checkbox = context.querySelector('.ons-js-checkbox');
+    this.radios = [...context.closest('.ons-radios__items').querySelectorAll('.ons-js-radio')];
     this.childInputs = [...this.context.querySelectorAll('input')];
     this.selectAllChildrenInput = this.context.querySelector('.ons-js-select-all-children');
 
     if (this.selectAllChildrenInput) {
       this.selectAllChildrenInput.addEventListener('change', this.checkChildInputsOnSelect.bind(this));
     } else {
-      this.checkbox.addEventListener('change', this.uncheckChildInputsOnDeselect.bind(this));
+      this.radios.forEach(radio => radio.addEventListener('change', this.uncheckChildInputsOnDeselect.bind(this)));
     }
   }
 
@@ -19,7 +19,8 @@ export default class CheckboxWithFieldset {
   }
 
   uncheckChildInputsOnDeselect() {
-    if (this.checkbox.checked === false) {
+    const isOther = this.radios.find(radio => radio.classList.contains('ons-js-other'));
+    if (isOther && isOther.checked === false) {
       this.childInputs.forEach(input => {
         input.checked = false;
       });

--- a/src/components/radios/radios.dom.js
+++ b/src/components/radios/radios.dom.js
@@ -25,14 +25,13 @@ domready(async () => {
       new CheckRadios(radioInput, openOther);
     }
 
-    const other = document.querySelector('.ons-js-other');
-    if (other) {
-      const otherFieldset = other.parentNode.querySelector('.ons-js-other-fieldset');
-      if (otherFieldset) {
-        const CheckboxWithInnerFieldset = (await import('../checkboxes/checkbox-with-fieldset')).default;
-
-        new CheckboxWithInnerFieldset(otherFieldset, radios);
-      }
+    const otherFieldsets = [...document.querySelectorAll('.ons-js-other-fieldset-radio')];
+    if (otherFieldsets) {
+      const RadioWithInnerFieldset = (await import('./radio-with-fieldset')).default;
+      otherFieldsets.forEach(otherFieldset => {
+        const context = otherFieldset.closest('.ons-radio');
+        new RadioWithInnerFieldset(context);
+      });
     }
   }
 });

--- a/src/components/radios/radios.spec.js
+++ b/src/components/radios/radios.spec.js
@@ -58,123 +58,231 @@ const EXAMPLE_RADIOS_PARAMS = {
 };
 
 describe('script: radios', () => {
-  beforeEach(async () => {
-    await setTestPage('/test', renderComponent('radios', EXAMPLE_RADIOS_PARAMS));
-  });
-
-  it('radios with other options should be given aria-expanded attributes', async () => {
-    const ariaExpandedOption1 = await page.$eval('#email', node => node.getAttribute('aria-expanded'));
-    expect(ariaExpandedOption1).toBe('false');
-    const ariaExpandedOption2 = await page.$eval('#phone', node => node.getAttribute('aria-expanded'));
-    expect(ariaExpandedOption2).toBe('false');
-  });
-
-  it('radios with "open" other options should not be given aria-expanded attributes', async () => {
-    const hasAriaExpandedOption3 = await page.$eval('#text', node => node.hasAttribute('aria-expanded'));
-    expect(hasAriaExpandedOption3).toBe(false);
-  });
-
-  describe('a radio checked', () => {
+  describe('other options', () => {
     beforeEach(async () => {
-      await page.click('#email');
+      await setTestPage('/test', renderComponent('radios', EXAMPLE_RADIOS_PARAMS));
     });
 
-    it('then the checked radio aria-expanded attribute should be set to true', async () => {
+    it('radios with other options should be given aria-expanded attributes', async () => {
       const ariaExpandedOption1 = await page.$eval('#email', node => node.getAttribute('aria-expanded'));
-      expect(ariaExpandedOption1).toBe('true');
-    });
-
-    it('then the unchecked radio aria-expanded attribute should be set to false', async () => {
+      expect(ariaExpandedOption1).toBe('false');
       const ariaExpandedOption2 = await page.$eval('#phone', node => node.getAttribute('aria-expanded'));
       expect(ariaExpandedOption2).toBe('false');
     });
 
-    it('then the unchecked radio aria-expanded attribute of "open" radio should not be set', async () => {
-      const hasAriaExpanded = await page.$eval('#text', node => node.hasAttribute('aria-expanded'));
-      expect(hasAriaExpanded).toBe(false);
+    it('radios with "open" other options should not be given aria-expanded attributes', async () => {
+      const hasAriaExpandedOption3 = await page.$eval('#text', node => node.hasAttribute('aria-expanded'));
+      expect(hasAriaExpandedOption3).toBe(false);
     });
 
-    it('then the clear button should be visible', async () => {
-      const isHidden = await page.$eval('.ons-js-clear-btn', node => node.classList.contains('ons-u-db-no-js_enabled'));
-      expect(isHidden).toBe(false);
-    });
-
-    it('then the aria live message should announce that the answer can be cleared', async () => {
-      const alertText = await page.$eval('.ons-js-clear-radio-alert', node => node.innerHTML);
-      expect(alertText).toBe('You can clear your answer by clicking the clear selection button under the radio buttons');
-    });
-
-    describe('and the radio selection is changed', () => {
+    describe('a radio checked', () => {
       beforeEach(async () => {
-        await page.click('#phone');
+        await page.click('#email');
       });
 
       it('then the checked radio aria-expanded attribute should be set to true', async () => {
-        const ariaExpandedOption2 = await page.$eval('#phone', node => node.getAttribute('aria-expanded'));
-        expect(ariaExpandedOption2).toBe('true');
+        const ariaExpandedOption1 = await page.$eval('#email', node => node.getAttribute('aria-expanded'));
+        expect(ariaExpandedOption1).toBe('true');
       });
 
       it('then the unchecked radio aria-expanded attribute should be set to false', async () => {
-        const ariaExpandedOption1 = await page.$eval('#email', node => node.getAttribute('aria-expanded'));
-        expect(ariaExpandedOption1).toBe('false');
+        const ariaExpandedOption2 = await page.$eval('#phone', node => node.getAttribute('aria-expanded'));
+        expect(ariaExpandedOption2).toBe('false');
       });
 
       it('then the unchecked radio aria-expanded attribute of "open" radio should not be set', async () => {
         const hasAriaExpanded = await page.$eval('#text', node => node.hasAttribute('aria-expanded'));
         expect(hasAriaExpanded).toBe(false);
       });
+
+      it('then the clear button should be visible', async () => {
+        const isHidden = await page.$eval('.ons-js-clear-btn', node => node.classList.contains('ons-u-db-no-js_enabled'));
+        expect(isHidden).toBe(false);
+      });
+
+      it('then the aria live message should announce that the answer can be cleared', async () => {
+        const alertText = await page.$eval('.ons-js-clear-radio-alert', node => node.innerHTML);
+        expect(alertText).toBe('You can clear your answer by clicking the clear selection button under the radio buttons');
+      });
+
+      describe('and the radio selection is changed', () => {
+        beforeEach(async () => {
+          await page.click('#phone');
+        });
+
+        it('then the checked radio aria-expanded attribute should be set to true', async () => {
+          const ariaExpandedOption2 = await page.$eval('#phone', node => node.getAttribute('aria-expanded'));
+          expect(ariaExpandedOption2).toBe('true');
+        });
+
+        it('then the unchecked radio aria-expanded attribute should be set to false', async () => {
+          const ariaExpandedOption1 = await page.$eval('#email', node => node.getAttribute('aria-expanded'));
+          expect(ariaExpandedOption1).toBe('false');
+        });
+
+        it('then the unchecked radio aria-expanded attribute of "open" radio should not be set', async () => {
+          const hasAriaExpanded = await page.$eval('#text', node => node.hasAttribute('aria-expanded'));
+          expect(hasAriaExpanded).toBe(false);
+        });
+      });
+    });
+
+    describe('the clear button is clicked', () => {
+      beforeEach(async () => {
+        await page.$eval('.ons-js-clear-btn', node => node.click());
+      });
+
+      it('then the clear button should not be visible', async () => {
+        const isHidden = await page.$eval('.ons-js-clear-btn', node => node.classList.contains('ons-u-db-no-js_enabled'));
+        expect(isHidden).toBe(true);
+      });
+
+      it('then the aria live message should announce that the answer has been cleared', async () => {
+        const alertText = await page.$eval('.ons-js-clear-radio-alert', node => node.innerHTML);
+        expect(alertText).toBe('You have cleared your answer');
+      });
+
+      it('then all radios should not be checked', async () => {
+        const checkedRadios = await page.$$eval('.ons-js-radio', nodes => nodes.map(node => node.checked));
+        expect(checkedRadios).not.toContain(true);
+      });
+
+      it('then all other input fields should be empty', async () => {
+        const emailOtherValue = await page.$eval('#email-other', node => node.value);
+        expect(emailOtherValue).toBe('');
+        const telOtherValue = await page.$eval('#tel-other', node => node.value);
+        expect(telOtherValue).toBe('');
+        const textOtherValue = await page.$eval('#text-other', node => node.value);
+        expect(textOtherValue).toBe('');
+      });
+    });
+
+    describe('there is a visible input which is focused', () => {
+      beforeEach(async () => {
+        await page.focus('#text-other');
+      });
+
+      it('then the radio button should be checked', async () => {
+        const isRadioChecked = await page.$eval('#text', node => node.checked);
+        expect(isRadioChecked).toBe(true);
+      });
+    });
+
+    describe('there is a visible input and the radio is checked', () => {
+      beforeEach(async () => {
+        await page.click('#text');
+      });
+
+      it('then the input should have a tab index of 0', async () => {
+        const tabIndex = await page.$eval('#text-other', node => node.getAttribute('tabindex'));
+        expect(tabIndex).toBe('0');
+      });
     });
   });
 
-  describe('the clear button is clicked', () => {
+  describe('reveal and fieldset', function() {
+    const params = {
+      legend: 'What are your favourite pizza toppings?',
+      name: 'food-other',
+      radios: [
+        {
+          id: 'bacon-other',
+          label: {
+            text: 'Bacon',
+          },
+          value: 'bacon',
+        },
+        {
+          id: 'olives-other',
+          label: {
+            text: 'Olives',
+          },
+          value: 'olives',
+        },
+        {
+          id: 'other-radio',
+          label: {
+            text: 'Other',
+            description: 'An answer is required',
+          },
+          value: 'other',
+          other: {
+            id: 'other-textbox',
+            name: 'other-answer',
+            legend: 'Please specify other',
+            otherType: 'checkboxes',
+            checkboxes: [
+              {
+                id: 'inner-bacon-other',
+                label: {
+                  text: 'Bacon',
+                },
+                value: 'bacon',
+              },
+              {
+                id: 'inner-olives-other',
+                label: {
+                  text: 'Olives',
+                },
+                value: 'olives',
+              },
+            ],
+          },
+        },
+      ],
+    };
+
     beforeEach(async () => {
-      await page.$eval('.ons-js-clear-btn', node => node.click());
+      await setTestPage('/test', renderComponent('radios', params));
     });
 
-    it('then the clear button should not be visible', async () => {
-      const isHidden = await page.$eval('.ons-js-clear-btn', node => node.classList.contains('ons-u-db-no-js_enabled'));
-      expect(isHidden).toBe(true);
+    it('radios with other options should be given aria-expanded attributes', async () => {
+      const ariaExpanded = await page.$eval('#other-radio', node => node.getAttribute('aria-expanded'));
+      expect(ariaExpanded).toBe('false');
     });
 
-    it('then the aria live message should announce that the answer has been cleared', async () => {
-      const alertText = await page.$eval('.ons-js-clear-radio-alert', node => node.innerHTML);
-      expect(alertText).toBe('You have cleared your answer');
-    });
+    describe('and a radio with an other input is checked', () => {
+      beforeEach(async () => {
+        await page.click('#other-radio');
+      });
 
-    it('then all radios should not be checked', async () => {
-      const checkedRadios = await page.$$eval('.ons-js-radio', nodes => nodes.map(node => node.checked));
-      expect(checkedRadios).not.toContain(true);
-    });
+      it('has aria-expanded attribute should be set to true', async () => {
+        const ariaExpanded = await page.$eval('#other-radio', node => node.getAttribute('aria-expanded'));
+        expect(ariaExpanded).toBe('true');
+      });
 
-    it('then all other input fields should be empty', async () => {
-      const emailOtherValue = await page.$eval('#email-other', node => node.value);
-      expect(emailOtherValue).toBe('');
-      const telOtherValue = await page.$eval('#tel-other', node => node.value);
-      expect(telOtherValue).toBe('');
-      const textOtherValue = await page.$eval('#text-other', node => node.value);
-      expect(textOtherValue).toBe('');
-    });
-  });
+      describe('and any other radio is changed', () => {
+        beforeEach(async () => {
+          await page.click('#bacon-other');
+        });
 
-  describe('there is a visible input which is focused', () => {
-    beforeEach(async () => {
-      await page.focus('#text-other');
-    });
+        it('the radio with an other input aria-expanded attribute changes', async () => {
+          const ariaExpanded = await page.$eval('#other-radio', node => node.getAttribute('aria-expanded'));
+          expect(ariaExpanded).toBe('false');
+        });
+      });
 
-    it('then the radio button should be checked', async () => {
-      const isRadioChecked = await page.$eval('#text', node => node.checked);
-      expect(isRadioChecked).toBe(true);
-    });
-  });
+      describe('and a child of other radio is checked', () => {
+        beforeEach(async () => {
+          await page.click('#inner-bacon-other');
+        });
 
-  describe('there is a visible input and the radio is checked', () => {
-    beforeEach(async () => {
-      await page.click('#text');
-    });
+        describe('and another radio is checked', () => {
+          beforeEach(async () => {
+            await page.click('#olives-other');
+          });
 
-    it('then the input should have a tab index of 0', async () => {
-      const tabIndex = await page.$eval('#text-other', node => node.getAttribute('tabindex'));
-      expect(tabIndex).toBe('0');
+          it('the other radio aria-expanded attribute should be set to false', async () => {
+            const ariaExpanded = await page.$eval('#other-radio', node => node.getAttribute('aria-expanded'));
+            expect(ariaExpanded).toBe('false');
+          });
+
+          it('the child of other checkbox should be unchecked', async () => {
+            const innerInputChecked = await page.$eval('#inner-bacon-other', node => node.checked);
+            expect(innerInputChecked).toBe(false);
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
Issue observed with the checkboxes/radios script for implementations that used the nested "other" fieldset containing radios/checkboxes.

The `change` event for radios does not provide `false` (only `true`). This caused problems with deselecting child (inner fieldset) radios and checkboxes.

The component has the following implementation options:

- Checkboxes with nested checkboxes or radios
- Checkboxes with nested checkboxes that can pre select child checkboxes
- Radios with nested checkboxes or radios
- Radios with nested checkboxes that can pre select child checkboxes

These were handled by a single script for both checkboxes and radios. This PR separates the concerns by creating a seperate script for checkboxes and radios. 


### How to review
- Test the scenarios above and importantly that child radios/checkboxes are unchecked when the parent radio/checkbox is unchecked
