### PR TITLE
Fix summary style for grouped household style answers

### DIFF
--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -112,7 +112,7 @@
                     {% endif %}
 
                     {% if group.summaryLink %}
-                        <div class="ons-summary__link{% if group.placeholderText or group.rows %} ons-u-pt-s{% endif %}{% if group.placeholderText is not defined and group.rows | length > 1 %} ons-u-bt{% endif %}">
+                        <div class="ons-summary__link{% if group.placeholderText or group.rows %} ons-u-pt-s{% endif %}{% if group.placeholderText is not defined and group.rows | length > 1 %} ons-u-bt{% endif %}{% if not group.last %} ons-u-mb-xl{% endif %}">
                             <a {% if group.summaryLink.attributes %}{% for attribute, value in (group.summaryLink.attributes.items() if group.summaryLink.attributes is mapping and group.summaryLink.attributes.items else group.summaryLink.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %} href="{{ group.summaryLink.url }}">{{ group.summaryLink.text }}</a>
                         </div>
                     {% endif %}

--- a/src/components/summary/_macro.spec.js
+++ b/src/components/summary/_macro.spec.js
@@ -115,7 +115,6 @@ const EXAMPLE_SUMMARY_GROUPS = {
     {
       id: 'group-id-1',
       groupTitle: 'group title',
-      headers: ['Header 1', 'Header 2', 'Header 3'],
       ...EXAMPLE_SUMMARY_ROWS,
     },
   ],
@@ -134,6 +133,123 @@ const EXAMPLE_SUMMARY_GROUPS_NO_ROWS = {
       },
     },
   ],
+};
+
+const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
+  rows: [
+    {
+      rowItems: [
+        {
+          rowTitle: 'row item 1',
+          valueList: [
+            {
+              text: 'list item 1',
+            },
+          ],
+          actions: [
+            {
+              text: 'Change',
+              ariaLabel: 'Change list item',
+              url: '#0',
+            },
+            {
+              text: 'Remove',
+              ariaLabel: 'Remove list item',
+              url: '#0',
+            },
+          ],
+        },
+        {
+          rowTitle: 'row item 2',
+          valueList: [
+            {
+              text: 'list item 2',
+            },
+          ],
+          actions: [
+            {
+              text: 'Change',
+              ariaLabel: 'Remove list item',
+              url: '#0',
+            },
+          ],
+        },
+        {
+          rowTitle: 'row item 3',
+          valueList: [
+            {
+              text: 'list item 3',
+            },
+          ],
+          actions: [
+            {
+              text: 'Change',
+              ariaLabel: 'Change list item',
+              url: '#0',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      rowItems: [
+        {
+          rowTitle: 'row item 4',
+          valueList: [
+            {
+              text: 'list item 4',
+            },
+          ],
+          actions: [
+            {
+              text: 'Change',
+              ariaLabel: 'Change answer',
+              url: '#0',
+            },
+            {
+              text: 'Remove',
+              ariaLabel: 'Change list item',
+              url: '#0',
+            },
+          ],
+        },
+        {
+          rowTitle: 'row item 5',
+          valueList: [
+            {
+              text: 'list item 5',
+            },
+          ],
+          actions: [
+            {
+              text: 'Change',
+              ariaLabel: 'Change list item',
+              url: '#0',
+            },
+          ],
+        },
+        {
+          rowTitle: 'row item 6',
+          valueList: [
+            {
+              text: 'list item 6',
+            },
+          ],
+          actions: [
+            {
+              text: 'Change',
+              ariaLabel: 'Change list item',
+              url: '#0',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  summaryLink: {
+    text: 'Summary link',
+    url: '#0',
+  },
 };
 
 const EXAMPLE_SUMMARY_BASIC = {
@@ -158,6 +274,31 @@ const EXAMPLE_SUMMARY_WITH_NO_ROWS = {
     {
       summaryTitle: 'summary title',
       ...EXAMPLE_SUMMARY_GROUPS_NO_ROWS,
+    },
+  ],
+};
+
+const EXAMPLE_SUMMARY_MULTIPLE_GROUPS = {
+  summaries: [
+    {
+      summaryTitle: 'summary title',
+      groups: [
+        {
+          id: 'group-id-1',
+          groupTitle: 'group title',
+          ...EXAMPLE_SUMMARY_ROWS,
+        },
+        {
+          id: 'group-id-2',
+          groupTitle: 'group title',
+          ...EXAMPLE_SUMMARY_HOUSEHOLD_GROUP,
+        },
+        {
+          id: 'group-id-3',
+          groupTitle: 'group title',
+          ...EXAMPLE_SUMMARY_ROWS,
+        },
+      ],
     },
   ],
 };
@@ -199,6 +340,12 @@ describe('macro: summary', () => {
         const $ = cheerio.load(renderComponent('summary', EXAMPLE_SUMMARY_BASIC));
 
         expect($('.ons-summary__group-title').text()).toBe('group title');
+      });
+
+      it('has larger margin between groups if the top one is a household style summary', () => {
+        const $ = cheerio.load(renderComponent('summary', EXAMPLE_SUMMARY_MULTIPLE_GROUPS));
+
+        expect($('.ons-summary__group:nth-last-of-type(2) .ons-summary__link').hasClass('ons-u-mb-xl')).toBe(true);
       });
     });
 

--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -178,7 +178,7 @@ $hub-row-spacing: 1.3rem;
     &__item-title,
     &__values,
     &__actions {
-      flex: 2;
+      flex: 4;
       padding-top: $summary-row-spacing;
       vertical-align: top;
 
@@ -194,7 +194,7 @@ $hub-row-spacing: 1.3rem;
 
     &__item-title,
     &__values {
-      flex: 6.19;
+      flex: 7.3;
     }
 
     &__item-title--2 {

--- a/src/components/summary/examples/summary-grouped/index.njk
+++ b/src/components/summary/examples/summary-grouped/index.njk
@@ -157,6 +157,126 @@
                         ]
                     },
                     {
+                        "groupTitle": "Employment history",
+                        "rows": [
+                            {
+                                "rowItems": [
+                                    {
+                                        "rowTitle": "Name of UK company",
+                                        "valueList": [
+                                            {
+                                                "text": "Company A"
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": "#0"
+                                            },
+                                            {
+                                                "text": "Remove",
+                                                "ariaLabel": "Remove company",
+                                                "url": "#0"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "rowTitle": "Head office location",
+                                        "valueList": [
+                                            {
+                                                "text": "Cardiff"
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": "#0"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "rowTitle": "Is this UK company your current employer?",
+                                        "valueList": [
+                                            {
+                                                "text": "No"
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": "#0"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "rowItems": [
+                                    {
+                                        "rowTitle": "Name of UK company",
+                                        "valueList": [
+                                            {
+                                                "text": "Company A"
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": "#0"
+                                            },
+                                            {
+                                                "text": "Remove",
+                                                "ariaLabel": "Remove company",
+                                                "url": "#0"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "rowTitle": "Head office location",
+                                        "valueList": [
+                                            {
+                                                "text": "Newport"
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": "#0"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "rowTitle": "Is this UK company your current employer?",
+                                        "valueList": [
+                                            {
+                                                "text": "Yes"
+                                            }
+                                        ],
+                                        "actions": [
+                                            {
+                                                "text": "Change",
+                                                "ariaLabel": "Change answer",
+                                                "url": "#0"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "summaryLink": {
+                            "text": "Add a UK company or branch",
+                            "url": "#0",
+                            "attributes": {
+                                "data-qa": "add-item-link"
+                            }
+                        }
+                    },
+                    {
                         "groupTitle": "Spending",
                         "rows": [
                             {


### PR DESCRIPTION
### What is the context of this PR?
- Fixes answer alignment for grouped "household" style answers
- Adds these type of answers into one of the examples
- Adds some spacing to answers that come after "household" style answers
- Removes headers param from summary test because the param is no longer used

Fixes: #2510 

### How to review
- Check that all types of summary still work and look as expected
- Check that summary answers for "household" style answers are now aligned at all screen sizes
