### PR TITLE
Add print hidden utility class

### DIFF
--- a/src/scss/print.scss
+++ b/src/scss/print.scss
@@ -8,7 +8,8 @@ html {
 .ons-footer,
 .ons-cookies-banner,
 .ons-language-links,
-.ons-breadcrumb {
+.ons-breadcrumb,
+.ons-u-ph {
   display: none !important;
 }
 

--- a/src/scss/print.scss
+++ b/src/scss/print.scss
@@ -1,7 +1,3 @@
-html {
-  --ons-color-black: #222;
-}
-
 .ons-btn,
 .ons-navigation-search,
 .ons-summary__actions,


### PR DESCRIPTION
### What is the context of this PR?
On the eQ service there is a need to set some elements to be hidden from printing so this PR creates a new utility class (`ons-u-ph`) that will allow this control from the service side.

Also removes the setting of the `--ons-color-black` var as this is not needed.

Fixes: #2623 

### How to review
Add new class to element to see that it is now hidden from printing
