### PR TITLE
Look for `page.title` in `_template.njk` as a fallback.

### DIFF
--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -38,6 +38,8 @@
     {% set page_title = pageConfig.title %}
 {% elif pageInfo and pageInfo.title %}
     {% set page_title = pageInfo.title %}
+{% elif page and page.title %}
+    {% set page_title = page.title %}
 {% else %}
     {% set page_title = "ONS Design System" %}
 {% endif %}


### PR DESCRIPTION
### What is the context of this PR?
At the moment full-page examples rely on `pageConfig.title` being set as a fallback; but the service manual doesn't have a `pageConfig` object.

### How to review
Verify that this does not affect the current design system website.