### PR TITLE
Enhancement/2679/accessible names of change buttons in summary component

### DIFF
--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -57,7 +57,6 @@
 | ---------- | ------ | -------- | ------------------------------------------------------------------------------------------ |
 | text       | string | true     | Text for the action link                                                                   |
 | url        | string | true     | The URL for the HTML `href` attribute of the link used to change the value of the row item |
-| ariaLabel  | string | false    | An `aria-label` to apply to the action link to add more context for screen readers         |
 | attributes | object | false    | HTML attributes (for example, data attributes) to add to the action link                   |
 
 ## SummaryLink

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -97,7 +97,7 @@
                                                             href="{{ action.url }}"
                                                             class="ons-summary__button"
                                                             {% if action.attributes %}{% for attribute, value in (action.attributes.items() if action.attributes is mapping and action.attributes.items else action.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
-                                                        >{{ action.text }}<span class="ons-u-vh">{{ row.rowTitle }}</span></a>
+                                                        >{{ action.text }}<span class="ons-u-vh">answer for {{ row.rowTitle }}</span></a>
                                                     {% endfor %}
                                                 </dd>
                                             {% endif %}

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -96,9 +96,8 @@
                                                         <a
                                                             href="{{ action.url }}"
                                                             class="ons-summary__button"
-                                                            {% if action.ariaLabel %} aria-label="{{ action.ariaLabel }}"{% endif %}
                                                             {% if action.attributes %}{% for attribute, value in (action.attributes.items() if action.attributes is mapping and action.attributes.items else action.attributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
-                                                        >{{ action.text }}</a>
+                                                        >{{ action.text }}<span class="ons-u-vh">{{ row.rowTitle }}</span></a>
                                                     {% endfor %}
                                                 </dd>
                                             {% endif %}

--- a/src/components/summary/_macro.spec.js
+++ b/src/components/summary/_macro.spec.js
@@ -483,19 +483,32 @@ describe('macro: summary', () => {
         ).toBe('Action 2');
       });
 
-      it('has the `aria-label` provided', () => {
+      // it('has the `aria-label` provided', () => {
+      //   const $ = cheerio.load(renderComponent('summary', EXAMPLE_SUMMARY_BASIC));
+
+      //   expect(
+      //     $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:first-child').attr(
+      //       'aria-label',
+      //     ),
+      //   ).toBe('action aria label 1');
+      //   expect(
+      //     $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:last-child').attr(
+      //       'aria-label',
+      //     ),
+      //   ).toBe('action aria label 2');
+      // });
+
+      it('has the correct visually hidden <span> text', () => {
         const $ = cheerio.load(renderComponent('summary', EXAMPLE_SUMMARY_BASIC));
 
         expect(
-          $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:first-child').attr(
-            'aria-label',
-          ),
-        ).toBe('action aria label 1');
+          $(
+            '.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:first-child .ons-u-vh',
+          ).text(),
+        ).toBe('Action 1 answer for row title 2');
         expect(
-          $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:last-child').attr(
-            'aria-label',
-          ),
-        ).toBe('action aria label 2');
+          $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:last-child .ons-u-vh').text(),
+        ).toBe('Action 2 answer for row title 3');
       });
 
       it('has custom `attributes`', () => {

--- a/src/components/summary/_macro.spec.js
+++ b/src/components/summary/_macro.spec.js
@@ -477,26 +477,11 @@ describe('macro: summary', () => {
 
         expect(
           $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:first-child').text(),
-        ).toBe('Action 1');
+        ).toBe('Action 1answer for row title 2');
         expect(
           $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:last-child').text(),
-        ).toBe('Action 2');
+        ).toBe('Action 2answer for row title 2');
       });
-
-      // it('has the `aria-label` provided', () => {
-      //   const $ = cheerio.load(renderComponent('summary', EXAMPLE_SUMMARY_BASIC));
-
-      //   expect(
-      //     $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:first-child').attr(
-      //       'aria-label',
-      //     ),
-      //   ).toBe('action aria label 1');
-      //   expect(
-      //     $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:last-child').attr(
-      //       'aria-label',
-      //     ),
-      //   ).toBe('action aria label 2');
-      // });
 
       it('has the correct visually hidden <span> text', () => {
         const $ = cheerio.load(renderComponent('summary', EXAMPLE_SUMMARY_BASIC));
@@ -505,10 +490,7 @@ describe('macro: summary', () => {
           $(
             '.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:first-child .ons-u-vh',
           ).text(),
-        ).toBe('Action 1 answer for row title 2');
-        expect(
-          $('.ons-summary__items .ons-summary__item:nth-of-type(2) .ons-summary__actions .ons-summary__button:last-child .ons-u-vh').text(),
-        ).toBe('Action 2 answer for row title 3');
+        ).toBe('answer for row title 2');
       });
 
       it('has custom `attributes`', () => {

--- a/src/components/summary/_macro.spec.js
+++ b/src/components/summary/_macro.spec.js
@@ -49,7 +49,6 @@ const EXAMPLE_SUMMARY_ROWS = {
           actions: [
             {
               text: 'Action 1',
-              ariaLabel: 'action aria label 1',
               attributes: {
                 a: 'abc',
                 b: 'def',
@@ -58,7 +57,6 @@ const EXAMPLE_SUMMARY_ROWS = {
             },
             {
               text: 'Action 2',
-              ariaLabel: 'action aria label 2',
               url: '#2',
             },
           ],
@@ -149,12 +147,10 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           actions: [
             {
               text: 'Change',
-              ariaLabel: 'Change list item',
               url: '#0',
             },
             {
               text: 'Remove',
-              ariaLabel: 'Remove list item',
               url: '#0',
             },
           ],
@@ -169,7 +165,6 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           actions: [
             {
               text: 'Change',
-              ariaLabel: 'Remove list item',
               url: '#0',
             },
           ],
@@ -184,7 +179,6 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           actions: [
             {
               text: 'Change',
-              ariaLabel: 'Change list item',
               url: '#0',
             },
           ],
@@ -203,12 +197,10 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           actions: [
             {
               text: 'Change',
-              ariaLabel: 'Change answer',
               url: '#0',
             },
             {
               text: 'Remove',
-              ariaLabel: 'Change list item',
               url: '#0',
             },
           ],
@@ -223,7 +215,6 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           actions: [
             {
               text: 'Change',
-              ariaLabel: 'Change list item',
               url: '#0',
             },
           ],
@@ -238,7 +229,6 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           actions: [
             {
               text: 'Change',
-              ariaLabel: 'Change list item',
               url: '#0',
             },
           ],

--- a/src/components/summary/example-summary-grouped-total.njk
+++ b/src/components/summary/example-summary-grouped-total.njk
@@ -19,7 +19,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -38,7 +37,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]

--- a/src/components/summary/example-summary-grouped-with-errors.njk
+++ b/src/components/summary/example-summary-grouped-with-errors.njk
@@ -19,7 +19,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -40,7 +39,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -60,7 +58,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -80,7 +77,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]

--- a/src/components/summary/example-summary-grouped.njk
+++ b/src/components/summary/example-summary-grouped.njk
@@ -23,7 +23,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -42,7 +41,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -61,7 +59,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -85,7 +82,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -104,7 +100,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -128,7 +123,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -147,7 +141,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -171,12 +164,10 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             },
                                             {
                                                 "text": "Remove",
-                                                "ariaLabel": "Remove company",
                                                 "url": "#0"
                                             }
                                         ]
@@ -191,7 +182,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -206,7 +196,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -225,12 +214,10 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             },
                                             {
                                                 "text": "Remove",
-                                                "ariaLabel": "Remove company",
                                                 "url": "#0"
                                             }
                                         ]
@@ -245,7 +232,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -260,7 +246,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -292,7 +277,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -307,7 +291,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -322,7 +305,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -337,7 +319,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]

--- a/src/components/summary/example-summary-household.njk
+++ b/src/components/summary/example-summary-household.njk
@@ -15,7 +15,6 @@
                                     "actions": [
                                         {
                                             "text": "Change",
-                                            "ariaLabel": "Change details for Joe Bloggs",
                                             "url": "#0"
                                         }
                                     ]
@@ -30,12 +29,10 @@
                                     "actions": [
                                         {
                                             "text": "Change",
-                                            "ariaLabel": "Change details for Barry Scott",
                                             "url": "#0"
                                         },
                                         {
                                             "text": "Remove",
-                                            "ariaLabel": "Remove Barry Scott",
                                             "url": "#0"
                                         }
                                     ]
@@ -50,12 +47,10 @@
                                     "actions": [
                                         {
                                             "text": "Change",
-                                            "ariaLabel": "Change details for Susan Gill",
                                             "url": "#0"
                                         },
                                         {
                                             "text": "Remove",
-                                            "ariaLabel": "Remove Susan Gill",
                                             "url": "#0"
                                         }
                                     ]

--- a/src/components/summary/example-summary-hub.njk
+++ b/src/components/summary/example-summary-hub.njk
@@ -20,7 +20,6 @@
                                     "actions": [
                                         {
                                             "text": "View answers",
-                                            "ariaLabel": "View answers for People who live here",
                                             "url": "#0"
                                         }
                                     ]
@@ -40,7 +39,6 @@
                                     "actions": [
                                         {
                                             "text": "View answers",
-                                            "ariaLabel": "View answers for Accommodation",
                                             "url": "#0"
                                         }
                                     ]
@@ -60,7 +58,6 @@
                                     "actions": [
                                         {
                                             "text": "View answers",
-                                            "ariaLabel": "View answers for Mary Smith",
                                             "url": "#0"
                                         }
                                     ]
@@ -79,7 +76,6 @@
                                     "actions": [
                                         {
                                             "text": "Continue with section",
-                                            "ariaLabel": "Continue with John Smith's section",
                                             "url": "#0"
                                         }
                                     ]
@@ -98,7 +94,6 @@
                                     "actions": [
                                         {
                                             "text": "Start section",
-                                            "ariaLabel": "Start Billy Smith's section",
                                             "url": "#0"
                                         }
                                     ]
@@ -117,7 +112,6 @@
                                     "actions": [
                                         {
                                             "text": "Start section",
-                                            "ariaLabel": "Start Sally Smith's section",
                                             "url": "#0"
                                         }
                                     ]
@@ -136,7 +130,6 @@
                                     "actions": [
                                         {
                                             "text": "Start section",
-                                            "ariaLabel": "Start Wilhelmina Susannah Clementine-Smith's section",
                                             "url": "#0"
                                         }
                                     ]
@@ -155,7 +148,6 @@
                                     "actions": [
                                         {
                                             "text": "Start section",
-                                            "ariaLabel": "Start Vera Jones's section",
                                             "url": "#0"
                                         }
                                     ]

--- a/src/components/summary/example-summary-multiple.njk
+++ b/src/components/summary/example-summary-multiple.njk
@@ -20,7 +20,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -35,7 +34,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -50,7 +48,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -65,7 +62,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]

--- a/src/components/summary/example-summary.njk
+++ b/src/components/summary/example-summary.njk
@@ -24,7 +24,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -45,7 +44,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -70,7 +68,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]
@@ -91,7 +88,6 @@
                                         "actions": [
                                             {
                                                 "text": "Change",
-                                                "ariaLabel": "Change answer",
                                                 "url": "#0"
                                             }
                                         ]


### PR DESCRIPTION
###BREAKING CHANGES
This PR removes the `aria-label` attribute from the `<a>` element. If you are using the `aria-label` for anything, this will no longer be possible. 

### What is the context of this PR?
#2679 

The "Change" button in the Summary component was using an aria-label for screen readers. I have removed this functionality and added a visually hidden span element so screen readers will now read out "change answer for [question]"

### How to review
Go to the summary component examples and check that a screen reader says the above when you tab to the change button.
