### PR TITLE
Added `novalidate` to form config

### DIFF
--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -636,7 +636,7 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             <div class=\\"ons-page\\">
                 <div class=\\"ons-page__content\\">
                     
-                        <form class=\\"form-class\\" method=\\"POST\\" autocomplete=\\"off\\" novalidate=\\"null\\">
+                        <form class=\\"form-class\\" method=\\"POST\\" novalidate=\\"\\" autocomplete=\\"off\\" action=\\"/example.html\\">
                     
                     Some preHeader content
                     

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -131,6 +131,7 @@
                         <form
                             {% if form.classes %}class="{{ form.classes }}"{% endif %}
                             method="{{ form.method | default('POST') }}"
+                            novalidate
                             {% if form.attributes %}{% for attribute, value in (form.attributes.items() if form.attributes is mapping and form.attributes.items else form.attributes) %}{{ attribute }}{% if value %}="{{value}}" {% endif %}{% endfor %}{% endif %}
                         >
                     {% endif %}

--- a/src/layout/_template.spec.js
+++ b/src/layout/_template.spec.js
@@ -297,7 +297,7 @@ const FULL_EXAMPLE = `
     "method": "POST",
     "attributes": {
         "autocomplete": "off",
-        "novalidate": "null"
+        "action": "/example.html"
     }
 } %}
 {% block main %}

--- a/src/patterns/help-users-to/correct-errors/examples/errors-proto/index.njk
+++ b/src/patterns/help-users-to/correct-errors/examples/errors-proto/index.njk
@@ -42,8 +42,7 @@ layout: none
 {% set form = {
     "method": "GET",
     "attributes": {
-        "action": pageInfo.url + "errors",
-        "novalidate": ""
+        "action": pageInfo.url + "errors"
     }
 } %}
 


### PR DESCRIPTION
### What is the context of this PR?
Fixes #2240 

To help users prevent the browser validating inputs such as `number` and `email`, added `novalidate` as a hardcoded attribute to the base page template `form` config.

Browser validation should be avoided because:
- the visual style, placement and content of HTML5 error messages cannot be made consistent with the ONS Design System
- we know that the ONS Design System error details and error summary components are accessible

We will also add guidance to the 'input' component and 'correct errors' pattern in a separate ticket telling users why they should add the attribute if not using base page template.

---
**Note:**  Developers already setting `novalidate` with `form.attributes` in the base page template will need to remove the attribute to avoid invalid HTML with the duplicate attributes.

---

### How to review
Check attribute is applied by default when using `form` config in base page template.