### PR TITLE
Fix multiple summaries title spacing

### DIFF
--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -12,7 +12,7 @@
     <div class="{{ className }}">
         {% for summary in params.summaries %}
             {% if summary.summaryTitle %}
-                <h2 class="ons-summary__title ons-u-mb-m">{{ summary.summaryTitle }}</h2>
+                <h2 class="ons-summary__title ons-u-mb-m{{ " ons-u-mt-m" if loop.index > 1 else "" }}">{{ summary.summaryTitle }}</h2>
                 {% set titleSize = "3" %}
             {% endif %}
             {% for group in summary.groups %}


### PR DESCRIPTION
### What is the context of this PR?
Fixes: #2650 


### How to review
In the `example-summary-grouped` example duplicate the entire summary in the `summaries` array and compare this branch to main seeing that the space is added in this branch
