### PR TITLE
Fix: nested input error state

### DIFF
--- a/src/components/checkboxes/_macro.njk
+++ b/src/components/checkboxes/_macro.njk
@@ -79,7 +79,7 @@
                                 "otherType": checkbox.other.otherType,
                                 "options": checkbox.other.options,
                                 "width": checkbox.other.width,
-                                "classes": ("ons-input--error" if params.error else "") + checkbox.other.classes | default('') + exclusiveClass | default(''),
+                                "classes": ("ons-input--error" if params.error and checkbox.checked else "") + checkbox.other.classes | default('') + exclusiveClass | default(''),
                                 "attributes": checkbox.other.attributes,
                                 "label": {
                                     "text": checkbox.other.label.text

--- a/src/components/radios/_macro.njk
+++ b/src/components/radios/_macro.njk
@@ -54,7 +54,7 @@
                                             "name": radio.other.name,
                                             "type": radio.other.type,
                                             "required": radio.other.required,
-                                            "classes": ("ons-input--error " if params.error else "") + radio.other.classes | default(''),
+                                            "classes": ("ons-input--error " if params.error and radio.checked else "") + radio.other.classes | default(''),
                                             "width": radio.other.width | default('auto'),
                                             "attributes": radio.other.attributes,
                                             "label": {
@@ -73,7 +73,7 @@
                                             "id": radio.other.id,
                                             "name": radio.other.name,
                                             "options": radio.other.options,
-                                            "classes": ("ons-input--error " if params.error else "") + radio.other.classes | default(''),
+                                            "classes": ("ons-input--error " if params.error and radio.checked else "") + radio.other.classes | default(''),
                                             "label": {
                                                 "id": radio.other.id + "-label",
                                                 "text": radio.other.label.text,


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2413 

The change is to add an additional check to only style the input as an error if the parent checkbox/radio is checked.

### How to review
Check via the errors prototype

https://deploy-preview-2523--ons-design-system.netlify.app/patterns/correct-errors/examples/errors-proto/