### PR TITLE
Use 'cors' package with 'dev-server.js'

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -1,3 +1,4 @@
+import cors from 'cors';
 import express from 'express';
 
 import createNunjucksEnvironment from './rendering/create-nunjucks-environment.js';
@@ -8,6 +9,8 @@ import renderPage from './rendering/render-page.js';
 process.env.IS_DEV_SERVER = true;
 
 const app = express();
+
+app.use(cors());
 
 const nunjucksEnvironment = createNunjucksEnvironment();
 installRenderHelpers(nunjucksEnvironment);

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "cheerio": "^1.0.0-rc.10",
     "codecov": "^3.8.3",
     "core-js": "^3.21.1",
+    "cors": "^2.8.5",
     "dialog-polyfill": "^0.5.6",
     "eslint": "^5.9.0",
     "eslint-cli": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3885,7 +3885,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cors@^2.8.4:
+cors@^2.8.4, cors@^2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
   integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==


### PR DESCRIPTION
### What is the context of this PR?
Resolves #2515 

### How to review
This can be verified by hosting a local server and attempting to access a font from `http://localhost:3002` when using `yarn start` from the design system. It works as expected if the font can be accessed without any CORS errors being shown.