### PR TITLE
Make sub-navigation of navigation component check for `params.wide` in addition to `params.navigation.wide` for consistency with primary navigation.

### DIFF
--- a/src/components/navigation/_macro.njk
+++ b/src/components/navigation/_macro.njk
@@ -51,7 +51,7 @@
     </div>
     {% if params.navigation.subNavigation %}
         <nav class="ons-navigation ons-navigation--sub ons-u-d-no@xxs@l{{ ' ' + params.navigation.subNavigation.classes if params.navigation.subNavigation.classes }}" id="{{ params.navigation.subNavigation.id }}" aria-label="{{ params.navigation.subNavigation.ariaLabel | default("Section menu") }}" data-analytics="header-section-navigation">
-            <div class="ons-container ons-container--gutterless@xxs@l{{ ' ons-container--full-width' if params.navigation.fullWidth }}{{ ' ons-container--wide' if params.navigation.wide }}">
+            <div class="ons-container ons-container--gutterless@xxs@l{{ ' ons-container--full-width' if params.navigation.fullWidth }}{{ ' ons-container--wide' if params.wide or params.navigation.wide }}">
                 <ul class="ons-navigation__list ons-navigation__list">
                     {% for item in (params.navigation.subNavigation.itemsList if params.navigation.subNavigation.itemsList is iterable else params.navigation.subNavigation.itemsList.items()) %}
                         <li class="ons-navigation__item {{ item.classes }}{{ ' ons-navigation__item--active' if (item.url == params.navigation.currentPath) or (params.navigation.currentPath is not string and item.url in params.navigation.currentPath) }}">

--- a/src/components/navigation/_macro.spec.js
+++ b/src/components/navigation/_macro.spec.js
@@ -102,10 +102,16 @@ describe('macro: navigation', () => {
       expect($('.ons-container').hasClass('ons-container--full-width')).toBe(true);
     });
 
-    it('has the correct container if `wide`', () => {
+    it('has the correct container if `params.wide` is provided', () => {
+      const $ = cheerio.load(renderComponent('navigation', { wide: true, navigation: PARAMS }));
+
+      expect($('.ons-navigation-wrapper .ons-container').hasClass('ons-container--wide')).toBe(true);
+    });
+
+    it('has the correct container if `params.navigation.wide` is provided', () => {
       const $ = cheerio.load(renderComponent('navigation', { navigation: { ...PARAMS, wide: true } }));
 
-      expect($('.ons-container').hasClass('ons-container--wide')).toBe(true);
+      expect($('.ons-navigation-wrapper .ons-container').hasClass('ons-container--wide')).toBe(true);
     });
 
     it('has the search autosuggest with correct output', () => {
@@ -216,6 +222,18 @@ describe('macro: navigation', () => {
           'aria-expanded': 'false',
         },
       });
+    });
+
+    it('has the correct container if `params.wide` is provided', () => {
+      const $ = cheerio.load(renderComponent('navigation', { wide: true, navigation: PARAMS }));
+
+      expect($('.ons-navigation--sub .ons-container').hasClass('ons-container--wide')).toBe(true);
+    });
+
+    it('has the correct container if `params.navigation.wide` is provided', () => {
+      const $ = cheerio.load(renderComponent('navigation', { navigation: { ...PARAMS, wide: true } }));
+
+      expect($('.ons-navigation--sub .ons-container').hasClass('ons-container--wide')).toBe(true);
     });
 
     it('has the provided `id` attribute', () => {


### PR DESCRIPTION
### What is the context of this PR?
Resolves #2421

### How to review
- Verify that tests pass
- Verify that navigation looks correct when `wide` is specified as `true` using `pageConfig`.