### PR TITLE
Change custom base page template example to have 2 languages and not 4

### DIFF
--- a/src/foundations/layout/page-template/examples/custom/index.njk
+++ b/src/foundations/layout/page-template/examples/custom/index.njk
@@ -28,18 +28,6 @@ layout: none
                     "ISOCode": "cy",
                     "text": "Cymraeg",
                     "current": false
-                },
-                {
-                    "url": "#0",
-                    "ISOCode": "ga",
-                    "text": "Gaeilge",
-                    "current": false
-                },
-                {
-                    "url": "#0",
-                    "ISOCode": "sco",
-                    "text": "Ulstèr-Scotch",
-                    "current": false
                 }
             ]
         }


### PR DESCRIPTION
### What is the context of this PR?
Resolves #2410 

### How to review
Check that the custom page template example language toggle works correctly on small viewport 