### PR TITLE
Change current page link background colour

### DIFF
--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -43,7 +43,7 @@ $pagination-item-width: 2.5rem;
   }
 
   &__item--current &__link {
-    background: var(--ons-color-text-link-hover);
+    background: var(--ons-color-text-link-active);
     color: var(--ons-color-white);
     outline: 2px solid transparent; // Add transparent outline because Windows High Contrast Mode doesn't show backgrounds
     text-decoration: none;


### PR DESCRIPTION
### What is the context of this PR?
Resolves #2430 

Pagination using the wrong colour variable for the active state.

Should be using $color-text-link-active (same as active section nav item) rather than $color-text-link-hover

Originally posted by @jrbarnes9 in https://github.com/ONSdigital/design-system/discussions/1384#discussioncomment-3527299

### How to review
Confirm correct colour is presented