### PR TITLE
fix/1302/reduce margin top when page main contains child with panel error

### DIFF
--- a/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-checkboxes-expanded_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-checkboxes-expanded_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa81b50ec02017ccc97dd478092917ef15f14bf4016558a368143c77b816f7eb
-size 33304
+oid sha256:46a83a90b8a3d953c3e6901548207de7be7244d7eb55b2f62ea72dceeadcac78
+size 33336

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-checkboxes-expanded_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-checkboxes-expanded_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a6de26042f663cbad0fe8070438d4c12f5ee5a9ecc2b60fe05a76f085c709d3
-size 27258
+oid sha256:af5f5f0c0eb2b8bcfe1fc56b6215e949c8a72958c7f20c2dae154d4320c46510
+size 27285

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-checkboxes-expanded_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-checkboxes-expanded_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5630111a6e7ec1d884cbadf483d739f9493a695f2cb0836abc70b8e8e2dd4fc
-size 24073
+oid sha256:74379c18d4d5a80316afa1944eccc9ce921b66e0ce1a0e5e640745b9dc80b080
+size 24102

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-radios-expanded_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-radios-expanded_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c331857104e5cb12832b2cc2f605898999589fbf0a2a3613deb361c666bbbf88
-size 35833
+oid sha256:44caebc9ceddd13f0dbd38f2157e3b51d169b6d9097c3150daf8638396927afa
+size 35861

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-radios-expanded_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-radios-expanded_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dfd8890f88ff277df11f1f4b83411f49e0131c846caf9af4df6b79c626ac1d21
-size 29808
+oid sha256:1b147088709f58435b5fd5c5a77af286637600be0bb97f954411528a8882a983
+size 29829

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-radios-expanded_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_radios_example-radios-with-revealed-radios-expanded_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f59b82e420e8c12efb607975bc0a034fed487c7306bd0d4a22c442fd1b48737b
-size 26321
+oid sha256:fa04222f42254ad768f10b5ec7c7dc319591daa089353bf678b567c0fe71c295
+size 26346

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_relationships_example-relationships-error_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_relationships_example-relationships-error_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a59c2dceaf54da51a1b597301a11c6a018c4b16022ddf4e3f79be41ac025f66
-size 100045
+oid sha256:b19bc3166fd783a79211f917ffff20522e11729f2a90b7eafcdc601b7572ed2f
+size 99716

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_relationships_example-relationships-error_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_relationships_example-relationships-error_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9a3e1fbc0acd5aa142d4060750e3387f98f616c4b73050b29869664c65bce20
-size 88900
+oid sha256:f1b3c50a3856701da8158be4da134e68532dda62398a8b50b71921dd761a54bd
+size 88730

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_relationships_example-relationships-error_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_relationships_example-relationships-error_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38d5b46abac94dd9a9a6d67d072434f2cfe65e9aa60514d8d330dd753bba45e6
-size 85853
+oid sha256:bed6a401ff55aa2686fa009fe03e058274a1d280193880e76fe91430c5d85264
+size 85774

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_timeout-panel_example-panel-with-timeout-warning_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_timeout-panel_example-panel-with-timeout-warning_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8cb52531d1d281043cf0541c3c8d2a5b93bbc00c3d2a60d1244b4949a954c265
-size 13505
+oid sha256:255ba5261f88e83a8fb612ac518ba06379e3d196a20b65f9d17e2b856fe84124
+size 13594

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_correct-errors_example-errors-proto-errors_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_correct-errors_example-errors-proto-errors_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea39f0a98eee3a457373c53fa3f617c4e780175929a3836a6f75b67ff1bd8b1b
-size 217903
+oid sha256:291390e5900a48b072b4db18f65242bd908d598ba60f15df5d1512f6d3ee2cf8
+size 217437

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_correct-errors_example-errors-proto-errors_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_correct-errors_example-errors-proto-errors_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1da0b72c4349be606bcd228331290152c3f9663e5bcae123237b32f7d827e516
-size 193892
+oid sha256:b17455eff9243b53d3c4604c82772feeae5af0a44c1d993c96b1e963464fb454
+size 193663

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_correct-errors_example-errors-proto-errors_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_correct-errors_example-errors-proto-errors_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dec380ba1b93b29b33865c3e0c593d11b4d6bab3c8db08c8d4970e54dadecf7a
-size 206214
+oid sha256:415bffbb66847bcc4118f48653ca9a9008de77a496f0ee521bb194f2d8dbedc2
+size 206209

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_feedback_example-feedback-form-errors_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_feedback_example-feedback-form-errors_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f57c57efa0419afd47c1a83f616395765d25ea9abbaf3c513f83b14a78cce86
-size 94348
+oid sha256:cd2d431a36359e82bc70dcfb6bfa8f6d1f741aef921ac8a5bf47f7d36a4e98b0
+size 94045

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_feedback_example-feedback-form-errors_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_feedback_example-feedback-form-errors_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad11789bc972ca2034f5290047d64ddc10eb9acebe7a45b359a9427d3eb4b69a
-size 83460
+oid sha256:1fce56b76228a59b3f0c5cfacd5e0123ad533d8b53124fa56ffd47da03681d49
+size 83238

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_feedback_example-feedback-form-errors_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_feedback_example-feedback-form-errors_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d88c561f0107a4c1056ab2f5b5283f6f44301f47214d9c580aebdf2f6c539a01
-size 84766
+oid sha256:adac5996306d8f30eaef8d88d45170830a0173108d1ad1b9154df8c6af988596
+size 84711

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_send-a-web-form_example-errors_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_send-a-web-form_example-errors_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a1eedb1760dba38904a864008198ab4bde50fe2fc69200623f9c7c61e9cc24b
-size 127341
+oid sha256:80ff7e3a4dda96649d3930ffbf1d8c013b7c4f5573dd862bb074037a58e4ad4b
+size 127110

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_send-a-web-form_example-errors_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_send-a-web-form_example-errors_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a93cc14689dbefd690837887a76aa82bd379aec896770ab368fb2a181b559b40
-size 113528
+oid sha256:ab6a8f47cc0686a6e3968230c03c187988a53084c614927ec2ef3c5773baa4fd
+size 113298

--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_send-a-web-form_example-errors_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_send-a-web-form_example-errors_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7aa39c8490de47cf8bd9a62cd5a0c0029cbb9d990c0253575f189fb4ef5018b1
-size 111559
+oid sha256:10bdd2a6db5f422676302f9d7256177f24068a5e593fd81768c3ee2edabc0852
+size 111494

--- a/src/scss/objects/_page.scss
+++ b/src/scss/objects/_page.scss
@@ -25,8 +25,9 @@
 }
 
 // Adjust margin-top when .ons-page__main contains .ons-panel--error */
-.ons-page__main:has(.ons-panel--error){
+.ons-breadcrumbs ~ .ons-grid .ons-grid__col .ons-page__main:has(.ons-panel--error){
   margin-top: 1rem; 
+  
 }
 
 .ons-page__body {

--- a/src/scss/objects/_page.scss
+++ b/src/scss/objects/_page.scss
@@ -21,6 +21,12 @@
   @include mq(xxs, m) {
     margin-top: 1.5rem;
   }
+
+}
+
+// Adjust margin-top when .ons-page__main contains .ons-panel--error */
+.ons-page__main:has(.ons-panel--error){
+  margin-top: 1rem; 
 }
 
 .ons-page__body {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #1302

Reduce spacing between the the error panel and the breadcrumbs components when there is an error panel in the main body. Spacing was previously set to 2.5rem between error panels and breadcrumbs, however is now variable. When there is no error panel, the spacing is equal between top and bottom of breadcrumbs to main content (1rem); when there are no breadcrumbs, spacing returns to 2.5rem.

### How to review this PR

Review changes to patterns where there is a error panel. 

- Spacing between breadcrumbs and error panel should be **1rem**. 
- Spacing with error panel without breadcrumbs should be **2.5rem**. 
- Spacing between header and main content without breadcrumbs or error panel should be **2.5rem**.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Project for this PR (Design System) and selected the correct status
- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
