### PR TITLE
fix: changed how radio buttons are displayed

### DIFF
--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -9,13 +9,15 @@
     box-shadow: inset 0 0 0 3px var(--ons-color-input-bg);
 
     &::after {
-      border-color: var(--ons-color-input-border);
+      background-color: var(--ons-color-input-border);
       border-radius: 50%;
-      border-width: 6px;
-      height: 0;
-      left: 3px;
-      top: 3px;
-      width: 0;
+      border-width: 0;
+      height: 12px;
+      left: 50%;
+      margin-left: -6px;
+      margin-top: -6px;
+      top: 50%;
+      width: 12px;
     }
   }
 


### PR DESCRIPTION
### What is the context of this PR?

Selected radio buttons were appearing off center at various window zoom sizes. I have implemented a fix that is not 100% perfect but much better than previous. The error is due to the way browsers calculate viewport units compared with DOM units.

#2652 

### How to review
Look at netlify and zoom in and out to see if the radio buttons behave appropriately. 