### PR TITLE
Remove form config from base page template

### DIFF
--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -48,6 +48,7 @@ exports[`base page template matches the body block override snapshot 1`] = `
         <script>document.body.className = ((document.body.className) ? document.body.className + ' ons-js-enabled' : 'ons-js-enabled');</script>
         
         Content
+        
 
         <script>
             (function() {
@@ -271,14 +272,13 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
                             </div>
                         </div>
                     
-
-                    
                 </div>
+                
                 
                     
                 
             </div>
-            
+        
         
 
         <script>
@@ -511,12 +511,11 @@ exports[`base page template matches the footer block override snapshot 1`] = `
                             </div>
                         </div>
                     
-
-                    
                 </div>
                 
+                
             </div>
-            
+        
         
 
         <script>
@@ -1310,9 +1309,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
                             </div>
                         </div>
                     
-
-                    Some preFooter content
                 </div>
+                Some preFooter content
                 
                     
                         
@@ -1754,8 +1752,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
                     
                 
             </div>
-            Some bodyEnd content
         
+        Some bodyEnd content
 
         <script>
             (function() {
@@ -1985,14 +1983,13 @@ exports[`base page template matches the meta block override snapshot 1`] = `
                             </div>
                         </div>
                     
-
-                    
                 </div>
+                
                 
                     
                 
             </div>
-            
+        
         
 
         <script>
@@ -2209,14 +2206,13 @@ exports[`base page template matches the social block override snapshot 1`] = `
                             </div>
                         </div>
                     
-
-                    
                 </div>
+                
                 
                     
                 
             </div>
-            
+        
         
 
         <script>

--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -72,6 +72,7 @@ exports[`base page template matches the body block override snapshot 1`] = `
 
         
     
+
 </body></html>"
 `;
 
@@ -117,7 +118,6 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
         
             <div class="ons-page">
                 <div class="ons-page__content">
-                    
                     
                     
                         
@@ -275,7 +275,6 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
                     
                 </div>
                 
-                
                     
                 
             </div>
@@ -305,6 +304,7 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
 
         
     
+
 </body></html>"
 `;
 
@@ -360,7 +360,6 @@ exports[`base page template matches the footer block override snapshot 1`] = `
                 <div class="ons-page__content">
                     
                     
-                    
                         
  
     <a class="ons-skip-to-content" href="#main-content">Skip to main content</a>
@@ -516,7 +515,6 @@ exports[`base page template matches the footer block override snapshot 1`] = `
                     
                 </div>
                 
-                
             </div>
             
         
@@ -544,6 +542,7 @@ exports[`base page template matches the footer block override snapshot 1`] = `
 
         
     
+
 </body></html>"
 `;
 
@@ -622,9 +621,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         
             <div class="ons-page">
                 <div class="ons-page__content">
-                    
-                        <form class="form-class" method="POST" autocomplete="off" novalidate="null">
-                    
                     Some preHeader content
                     
                         
@@ -1315,11 +1311,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
                         </div>
                     
 
-                    
-                        </form>
-                    
+                    Some preFooter content
                 </div>
-                Some preFooter content
                 
                     
                         
@@ -1787,6 +1780,7 @@ exports[`base page template matches the full configuration snapshot 1`] = `
 
         <script src="random-script.js"></script>
     
+
 </body></html>"
 `;
 
@@ -1840,7 +1834,6 @@ exports[`base page template matches the meta block override snapshot 1`] = `
                 <div class="ons-page__content">
                     
                     
-                    
                         
  
     <a class="ons-skip-to-content" href="#main-content">Skip to main content</a>
@@ -1996,7 +1989,6 @@ exports[`base page template matches the meta block override snapshot 1`] = `
                     
                 </div>
                 
-                
                     
                 
             </div>
@@ -2026,6 +2018,7 @@ exports[`base page template matches the meta block override snapshot 1`] = `
 
         
     
+
 </body></html>"
 `;
 
@@ -2065,7 +2058,6 @@ exports[`base page template matches the social block override snapshot 1`] = `
                 <div class="ons-page__content">
                     
                     
-                    
                         
  
     <a class="ons-skip-to-content" href="#main-content">Skip to main content</a>
@@ -2221,7 +2213,6 @@ exports[`base page template matches the social block override snapshot 1`] = `
                     
                 </div>
                 
-                
                     
                 
             </div>
@@ -2251,5 +2242,6 @@ exports[`base page template matches the social block override snapshot 1`] = `
 
         
     
+
 </body></html>"
 `;

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -130,11 +130,11 @@
                     {% block preHeader %}{% endblock %}
                     {% block skipLink %}
                         {{
-                        onsSkipToContent({
-                            "url": "#main-content",
-                            "text": "Skip to main content"
-                        })
-                    }}
+                            onsSkipToContent({
+                                "url": "#main-content",
+                                "text": "Skip to main content"
+                            })
+                        }}
                     {% endblock %}
                     {% block header %}
                         {{

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -185,9 +185,8 @@
                             </div>
                         </div>
                     {% endblock %}
-
-                    {% block preFooter %}{% endblock %}
                 </div>
+                {% block preFooter %}{% endblock %}
                 {% block footer %}
                     {% if pageConfig.footer %}
                         {{
@@ -212,8 +211,8 @@
                     {% endif %}
                 {% endblock %}
             </div>
-            {% block bodyEnd %}{% endblock %}
         {% endblock %}
+        {% block bodyEnd %}{% endblock %}
 
         <script{% if pageConfig.cspNonce %} nonce="{{ pageConfig.cspNonce }}"{% elif pageConfig.cspNonce is not defined and csp_nonce %} nonce="{{ csp_nonce() }}"{% endif %}>
             (function() {

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -127,13 +127,6 @@
         {% block body %}
             <div class="ons-page">
                 <div class="ons-page__content">
-                    {% if form and form.attributes %}
-                        <form
-                            {% if form.classes %}class="{{ form.classes }}"{% endif %}
-                            method="{{ form.method | default('POST') }}"
-                            {% if form.attributes %}{% for attribute, value in (form.attributes.items() if form.attributes is mapping and form.attributes.items else form.attributes) %}{{ attribute }}{% if value %}="{{value}}" {% endif %}{% endfor %}{% endif %}
-                        >
-                    {% endif %}
                     {% block preHeader %}{% endblock %}
                     {% block skipLink %}
                         {{
@@ -193,11 +186,8 @@
                         </div>
                     {% endblock %}
 
-                    {% if form and form.attributes %}
-                        </form>
-                    {% endif %}
+                    {% block preFooter %}{% endblock %}
                 </div>
-                {% block preFooter %}{% endblock %}
                 {% block footer %}
                     {% if pageConfig.footer %}
                         {{


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

This removes the form config from the page template as this is seen as specific code added originally for eQ and therefore should be moved into eQ. I have also moved the preFooter block slightly so that it mirrors the preHeader block and is now inside the page content div.

###BREAKING CHANGES###
- This PR removes the form element from the page template. If a form is needed on the page this will now need to be set in the service itself using the `bodyStart` and `bodyEnd` blocks to wrap the page content
- This PR moves the `bodyEnd` block on the page template to outside of the `body` block

### How to review this PR

- Tests pass
- DS can be spun up locally and checking a few patterns you can see that the pages are still displayed as expected

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Project for this PR (Design System) and selected the correct status
- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
