### PR TITLE
Add flex style to summary action link

### DIFF
--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -192,6 +192,10 @@ $hub-row-spacing: 1.3rem;
       justify-content: right;
     }
 
+    &__button {
+      align-self: flex-start;
+    }
+
     &__item-title,
     &__values {
       flex: 6.19;


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2480 

### How to review
Tab to focus an action link in a summary example and confirm that the focus state only wraps the text and does not fill the container itself.