### PR TITLE
Fix: Address autosuggest aria status message

### DIFF
--- a/src/components/autosuggest/autosuggest.ui.js
+++ b/src/components/autosuggest/autosuggest.ui.js
@@ -408,6 +408,7 @@ export default class AutosuggestUI {
       this.listbox.innerHTML = `<li class="${classAutosuggestOption} ${classAutosuggestOptionNoResults}">${message}</li>`;
     } else if (status > 400 || status === '') {
       message = this.errorAPI + (this.errorAPILinkText ? ' <a href="' + window.location.href + '">' + this.errorAPILinkText + '</a>.' : '');
+      let ariaMessage = this.errorAPI + (this.errorAPILinkText ? ' ' + this.errorAPILinkText : '');
 
       this.input.setAttribute('disabled', true);
       this.input.value = '';
@@ -415,7 +416,7 @@ export default class AutosuggestUI {
 
       this.listbox.innerHTML = '';
       this.listbox.insertBefore(this.createWarningElement(message), this.listbox.firstChild);
-      this.setAriaStatus(message);
+      this.setAriaStatus(ariaMessage);
     } else {
       message = this.noResults;
       this.listbox.innerHTML = `<li class="${classAutosuggestOption} ${classAutosuggestOptionNoResults}">${message}</li>`;


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2367 

The address autosuggest aria status message when the api connection had failed contained a link.

Now it contains just a string for the announced message.

This bug was spotted as focus state attached to the hidden link when tabbing out of the message.

### How to review
Check the message. Check that focus works as it should.