### PR TITLE
Fix: CSS variables - invalid uses of css variables

### DIFF
--- a/src/components/autosuggest/_autosuggest.scss
+++ b/src/components/autosuggest/_autosuggest.scss
@@ -128,7 +128,7 @@
   &--header {
     .ons-autosuggest-input__results {
       border: none;
-      box-shadow: 0 0 5px 0 rgba(var(--ons-color-black), 0.6);
+      box-shadow: 0 0 5px 0 rgba(34, 34, 34, 0.6);
       left: 0;
       position: absolute;
       z-index: 10;

--- a/src/components/download-resources/_download-resources.scss
+++ b/src/components/download-resources/_download-resources.scss
@@ -64,7 +64,7 @@
   &__actions {
     background-color: var(--ons-color-white);
     bottom: 0;
-    box-shadow: 0 0 5px 0 rgba(var(--ons-color-black), 0.5), 0 -1px 0 0 rgba(var(--ons-color-grey-100), 0.5);
+    box-shadow: 0 0 5px 0 rgba(34, 34, 34, 0.5), 0 -1px 0 0 rgba(65, 64, 66, 0.5);
     display: flex;
     left: 0;
     padding: 1rem;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -116,7 +116,7 @@
 }
 
 .ons-tabs--details {
-  border-top: 1px solid --ons-color-borders;
+  border-top: 1px solid var(--ons-color-borders);
   margin: 0;
 
   .ons-tab {

--- a/src/pages/guidance/installing-the-design-system/using-css-js-and-assets/index.njk
+++ b/src/pages/guidance/installing-the-design-system/using-css-js-and-assets/index.njk
@@ -77,7 +77,7 @@ The example below shows what custom properties are overidden to create the Censu
   --ons-color-branded-secondary: #df0667;
   --ons-color-branded-tertiary: #3c388e;
   --ons-color-branded-supporting: #00a3a6;
-  --ons-color-branded-supporting-tint: rgba(#00a3a6, 0.2);
+  --ons-color-branded-supporting-tint: rgba(0, 163, 166, 0.2);
 
   // Assignment
   --ons-color-tag-bg: var(--ons-color-branded-supporting-tint);

--- a/src/scss/settings/_census.scss
+++ b/src/scss/settings/_census.scss
@@ -7,7 +7,7 @@
   --ons-color-branded-secondary: #df0667;
   --ons-color-branded-tertiary: #3c388e;
   --ons-color-branded-supporting: #00a3a6;
-  --ons-color-branded-supporting-tint: rgba(#00a3a6, 0.2);
+  --ons-color-branded-supporting-tint: rgba(0, 163, 166, 0.2);
   --ons-color-census-gradient: linear-gradient(to bottom left, #902082 0%, #3c388e 100%);
 
   // Assignment


### PR DESCRIPTION
### What is the context of this PR?
![image](https://user-images.githubusercontent.com/1015442/193782968-c507fba1-c021-4376-aca3-2fe3a21222ba.png)

Also fixed issue where `rgba` was incorrectly using the `var(--selector)`
### How to review
Confirm that the variable is implemented correctly