### PR TITLE
Alignment issue on summaries

### DIFF
--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -38,7 +38,7 @@
 
                                     {% for rowItem in row.rowItems %}
                                         <dl class="ons-summary__row{{ " ons-summary__row--has-values" if rowItem.valueList else "" }}"{% if rowItem.id %} id="{{ rowItem.id }}"{% endif %}>
-                                            <dt class="ons-summary__item-title{% if not rowItem.actions %} ons-summary__item-title--2{% endif %}"
+                                            <dt class="ons-summary__item-title"
                                                 {% if rowItem.rowTitleAttributes %}{% for attribute, value in (rowItem.rowTitleAttributes.items() if rowItem.rowTitleAttributes is mapping and rowItem.rowTitleAttributes.items else rowItem.rowTitleAttributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
                                             >
                                                 {% if rowItem.iconType %}
@@ -63,7 +63,7 @@
                                             </dt>
                                             {% if rowItem.valueList %}
                                                 <dd
-                                                    class="ons-summary__values"
+                                                    class="ons-summary__values{% if not rowItem.actions %} ons-summary__values--2{% endif %}"
                                                     {% if rowItem.attributes %}{% for attribute, value in (rowItem.attributes.items() if rowItem.attributes is mapping and rowItem.attributes.items else rowItem.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
                                                 >
                                                     {% if rowItem.valueList | length == 1 %}

--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -178,7 +178,7 @@ $hub-row-spacing: 1.3rem;
     &__item-title,
     &__values,
     &__actions {
-      flex: 5;
+      flex: 5 1 33%;
       padding-top: $summary-row-spacing;
       vertical-align: top;
 
@@ -197,7 +197,7 @@ $hub-row-spacing: 1.3rem;
     }
 
     &__values--2 {
-      flex: 10.5;
+      flex: 10.5 1 66%;
     }
 
     &--hub & {
@@ -206,24 +206,6 @@ $hub-row-spacing: 1.3rem;
       &__actions {
         padding-top: $hub-row-spacing;
       }
-    }
-  }
-
-  @include mq(l) {
-    &__values--2 {
-      flex: 10.4;
-    }
-  }
-
-  @include mq(xl) {
-    &__values--2 {
-      flex: 10.3;
-    }
-  }
-
-  @include mq(xxl) {
-    &__values--2 {
-      flex: 10.2;
     }
   }
 }

--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -178,7 +178,7 @@ $hub-row-spacing: 1.3rem;
     &__item-title,
     &__values,
     &__actions {
-      flex: 4;
+      flex: 5;
       padding-top: $summary-row-spacing;
       vertical-align: top;
 
@@ -196,13 +196,8 @@ $hub-row-spacing: 1.3rem;
       align-self: flex-start;
     }
 
-    &__item-title,
-    &__values {
-      flex: 7.3;
-    }
-
-    &__item-title--2 {
-      flex: 4.5;
+    &__values--2 {
+      flex: 10.5;
     }
 
     &--hub & {
@@ -211,10 +206,24 @@ $hub-row-spacing: 1.3rem;
       &__actions {
         padding-top: $hub-row-spacing;
       }
+    }
+  }
 
-      &__actions {
-        flex: 6;
-      }
+  @include mq(l) {
+    &__values--2 {
+      flex: 10.4;
+    }
+  }
+
+  @include mq(xl) {
+    &__values--2 {
+      flex: 10.3;
+    }
+  }
+
+  @include mq(xxl) {
+    &__values--2 {
+      flex: 10.2;
     }
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
Fixes an alignment issue on with values in summaries lining up when used within a page rather than on their own like in a DS example.

<img width="691" alt="image" src="https://user-images.githubusercontent.com/42928680/207398971-237beaef-0268-4992-9ad9-1cd3e29eeb23.png">



Also fixes an issue where summaries with totals aren't aligned at all screen widths

<img width="1837" alt="Screenshot 2022-12-13 at 17 06 14" src="https://user-images.githubusercontent.com/42928680/207398028-b1bbcc68-dfd1-45f5-96ab-09f0078031a8.png">

### How to review
- Test the summary grouped total example at all screen widths to check that the values are aligned
- Test summary with "Household" style answers like the ones in the Grouped example are aligned at all widths when used in a full page

