### PR TITLE
Enhancement/2734: create visually hidden h2 for section nav component

### DIFF
--- a/src/components/section-navigation/_macro-options.md
+++ b/src/components/section-navigation/_macro-options.md
@@ -1,13 +1,14 @@
-| Name        | Type          | Required                        | Description                                                                                             |
-| ----------- | ------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| id          | string        | false                           | The HTML `id` of the `<nav>` element of the component                                                   |
-| classes     | string        | false                           | Additional classes for the `<nav>` element                                                              |
-| ariaLabel   | string        | false                           | The `aria-label` attribute for the `<nav>` element to describe its purpose. Defaults to ”Section menu”. |
-| variants    | string        | false                           | To adjust the orientation of the component using available variant “vertical”                           |
-| currentPath | string        | true (unless `tabQuery` set)    | Path to the current active page                                                                         |
-| tabQuery    | string        | true (unless `currentPath` set) | Query parameter in the URL for the current active page                                                  |
-| title       | string        | false                           | The title/header to display in the section navigation element (only for entries without sections)       |
-| sections    | `Array<Item>` | false                           | An array of [sections](#sections) for the component                                                     |
+| Name          | Type          | Required                        | Description                                                                                                                   |
+| ------------- | ------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| id            | string        | false                           | The HTML `id` of the `<nav>` element of the component                                                                         |
+| classes       | string        | false                           | Additional classes for the `<nav>` element                                                                                    |
+| hiddenTitle   | string        | false                           | The value of the visually hidden `<h2>` element for screen readers. Defaults to "Pages in this section".                      |
+| hiddenTitleId | string        | false                           | The value of the visually hidden title ID. Necessary if you have multiple section navs. Defaults to "section-menu-nav-title". |
+| variants      | string        | false                           | To adjust the orientation of the component using available variant “vertical”                                                 |
+| currentPath   | string        | true (unless `tabQuery` set)    | Path to the current active page                                                                                               |
+| tabQuery      | string        | true (unless `currentPath` set) | Query parameter in the URL for the current active page                                                                        |
+| title         | string        | false                           | The title/header to display in the section navigation element (only for entries without sections)                             |
+| sections      | `Array<Item>` | false                           | An array of [sections](#sections) for the component                                                                           |
 
 ## Sections
 

--- a/src/components/section-navigation/_macro.njk
+++ b/src/components/section-navigation/_macro.njk
@@ -1,5 +1,6 @@
 {% macro onsSectionNavigation(params) %}
-  <nav class="ons-section-nav{% if params.variants == 'vertical' %} ons-section-nav--vertical{% endif %} {% if params.classes %} {{ params.classes }} {% endif %}"{% if params.id %} id="{{ params.id }}"{% endif %} aria-label="{{ params.ariaLabel | default("Section menu") }}">
+  <nav class="ons-section-nav{% if params.variants == 'vertical' %} ons-section-nav--vertical{% endif %} {% if params.classes %} {{ params.classes }} {% endif %}"{% if params.id %} id="{{ params.id }}"{% endif %} aria-labelledby="{{ params.hiddenTitleId | default("section-menu-nav-title")}}">
+  <h2 class="ons-u-vh" id="{{ params.hiddenTitleId | default("section-menu-nav-title") }}">{{ params.hiddenTitle | default("Pages in this section") }}</h2>
     {% if params.sections %}
       {% for section in params.sections %}
         <div class="ons-section-nav__sub">

--- a/src/components/section-navigation/_macro.spec.js
+++ b/src/components/section-navigation/_macro.spec.js
@@ -138,7 +138,7 @@ describe('macro: section-navigation', () => {
   it('assumes a default `hiddenTitleId` of "Section menu"', () => {
     const $ = cheerio.load(renderComponent('section-navigation', EXAMPLE_SECTION_NAVIGATION));
 
-    expect($('.ons-section-nav').attr('aria-labelledby')).toBe('navigation-menu');
+    expect($('.ons-section-nav').attr('aria-labelledby')).toBe('section-menu-nav-title');
   });
 
   it('assumes a default `hiddenTitle` of "Pages in this section"', () => {

--- a/src/components/section-navigation/_macro.spec.js
+++ b/src/components/section-navigation/_macro.spec.js
@@ -141,6 +141,12 @@ describe('macro: section-navigation', () => {
     expect($('.ons-section-nav').attr('aria-labelledby')).toBe('section-menu-nav-title');
   });
 
+  it('has the visually hidden class', () => {
+    const $ = cheerio.load(renderComponent('section-navigation', EXAMPLE_SECTION_NAVIGATION));
+
+    expect($('h2').hasClass('.ons-u-vh')).toBe(true);
+  });
+
   it('assumes a default `hiddenTitle` of "Pages in this section"', () => {
     const $ = cheerio.load(renderComponent('section-navigation', EXAMPLE_SECTION_NAVIGATION));
 

--- a/src/components/section-navigation/_macro.spec.js
+++ b/src/components/section-navigation/_macro.spec.js
@@ -135,21 +135,16 @@ describe('macro: section-navigation', () => {
     expect($('.ons-section-nav').hasClass('custom-class')).toBe(true);
   });
 
-  it('has the provided `ariaLabel` parameter', () => {
-    const $ = cheerio.load(
-      renderComponent('section-navigation', {
-        ...EXAMPLE_SECTION_NAVIGATION,
-        ariaLabel: 'Section navigation menu',
-      }),
-    );
-
-    expect($('.ons-section-nav').attr('aria-label')).toBe('Section navigation menu');
-  });
-
-  it('assumes a default `ariaLabel` of "Section menu"', () => {
+  it('assumes a default `hiddenTitleId` of "Section menu"', () => {
     const $ = cheerio.load(renderComponent('section-navigation', EXAMPLE_SECTION_NAVIGATION));
 
-    expect($('.ons-section-nav').attr('aria-label')).toBe('Section menu');
+    expect($('.ons-section-nav').attr('aria-labelledby')).toBe('navigation-menu');
+  });
+
+  it('assumes a default `hiddenTitle` of "Pages in this section"', () => {
+    const $ = cheerio.load(renderComponent('section-navigation', EXAMPLE_SECTION_NAVIGATION));
+
+    expect($('h2').toBe('Pages in this section'));
   });
 
   describe('navigation items', () => {

--- a/src/components/section-navigation/_macro.spec.js
+++ b/src/components/section-navigation/_macro.spec.js
@@ -141,18 +141,6 @@ describe('macro: section-navigation', () => {
     expect($('.ons-section-nav').attr('aria-labelledby')).toBe('section-menu-nav-title');
   });
 
-  it('has the visually hidden class', () => {
-    const $ = cheerio.load(renderComponent('section-navigation', EXAMPLE_SECTION_NAVIGATION));
-
-    expect($('h2').hasClass('.ons-u-vh')).toBe(true);
-  });
-
-  it('assumes a default `hiddenTitle` of "Pages in this section"', () => {
-    const $ = cheerio.load(renderComponent('section-navigation', EXAMPLE_SECTION_NAVIGATION));
-
-    expect($('h2').toBe('Pages in this section'));
-  });
-
   describe('navigation items', () => {
     it('renders top level navigation items', () => {
       const $ = cheerio.load(renderComponent('section-navigation', EXAMPLE_SECTION_NAVIGATION));


### PR DESCRIPTION
### What is the context of this PR?
#2734 

### How to review
Check that in the section navigation component, an `<h2>` with the class `.ons-u-vh` is the first child of the `<nav>` element. 
