### PR TITLE
Fix/243/link text used for multiple different destinations

### DIFF
--- a/src/components/tabs/_macro-options.md
+++ b/src/components/tabs/_macro-options.md
@@ -8,9 +8,9 @@
 
 ## Tab
 
-| Name       | Type   | Required | Description                                     |
-| ---------- | ------ | -------- | ----------------------------------------------- |
-| id         | string | false    | Sets the HTML `id` of the tab                   |
-| title      | string | true     | The title for the tab                           |
-| hiddenSpan | string | false    | To add description                              |
-| content    | string | true     | The contents of the tab. This can contain HTML. |
+| Name       | Type   | Required | Description                                                                                                                                    |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| id         | string | false    | Sets the HTML `id` of the tab                                                                                                                  |
+| title      | string | true     | The title for the tab                                                                                                                          |
+| hiddenSpan | string | false    | Sets a visually hidden span after the title to distinguish the tab from others if multiple tabs with same title are displayed in the same page |
+| content    | string | true     | The contents of the tab. This can contain HTML.                                                                                                |

--- a/src/components/tabs/_macro-options.md
+++ b/src/components/tabs/_macro-options.md
@@ -8,8 +8,9 @@
 
 ## Tab
 
-| Name    | Type   | Required | Description                                     |
-| ------- | ------ | -------- | ----------------------------------------------- |
-| id      | string | false    | Sets the HTML `id` of the tab                   |
-| title   | string | true     | The title for the tab                           |
-| content | string | true     | The contents of the tab. This can contain HTML. |
+| Name       | Type   | Required | Description                                     |
+| ---------- | ------ | -------- | ----------------------------------------------- |
+| id         | string | false    | Sets the HTML `id` of the tab                   |
+| title      | string | true     | The title for the tab                           |
+| hiddenSpan | string | false    | To add description                              |
+| content    | string | true     | The contents of the tab. This can contain HTML. |

--- a/src/components/tabs/_macro.njk
+++ b/src/components/tabs/_macro.njk
@@ -15,7 +15,7 @@
 
         <ul class="ons-tabs__list">
             {%- for tab in params.tabs -%}
-                <li class="ons-tab__list-item"><a href="#{{ tab.id if tab.id else 'tabId' ~ loop.index }}" class="ons-tab" data-ga="click" data-ga-category="tabs" data-ga-action="Show: {{ tab.title }}" data-ga-label="Show: {{ tab.title }}">{{ tab.title }}</a></li>
+                <li class="ons-tab__list-item"><a href="#{{ tab.id if tab.id else 'tabId' ~ loop.index }}" class="ons-tab" data-ga="click" data-ga-category="tabs" data-ga-action="Show: {{ tab.title }}" data-ga-label="Show: {{ tab.title }}">{{ tab.title }}{% if params.hiddenSpan %}<span class='ons-u-d-no'>{{params.hiddenSpan}}</span>{% endif %}</a></li>
             {%- endfor -%}
         </ul>
 

--- a/src/components/tabs/_macro.njk
+++ b/src/components/tabs/_macro.njk
@@ -15,7 +15,7 @@
 
         <ul class="ons-tabs__list">
             {%- for tab in params.tabs -%}
-                <li class="ons-tab__list-item"><a href="#{{ tab.id if tab.id else 'tabId' ~ loop.index }}" class="ons-tab" data-ga="click" data-ga-category="tabs" data-ga-action="Show: {{ tab.title }}" data-ga-label="Show: {{ tab.title }}">{{ tab.title }}{% if params.hiddenSpan %}<span class='ons-u-d-no'>{{params.hiddenSpan}}</span>{% endif %}</a></li>
+                <li class="ons-tab__list-item"><a href="#{{ tab.id if tab.id else 'tabId' ~ loop.index }}" class="ons-tab" data-ga="click" data-ga-category="tabs" data-ga-action="Show: {{ tab.title }}" data-ga-label="Show: {{ tab.title }}">{{ tab.title }}{% if tab.hiddenSpan %}<span class='ons-u-d-no'>{{tab.hiddenSpan}}</span>{% endif %}</a></li>
             {%- endfor -%}
         </ul>
 

--- a/src/components/tabs/_macro.spec.js
+++ b/src/components/tabs/_macro.spec.js
@@ -12,6 +12,7 @@ const EXAMPLE_TABS = {
       id: 'first-tab',
       title: 'Tab 1',
       content: 'Example content...',
+      hiddenSpan: 'for Example',
     },
     {
       id: 'second-tab',
@@ -91,14 +92,10 @@ describe('macro: tabs', () => {
     expect($('.ons-tabs__panel:last').attr('id')).toBe('tabId2');
   });
 
-  it('has expected label text in tab links', () => {
+  it('has expected label text in tab links and visually hidden span in tab 1', () => {
     const $ = cheerio.load(renderComponent('tabs', EXAMPLE_TABS));
 
-    expect(
-      $('.ons-tab:first')
-        .text()
-        .trim(),
-    ).toBe('Tab 1');
+    expect($('.ons-tab:first').html()).toBe('Tab 1<span class="ons-u-d-no">for Example</span>');
     expect(
       $('.ons-tab:last')
         .text()

--- a/src/components/tabs/example-tabs.njk
+++ b/src/components/tabs/example-tabs.njk
@@ -7,6 +7,7 @@
             {
                 "id": "ukis",
                 "title": 'UKIS',
+                "hiddenSpan": 'for UKIS',
                 "content": '<h2 class="ons-u-d-no@m">UKIS</h2>
                 <h3>Aim of this survey</h3>
                 <p class="ons-u-fs-r">The aim of the UK Innovation Survey (UKIS) is to collect data from businesses about various aspects of their innovation related activities. Using this data we can measure the level, types and trends in innovation.</p>


### PR DESCRIPTION
### What is the context of this PR?
A hiddenPan parameter has been added to the tab component. This is to help differentiate the tabs if multiple tabs with the same title are displayed in the same page. 

### How to review
You can add the hiddenSpan parameter to one of the tab example and confirm that the title contains a visually hidden span. 
