### PR TITLE
Fix: Prevent Chrome print dialogue creating page break before grid col

### DIFF
--- a/src/scss/print.scss
+++ b/src/scss/print.scss
@@ -48,25 +48,15 @@ a::after {
   }
 }
 
-.ons-details {
-  &--initialised & {
-    &__icon {
-      display: none;
-    }
-
-    &__title {
-      color: var(--ons-color-black);
-      margin-bottom: 1rem;
-      margin-left: -1.5rem;
-      text-decoration: none;
-    }
-
-    &__content {
-      display: block;
-    }
-  }
+details,
+details > summary {
+  display: block !important;
 }
 
 .ons-hero {
   color-adjust: exact;
+}
+
+.ons-grid__col {
+  display: block; // Prevents page breaking before grid col when printing from Chrome see: https://github.com/ONSdigital/design-system/issues/2584
 }


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2584 

### How to review
Check long page content doesn't break between header and grid column in print styles
