### PR TITLE
Expose site search in page template currently as a non-documented feature to support service manual development.

### DIFF
--- a/src/components/navigation/_macro.njk
+++ b/src/components/navigation/_macro.njk
@@ -3,7 +3,7 @@
     {% from "components/autosuggest/_macro.njk" import onsAutosuggest %}
     <div class="ons-navigation-wrapper{% if params.variants == 'neutral' %} ons-navigation-wrapper--neutral{% endif %}">
         <div class="ons-container ons-container--gutterless@xxs@l{{ ' ons-container--full-width' if params.fullWidth or params.navigation.fullWidth }}{{ ' ons-container--wide' if params.wide or params.navigation.wide }}">
-            {% if params.navigation.siteSearchAutosuggest and isPatternLib %}
+            {% if params.navigation.siteSearchAutosuggest %}
                 <div class="ons-navigation-search ons-js-navigation-search">
                     {% set autosuggestClasses = "ons-input-search ons-input-search--icon" %}
                     {% set autosuggestLabelClasses = "ons-u-pl-m" %}


### PR DESCRIPTION
The `isPatternLib` parameter currently does two things:
- Enables site search in the page template.
- Includes .js and .css files for the patternlib.

This is good for the current design system website but it is too much for the service manual.