### PR TITLE
Fix: Pagination component - Change concatenation method to be compatible with jinja2

### DIFF
--- a/src/components/pagination/_macro.njk
+++ b/src/components/pagination/_macro.njk
@@ -7,7 +7,7 @@
   {% endfor %}
 
   {% set totalPages = params.pages | length %}
-  {% set position = "Page " + currentPageIndex + " of " + totalPages %}
+  {% set position = "Page " ~ currentPageIndex ~ " of " ~ totalPages %}
   {% set lastPage = params.pages | last %}
   {% set firstPage = params.pages | first %}
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #2591 

Changed concatenation method to be compatible with jinja2.

Uses `~` instead of `+`

### How to review
Ultimately this will need to be tested in a flask application with jinja2 templating