### PR TITLE
Bugfix/2222/invalid outputtable component outputs name attribute for trtd entries when trnametdname is provided

### DIFF
--- a/src/components/table/_macro-options.md
+++ b/src/components/table/_macro-options.md
@@ -28,7 +28,6 @@
 | --------- | ----------- | -------- | --------------------------------------------------- |
 | tds       | Array`<td>` | true     | An array of `td` [cell elements](#td) for each `tr` |
 | id        | string      | false    | The HTML `id` of the `tr` element                   |
-| name      | string      | false    | The HTML `name` attribute for the `tr` element      |
 | highlight | boolean     | false    | Set to “true” to highlight the row                  |
 
 ## td
@@ -37,7 +36,6 @@
 | --------- | -------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
 | tdClasses | string         | false                                      | Classes to add to the `td` element                                                                                                    |
 | id        | string         | false                                      | The HTML `id` of the `td` element                                                                                                     |
-| name      | string         | false                                      | The HTML `name` attribute for the `td` element                                                                                        |
 | data      | string         | false (unless “responsive” variant is set) | Set to the corresponding `th` header cell when using the “responsive” variant                                                         |
 | dataSort  | integer        | false                                      | Set the numerical order of a table cell in a column when using the “sortable” variant                                                 |
 | value     | string         | false                                      | The content for the `td` cell                                                                                                         |

--- a/src/components/table/_macro.njk
+++ b/src/components/table/_macro.njk
@@ -32,9 +32,9 @@
                 </thead>
                 <tbody class="ons-table__body">
                     {% for tr in params.trs %}
-                    <tr class="ons-table__row{{ " ons-table__row--highlight" if tr.highlight }}" {% if tr.name %} name="{{ tr.name }}"{% endif %} {% if tr.id %} id="{{ tr.id }}"{% endif %}>
+                    <tr class="ons-table__row{{ " ons-table__row--highlight" if tr.highlight }}" {% if tr.id %} id="{{ tr.id }}"{% endif %}>
                         {% for td in tr.tds %}
-                        <td class="ons-table__cell{{ ' ' + td.tdClasses if td.tdClasses }}{{ " ons-table__cell--numeric" if td.numeric }}" {% if td.id %} id="{{ td.id }}"{% endif %} {% if td.name %} name="{{ td.name }}"{% endif %} {% if td.data %} data-th="{{ td.data }}"{% endif %} {% if td.dataSort %} data-sort-value="{{ td.dataSort }}"{% endif %}>
+                        <td class="ons-table__cell{{ ' ' + td.tdClasses if td.tdClasses }}{{ " ons-table__cell--numeric" if td.numeric }}" {% if td.id %} id="{{ td.id }}"{% endif %} {% if td.data %} data-th="{{ td.data }}"{% endif %} {% if td.dataSort %} data-sort-value="{{ td.dataSort }}"{% endif %}>
                             {% if td.form %}
                                 <form action="{{ td.form.action }}" method="{{ td.form.method | default('POST')}}">
                                     {{

--- a/src/components/table/example-table-basic.njk
+++ b/src/components/table/example-table-basic.njk
@@ -19,7 +19,6 @@
                 "tds": [
                     {
                         "value": "Cell A1",
-                        "name": "cell-name"
                     },
                     {
                         "value": "Cell B1"

--- a/src/components/table/example-table-basic.njk
+++ b/src/components/table/example-table-basic.njk
@@ -18,7 +18,7 @@
             {
                 "tds": [
                     {
-                        "value": "Cell A1",
+                        "value": "Cell A1"
                     },
                     {
                         "value": "Cell B1"


### PR DESCRIPTION
### What is the context of this PR?
having `name` attributes on html `<tr>` & `<td>` elements is invalid. The option to place them has been removed and the macro options documentation has been updated.

### How to review
Review code and confirm that html name attributes can no longer be added to `<tr>` & `<td>` elements.

### Breaking Changes
Any usage of the Table Component where a `name` attribute is added to html `<tr>` & `<td>` elements will now not add the attribute. This will not break the component.

Any code where the `name` attribute is accessed/used on html `<tr>` & `<td>` elements will break. You will need to refactor your code for your individual use case. 