### PR TITLE
bugfix/2146/related-content-class-output-twice

### DIFF
--- a/src/components/related-content/_macro-options.md
+++ b/src/components/related-content/_macro-options.md
@@ -1,10 +1,8 @@
-| Name      | Type         | Required                       | Description                                                                                                                       |
-| --------- | ------------ | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| title     | string       | true (false if `Row` provided) | The text for the `h2` heading for related content                                                                                 |
-| body      | string       | true (false if `Row` provided) | The contents of the related content. This can contain HTML                                                                        |
-| ariaLabel | string       | false                          | Descriptive landmark ARIA label to give a screen reader user greater understanding of its purpose. Defaults to ”Related content”. |
-| classes   | string       | false                          | Custom classes to add to the related content `aside` element                                                                      |
-| rows      | `Array<Row>` | false                          | Settings for an array of [row objects](#row)                                                                                      |
+| Name      | Type         | Required | Description                                                                                                                       |
+| --------- | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| rows      | `Array<Row>` | true     | Settings for an array of [row objects](#row)                                                                                      |
+| ariaLabel | string       | false    | Descriptive landmark ARIA label to give a screen reader user greater understanding of its purpose. Defaults to ”Related content”. |
+| classes   | string       | false    | Custom classes to add to the related content `aside` element                                                                      |
 
 ## Row
 


### PR DESCRIPTION
### What is the context of this PR?

#2146 

Major changes have been made to this component since the ticket was raised. The bug in question no longer appears however documentation had not been updated. This PR covers the changes to the documentation to reflect how the component is expected to be used.

### How to review
Take a look at the related-content macro and determine whether the changes I have made to the markdown reflect how the macro works.