### PR TITLE
Hero - adjust how additional content is configured

### DIFF
--- a/src/components/hero/_macro-options.md
+++ b/src/components/hero/_macro-options.md
@@ -6,6 +6,7 @@
 | subtitle | string           | false    | Text for the hero subtitle                                                                          |
 | text     | string           | false    | Text to follow the hero title and subtitle                                                          |
 | button   | `Object<Button>` | false    | Settings for the hero [call to action button](#button)                                              |
+| html     | string           | false    | Allows arbitrary HTML for additional content to be added to the component                           |
 
 ## Button
 

--- a/src/components/hero/_macro.njk
+++ b/src/components/hero/_macro.njk
@@ -36,11 +36,15 @@
                         })
                     }}
                 {% endif %}
+                {% if caller %}
+                    <div class="ons-hero__additional-content">
+                        {{- caller() -}}
+                    </div>
+                {% endif %}
             </div>
-
-            {% if caller %}
-                <div class="ons-hero__additional">
-                    {{- caller() -}}
+            {% if params.html %}
+                <div class="ons-hero__additional-html">
+                    {{- params.html | safe -}}
                 </div>
             {% endif %}
         </div>

--- a/src/components/hero/_macro.spec.js
+++ b/src/components/hero/_macro.spec.js
@@ -61,6 +61,13 @@ describe('macro: hero', () => {
     expect(title).toBe('Hero text');
   });
 
+  it('has expected `html`', () => {
+    const $ = cheerio.load(renderComponent('hero', { ...EXAMPLE_HERO, html: '<span class="some-html">some html</span>' }));
+
+    const htmlOutput = $('.ons-hero__additional-html').html();
+    expect(htmlOutput).toBe('<span class="some-html">some html</span>');
+  });
+
   it('outputs the expected button', () => {
     const faker = templateFaker();
     const buttonSpy = faker.spy('button');
@@ -83,7 +90,7 @@ describe('macro: hero', () => {
   it('calls with content', () => {
     const $ = cheerio.load(renderComponent('hero', { EXAMPLE_HERO }, 'Example content...'));
 
-    const content = $('.ons-hero__additional')
+    const content = $('.ons-hero__additional-content')
       .text()
       .trim();
     expect(content).toEqual(expect.stringContaining('Example content...'));


### PR DESCRIPTION
### What is the context of this PR?

Fixes - #2516 

The new simplified hero had an issue when adding additional content using the `caller()`. 

This new approach will be to:

1 - Add the `caller()` inside the `.ons-hero__details` element so the layout doesn't break
2 - Create a new `params.html` property so arbitraty html can be added by the user.

### How to review
Review the new approach works ok