### PR TITLE
2158: Add default values to pagination "previous" and "next" paramaters

### DIFF
--- a/src/components/pagination/_macro-options.md
+++ b/src/components/pagination/_macro-options.md
@@ -1,11 +1,11 @@
 | Name               | Type          | Required | Description                                                        |
 | ------------------ | ------------- | -------- | ------------------------------------------------------------------ |
 | pages              | `Array<Page>` | true     | Settings for each [page](#page)                                    |
-| previous           | string        | true     | Text label for the “Previous” link                                 |
-| next               | string        | true     | Text label for the “Next” link                                     |
+| currentPageNumber  | integer       | true     | Sets the current page number                                       |
+| previous           | string        | false    | Text label for the “Previous” link. Default is "Previous".         |
+| next               | string        | false    | Text label for the “Next” link. Default is "Next".                 |
 | classes            | string        | false    | Classes to add to the pagination HTML `nav` element                |
 | hideRangeIndicator | boolean       | false    | Set to “true” to hide the range indicator on viewports &geq; 740px |
-| currentPageNumber  | integer       | true     | Sets the current page number                                       |
 
 ## Page
 

--- a/src/components/pagination/_macro.njk
+++ b/src/components/pagination/_macro.njk
@@ -13,7 +13,7 @@
             {% if currentPageIndex != 1 %}
                 {% set prevPageIndex = currentPageIndex - 2 %}
                 <li class="ons-pagination__item ons-pagination__item--previous">
-                    <a href="{{ params.pages[prevPageIndex].url }}" class="ons-pagination__link" rel="prev" aria-label="Go to the previous page (Page {{ currentPageIndex - 1 }})">{{ params.previous }}</a>
+                    <a href="{{ params.pages[prevPageIndex].url }}" class="ons-pagination__link" rel="prev" aria-label="Go to the previous page (Page {{ currentPageIndex - 1 }})">{{ params.previous | default("Previous") }}</a>
                 </li>
             {% endif %}
             {% if currentPageIndex > 2 %}
@@ -60,7 +60,7 @@
             {% endif %}
             {% if totalPages > 1 and totalPages != currentPageIndex %}
                 <li class="ons-pagination__item ons-pagination__item--next">
-                    <a href="{{ params.pages[currentPageIndex].url }}" class="ons-pagination__link" rel="next" aria-label="Go to the next page (Page {{ currentPageIndex + 1 }})">{{ params.next }}</a>
+                    <a href="{{ params.pages[currentPageIndex].url }}" class="ons-pagination__link" rel="next" aria-label="Go to the next page (Page {{ currentPageIndex + 1 }})">{{ params.next | default("Next") }}</a>
                 </li>
             {% endif %}
         </ul>

--- a/src/components/pagination/example-pagination-first.njk
+++ b/src/components/pagination/example-pagination-first.njk
@@ -2,8 +2,6 @@
 
 {{
     onsPagination({
-        "previous": "Previous",
-        "next": "Next",
         "hideRangeIndicator": true,
         "currentPageNumber": 1,
         "pages": [

--- a/src/components/pagination/example-pagination-last.njk
+++ b/src/components/pagination/example-pagination-last.njk
@@ -2,8 +2,6 @@
 
 {{
     onsPagination({
-        "previous": "Previous",
-        "next": "Next",
         "hideRangeIndicator": true,
         "currentPageNumber": 4,
         "pages": [

--- a/src/components/pagination/example-pagination-with-no-range-indicator.njk
+++ b/src/components/pagination/example-pagination-with-no-range-indicator.njk
@@ -2,8 +2,6 @@
 
 {{
     onsPagination({
-        "previous": "Previous",
-        "next": "Next",
         "hideRangeIndicator": true,
         "currentPageNumber": 5,
         "pages": [

--- a/src/components/pagination/example-pagination.njk
+++ b/src/components/pagination/example-pagination.njk
@@ -2,8 +2,6 @@
 
 {{
     onsPagination({
-        "previous": "Previous",
-        "next": "Next",
         "currentPageNumber": 5,
         "pages": [
             {


### PR DESCRIPTION
### What is the context of this PR?
fixes #2158 

### How to review
Pull branch and use see how the buttons are named. Add a `previous` or `next` value to one of the examples and see that it overrides the default.
