### PR TITLE
Fix summary spacer style and header doc links

### DIFF
--- a/src/components/header/_macro-options.md
+++ b/src/components/header/_macro-options.md
@@ -6,18 +6,18 @@
 | classes         | string                                            | false                            | Classes to add to the wrapping `header`                                                                                               |
 | variants        | array or string                                   | false                            | An array of values or single value (string) to adjust the component using available variants: “internal”, "neutral" and “description” |
 | mastheadLogoUrl | string                                            | false                            | Wraps the masthead logo in a link. Set the URL for the HTML `href` attribute for the link.                                            |
-| mastheadLogo    | object`<mastheadLogo>`                            | false                            | Settings for a [custom organisation logo](#mastheadLogo) in the masthead. Defaults to the ONS logo.                                   |
+| mastheadLogo    | object`<mastheadLogo>`                            | false                            | Settings for a [custom organisation logo](#mastheadlogo) in the masthead. Defaults to the ONS logo.                                   |
 | language        | `Language` [_(ref)_](/patterns/change-language)   | false                            | Settings for the language selector component                                                                                          |
 | serviceLinks    | object`<ServiceLinks>`                            | false                            | Settings for the [service links](#servicelinks) in the masthead                                                                       |
 | title           | string                                            | true (unless `titleLogo` is set) | The title for the service                                                                                                             |
 | description     | string                                            | false                            | Tagline or description for the service                                                                                                |
 | titleAsH1       | boolean                                           | false                            | Override to wrap the header `title` in an `<h1>` heading                                                                              |
-| titleLogo       | object`<titleLogo>`                               | false                            | Settings for a [custom title logo](#titleLogo) in the header.                                                                         |
+| titleLogo       | object`<titleLogo>`                               | false                            | Settings for a [custom title logo](#titlelogo) in the header.                                                                         |
 | titleUrl        | string                                            | false                            | Wraps the title logo in a link. Set the URL for the HTML `href` attribute for the link.                                               |
 | button          | object`<SignOutButton>`                           | false                            | Settings for the [sign out button](#signoutbutton) in the header used to exit a transactional service                                 |
 | navigation      | array`<Navigation>`                               | false                            | Settings for the [main menu links](#navigation)                                                                                       |
 
-## mastheadLogo
+## MastheadLogo
 
 | Name    | Type   | Required | Description                                                                    |
 | ------- | ------ | -------- | ------------------------------------------------------------------------------ |
@@ -25,7 +25,7 @@
 | large   | HTML   | true     | Any HTML to render an image for example embedded `<svg>` or `<img>`            |
 | small   | HTML   | false    | Optionally provide a version of the logo more suited to mobile viewports       |
 
-## titleLogo
+## TitleLogo
 
 | Name    | Type   | Required | Description                                                                    |
 | ------- | ------ | -------- | ------------------------------------------------------------------------------ |

--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -93,8 +93,8 @@ $hub-row-spacing: 1.3rem;
   &__spacer {
     background: var(--ons-color-black);
     display: inline-block;
-    height: 1rem;
-    margin: 0 0.25rem;
+    height: 1.15rem;
+    margin: 0.18rem 0.25rem 0;
     vertical-align: middle;
     width: 1px;
   }


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #2506 

Also fixes the header param table links that weren't working but now are

### How to review
- Check header param table links work
- Check summary action link spacer now looks as expected
