### PR TITLE
Fix page config welsh footer logo

### DIFF
--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -229,7 +229,7 @@
                                 "fullWidth": pageConfig.fullWidth,
                                 "classes": "ons-page__footer",
                                 "language": pageConfig.language,
-                                "lang": currentLanguageISOCode,
+                                "lang": pageConfig.footer.lang | default(currentLanguageISOCode),
                                 "rows": pageConfig.footer.rows,
                                 "cols": pageConfig.footer.cols,
                                 "poweredBy": pageConfig.footer.poweredBy,

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -4,10 +4,10 @@
 
 {% set currentLanguageISOCode = "en" %}
 
-{% if pageConfig and pageConfig.language and pageConfig.language.languages %}
-    {% set currentLanguage = pageConfig.language.languages | selectattr("current") | first %}
+{% if pageConfig and pageConfig.header.language and pageConfig.header.language.languages %}
+    {% set currentLanguage = pageConfig.header.language.languages | selectattr("current") | first %}
     {% set currentLanguageISOCode = currentLanguage.ISOCode %}
-    {% set otherLanguage = pageConfig.language.languages | rejectattr("current") | first %}
+    {% set otherLanguage = pageConfig.header.language.languages | rejectattr("current") | first %}
     {% set otherLanguageISOCode = otherLanguage.ISOCode %}
 {% endif %}
 
@@ -228,8 +228,7 @@
                                 "wide": pageConfig.wide,
                                 "fullWidth": pageConfig.fullWidth,
                                 "classes": "ons-page__footer",
-                                "language": pageConfig.language,
-                                "lang": pageConfig.footer.lang | default(currentLanguageISOCode),
+                                "lang": currentLanguageISOCode,
                                 "rows": pageConfig.footer.rows,
                                 "cols": pageConfig.footer.cols,
                                 "poweredBy": pageConfig.footer.poweredBy,

--- a/src/patterns/help-users-to/change-language/examples/cymraeg/index.njk
+++ b/src/patterns/help-users-to/change-language/examples/cymraeg/index.njk
@@ -27,6 +27,7 @@ layout: none
         }    
     },
     "footer": {
+        "lang": 'cy',
         "rows": [
             {
                 "itemsList": [

--- a/src/patterns/help-users-to/change-language/examples/cymraeg/index.njk
+++ b/src/patterns/help-users-to/change-language/examples/cymraeg/index.njk
@@ -27,7 +27,6 @@ layout: none
         }    
     },
     "footer": {
-        "lang": 'cy',
         "rows": [
             {
                 "itemsList": [


### PR DESCRIPTION
### What is the context of this PR?
The welsh footer logo isn't being displayed when using the footer component through page config. This PR fixes that and updates the example to show that.

Also removes the language param which isn't being used

### How to review
Check help users to change language example and see that the welsh ONS logo is now displayed
