### PR TITLE
Update prepend-file to v2

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ gulp.task('copy-js-files', () => {
   return gulp.src('./src/js/*.js').pipe(gulp.dest('./build/js'));
 });
 
-gulp.task('generate-pages', async function() {
+gulp.task('generate-pages', async function () {
   await generateStaticPages();
 });
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "pinst": "^3.0.0",
     "postcss": "^8.3.5",
     "postcss-url": "^10.1.3",
-    "prepend-file": "^1.3.1",
+    "prepend-file": "^2.0.1",
     "prettier": "^3.0.0",
     "puppeteer": "^21.0.2",
     "remark-cli": "^11.0.0",

--- a/src/tests/helpers/debug.js
+++ b/src/tests/helpers/debug.js
@@ -15,8 +15,8 @@ async function extractTextFromMessage(message) {
     // the actual error text. This is some sort of serialization thing between Chromium and
     // Puppeteer: https://github.com/puppeteer/puppeteer/issues/3397#issuecomment-434970058
     messageParts = await Promise.all(
-      message.args().map(arg =>
-        arg.executionContext().evaluate(arg => {
+      message.args().map((arg) =>
+        arg.executionContext().evaluate((arg) => {
           if (arg instanceof Error) {
             return arg.message;
           } else {
@@ -44,7 +44,7 @@ export function verifyConsoleSubscription(page) {
 
   consoleSubscriptionPage = page;
 
-  page.on('console', async message => {
+  page.on('console', async (message) => {
     const text = await extractTextFromMessage(message);
     quietLog(`browser ${message.type()}: ${text}`, message.type());
 

--- a/src/tests/helpers/puppeteer.js
+++ b/src/tests/helpers/puppeteer.js
@@ -5,7 +5,7 @@ import { quietLog } from './debug';
 const INTERCEPT_INSTANCE_HEADER_NAME = 'x-test-intercept-instance';
 
 export async function getNodeAttributes(page, selector) {
-  return await page.$eval(selector, node => {
+  return await page.$eval(selector, (node) => {
     const reducer = (map, attr) => {
       map[attr.name] = attr.value;
       return map;
@@ -41,7 +41,7 @@ export class PuppeteerEndpointFaker {
   }
 
   get requestedPaths() {
-    return this.requestHistory.map(entry => entry.path);
+    return this.requestHistory.map((entry) => entry.path);
   }
 
   async setup(page) {
@@ -67,7 +67,7 @@ export class PuppeteerEndpointFaker {
   }
 
   setOverrides(paths, response) {
-    paths.forEach(path => this.setOverride(path, response));
+    paths.forEach((path) => this.setOverride(path, response));
   }
 
   setTemporaryOverride(path, response) {
@@ -75,12 +75,12 @@ export class PuppeteerEndpointFaker {
   }
 
   setTemporaryOverrides(paths, response) {
-    paths.forEach(path => this.setTemporaryOverride(path, response));
+    paths.forEach((path) => this.setTemporaryOverride(path, response));
   }
 
   getRequestCount(path) {
     path = sanitizeHref(path);
-    return this.requestHistory.filter(entry => entry.path === path).length;
+    return this.requestHistory.filter((entry) => entry.path === path).length;
   }
 
   async #refreshInstanceHeader() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5680,7 +5680,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
+graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -8908,11 +8908,6 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-tmpdir@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
-
 os@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/os/-/os-0.1.2.tgz#f29a50c62908516ba42652de42f7038600cadbc2"
@@ -9459,12 +9454,12 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prepend-file@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/prepend-file/-/prepend-file-1.3.1.tgz#83b16e0b4ac1901fce88dbd945a22f4cc81df579"
-  integrity sha512-NFKEPDka08hvbVUZOu5JtFKJuWkZhWOJ/Odz6tsMlHWDtg6aUncrbu/BV3uTPRNa5T69SzbWIucg11e2kr4vBA==
+prepend-file@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/prepend-file/-/prepend-file-2.0.1.tgz#6a624b474a65ab1f87dc24d1757d5a6d989eb2db"
+  integrity sha512-0hXWjmOpz5YBIk6xujS0lYtCw6IAA0wCR3fw49UGTLc3E9BIhcxgqdMa8rzGvrtt2F8wFiGP42oEpQ8fo9zhRw==
   dependencies:
-    tmp "0.0.31"
+    temp-write "^4.0.0"
 
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
@@ -11463,6 +11458,22 @@ teeny-request@7.1.1:
     stream-events "^1.0.5"
     uuid "^8.0.0"
 
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+  integrity sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==
+
+temp-write@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-4.0.0.tgz#cd2e0825fc826ae72d201dc26eef3bf7e6fc9320"
+  integrity sha512-HIeWmj77uOOHb0QX7siN3OtwV3CTntquin6TNVg6SHOqCP3hYKmox90eeFOGaY1MqJ9WYDDjkyZrW6qS5AWpbw==
+  dependencies:
+    graceful-fs "^4.1.15"
+    is-stream "^2.0.0"
+    make-dir "^3.0.0"
+    temp-dir "^1.0.0"
+    uuid "^3.3.2"
+
 temp@^0.9.4:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.4.tgz#cd20a8580cb63635d0e4e9d4bd989d44286e7620"
@@ -11575,13 +11586,6 @@ titleize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
   integrity sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==
-
-tmp@0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
-  integrity sha512-lfyEfOppKvWNeId5CArFLwgwef+iCnbEIy0JWYf1httIEXnx4ndL4Dr1adw7hPgeQfSlTbc/gqn6iaKcROpw5Q==
-  dependencies:
-    os-tmpdir "~1.0.1"
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -12196,6 +12200,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^3.3.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 uuid@^8.0.0:
   version "8.3.2"


### PR DESCRIPTION
### What is the context of this PR?
Updates prepend-file to v2.

### How to review
- In `prepare-templates-for-zip.js` change `process.env.RELEASE_VERSION` to something 
- Run `yarn cdn-bundle` and check it runs without error
- See that in ./templates/layout/_template.njk that the first line includes setting the release version to what you replaced `process.env.RELEASE_VERSION` with
