### PR TITLE
Replaced en dashes with double hyphens for BEM modifier classes shown in Type scale example

### DIFF
--- a/src/foundations/style/typography/type-scale/examples/type-scale/index.njk
+++ b/src/foundations/style/typography/type-scale/examples/type-scale/index.njk
@@ -35,16 +35,16 @@
       <td class="ons-table__cell"><p class="ons-u-fs-m">ons-u-fs-m</p>Open Sans Bold - 1.2rem/22px</td>
     </tr>
     <tr class="ons-table__row">
-      <td class="ons-table__cell"><p class="ons-u-fs-r--b">ons-u-fs-r–b</p>Open Sans Bold - 1rem/18px</td>
-      <td class="ons-table__cell"><p class="ons-u-fs-r--b">ons-u-fs-r–b</p>Open Sans Bold - 1rem/18px</td>
+      <td class="ons-table__cell"><p class="ons-u-fs-r--b">ons-u-fs-r--b</p>Open Sans Bold - 1rem/18px</td>
+      <td class="ons-table__cell"><p class="ons-u-fs-r--b">ons-u-fs-r--b</p>Open Sans Bold - 1rem/18px</td>
     </tr>
     <tr class="ons-table__row">
       <td class="ons-table__cell"><p class="ons-u-fs-r">ons-u-fs-r</p>Open Sans Regular - 1rem/18px</td>
       <td class="ons-table__cell"><p class="ons-u-fs-r">ons-u-fs-r</p>Open Sans Regular - 1rem/18px</td>
     </tr>
     <tr class="ons-table__row">
-      <td class="ons-table__cell"><p class="ons-u-fs-s--b">ons-u-fs-s–b</p>Open Sans Bold - 0.7rem/14px</td>
-      <td class="ons-table__cell"><p class="ons-u-fs-s--b">ons-u-fs-s–b</p>Open Sans Bold - 0.7rem/14px</td>
+      <td class="ons-table__cell"><p class="ons-u-fs-s--b">ons-u-fs-s--b</p>Open Sans Bold - 0.7rem/14px</td>
+      <td class="ons-table__cell"><p class="ons-u-fs-s--b">ons-u-fs-s--b</p>Open Sans Bold - 0.7rem/14px</td>
     </tr>
     <tr class="ons-table__row">
       <td class="ons-table__cell"><p class="ons-u-fs-s">ons-u-fs-s</p>Open Sans Regular - 0.7rem/14px</td>


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2599 

### How to review
Check type scale classes in example are correct
