### PR TITLE
Fix small masthead logo render

### DIFF
--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -50,8 +50,10 @@
                             {% endif %}
                         </div>
                         <div class="ons-header__org-logo ons-header__org-logo--small">
-                            {% if params.mastheadLogo.small or params.mastheadLogo.large %}
+                            {% if params.mastheadLogo.small %}
                                 {{ params.mastheadLogo.small | safe }}
+                            {% elif params.mastheadLogo.large %}
+                                {{ params.mastheadLogo.large | safe }}
                             {% else %}
                                 {{
                                     onsIcon({


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #2579 

### How to review
Pass in large logo to the masthead but not the small one and see that the small one is defaulted to the large one when the screen width is reduced
