### PR TITLE
Fix printing page breaking inside elements

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -1,8 +1,8 @@
 // Block
 .ons-header {
+  @include font-smoothing;
+
   display: block;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   margin: 0;
   position: relative;
 

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -1,7 +1,7 @@
 html {
+  @include font-smoothing;
+
   font-size: $base;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   line-height: 1.6;
 }
 

--- a/src/scss/print.scss
+++ b/src/scss/print.scss
@@ -60,3 +60,15 @@ details > summary {
 .ons-grid__col {
   display: block; // Prevents page breaking before grid col when printing from Chrome see: https://github.com/ONSdigital/design-system/issues/2584
 }
+
+.ons-panel,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+div,
+p {
+  break-inside: avoid;
+}

--- a/src/scss/print.scss
+++ b/src/scss/print.scss
@@ -68,7 +68,6 @@ h3,
 h4,
 h5,
 h6,
-div,
 p {
   break-inside: avoid;
 }


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #2625 

Also updates some css that was being repeated when there was a mixin available to use

### How to review
Create a page with content longer than a page of A4 including long panels and test the comparison between printing a page on the main branch with this one and see that panels or paragraphs aren't broken by page breaks
