### PR TITLE
Remove check for `IntersectionObserver` support since the `table-of-contents` component no longer uses this.

### DIFF
--- a/src/components/table-of-contents/toc.dom.js
+++ b/src/components/table-of-contents/toc.dom.js
@@ -4,11 +4,9 @@ async function toc() {
   const toc = [...document.querySelectorAll('.ons-js-toc-container')];
 
   if (toc.length) {
-    if ('IntersectionObserver' in window) {
-      const Toc = (await import('./toc')).default;
+    const Toc = (await import('./toc')).default;
 
-      toc.forEach(component => new Toc(component));
-    }
+    toc.forEach(component => new Toc(component));
   }
 }
 


### PR DESCRIPTION
### What is the context of this PR?
Resolves #2465

### How to review
- Verify that tests pass.
- Verify that table of contents component still works in DS examples.
