### PR TITLE
updated navigation to hide when toggle button is hidden

### DIFF
--- a/src/components/navigation/navigation.js
+++ b/src/components/navigation/navigation.js
@@ -44,11 +44,15 @@ export default class NavigationToggle {
     this.navigation.classList.add(this.hideClass);
   }
 
+  isHidden(el) {
+    return el.offsetParent === null;
+  }
+
   setAria() {
-    const viewportDetails = GetViewportDetails();
+    const isToggleHidden = this.isHidden(this.toggle);
     const hasAria = this.navigation.hasAttribute(attrHidden);
 
-    if (viewportDetails.width < 980) {
+    if (!isToggleHidden) {
       if (!hasAria) {
         this.closeNav();
       }


### PR DESCRIPTION
### What is the context of this PR?
This fixes #2770. I have fixed this by making sure that the navigation is hidden if the button that opens the navigation is not longer visible. 

### How to review
Review the header component and confirm that the bug raised in the above ticket is not longer present. 

