### PR TITLE
Fix: focus state on multi lined links

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,7 +82,7 @@ gulp.task('build-styles', () => {
     .src(`./src/scss/*.scss`)
     .pipe(gulpIf(isDevelopment, gulpSourcemaps.init()))
     .pipe(gulpDartSass(sassOptions).on('error', gulpDartSass.logError))
-    .pipe(gulpIf(isProduction, gulpPostCss(postCssPlugins())))
+    .pipe(gulpPostCss(postCssPlugins()))
     .pipe(gulpIf(isDevelopment, gulpSourcemaps.write('./')))
     .pipe(gulp.dest('./build/css'))
     .pipe(browserSync.stream());

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -5,6 +5,12 @@
     text-decoration-thickness: 3px;
   }
 
+  &__title {
+    // This is to allow the focus state for multi lined title links to render the focus style correctly.
+    // This should be corrected when the typography scale is improved.
+    line-height: 1.65 !important;
+  }
+
   @include mq(m) {
     margin: 0;
     .ons-grid__col & {

--- a/src/scss/base/_global.scss
+++ b/src/scss/base/_global.scss
@@ -32,7 +32,6 @@ hr {
 %a-focus {
   background-color: var(--ons-color-focus);
   box-decoration-break: clone;
-  box-decoration-break: clone;
   box-shadow: 0 -2px var(--ons-color-focus), 0 4px var(--ons-color-text-link-focus);
   color: var(--ons-color-text-link-focus);
   outline: 3px solid transparent;

--- a/src/scss/base/_global.scss
+++ b/src/scss/base/_global.scss
@@ -31,6 +31,8 @@ hr {
 
 %a-focus {
   background-color: var(--ons-color-focus);
+  box-decoration-break: clone;
+  box-decoration-break: clone;
   box-shadow: 0 -2px var(--ons-color-focus), 0 4px var(--ons-color-text-link-focus);
   color: var(--ons-color-text-link-focus);
   outline: 3px solid transparent;


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2563 

Uses `box-decoration-break: clone;` -  https://developer.mozilla.org/en-US/docs/Web/CSS/box-decoration-break

The above property allows the box-shadow to correctly render over multiple lines. For the Card component which uses a larger font-size the line height is too low to allow it to render fully. I believe this is the only use case where this would be an issue (accordions work in a different way and wrap the entire heading in a link).

Our line height isn't responsive across our typography scale and this issue would be addressed when we look at #1935 

In this change I have also updated the postcss gulp task to run on dev and production instead of just production. This is so that autoprefixer() runs on local development. `box-decoration-break` required the `-webkit-` prefix for Chrome so was  necessary change.

### How to review
Test the focus state on multi lined links and cards