### PR TITLE
Change widths of components inside card to be their contents width

### DIFF
--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -13,14 +13,6 @@
     }
   } 
 
-  &__image--reorder {
-    order: 1;
-  }
-
-  &__title--reorder {
-    order: 2;
-  }
-
   &__link:hover {
     text-decoration-thickness: 3px;
   }

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -7,11 +7,11 @@
     flex-direction: column;
     margin-bottom: 1rem;
     width: fit-content;
-  }
 
-  &__remove--margin {
-    margin-bottom: 0;
-  }
+    & > .ons-card__title {
+      margin-bottom: 0;
+    }
+  } 
 
   &__image--reorder {
     order: 1;

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -5,6 +5,12 @@
   &__link {
     display: flex;
     flex-direction: column;
+    margin-bottom: 1rem;
+    width: fit-content;
+  }
+
+  &__remove--margin {
+    margin-bottom: 0;
   }
 
   &__image--reorder {

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -10,7 +10,7 @@
       {%- if params.url -%}
         <a href="{{ params.url }}" class="ons-card__link">
       {%- endif -%}
-          <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}}" id="{{ params.id }}">
+          <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}} ons-card__remove--margin" id="{{ params.id }}">
               {{ params.title }}
           </h{{ titleSize }}>
           {% if params.image.smallSrc %}
@@ -24,15 +24,15 @@
 
     {%- else -%}
 
-      <h{{ titleSize }} class="ons-card__title {{ params.titleClasses | default('ons-u-fs-m') }}" id="{{ params.id }}">
-        {%- if params.url -%}
-          <a class="ons-card__link" href="{{ params.url }}">
-        {%- endif -%}
+      {%- if params.url -%}
+        <a class="ons-card__link" href="{{ params.url }}">
+      {%- endif -%}
+        <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}} ons-card__remove--margin" id="{{ params.id }}">
           {{ params.title }}
-        {%- if params.url -%}
-          </a>
-        {%- endif -%}
-      </h{{ titleSize }}>
+        </h{{ titleSize }}>
+      {%- if params.url -%}
+        </a>
+      {%- endif -%}
 
     {%- endif -%}
 

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -5,23 +5,18 @@
   {% set titleSize = params.titleSize | default('2') %}
 
   <div class="ons-card">
-
-      {%- if params.url -%}
-        <a href="{{ params.url }}" class="ons-card__link">
+    <a href="{{ params.url }}" class="ons-card__link">
+      <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}}" id="{{ params.id }}">
+          {{ params.title }}
+      </h{{ titleSize }}>
+      {%- if params.image -%}
+        {% if params.image.smallSrc %}
+          <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="200" width="303"{% if params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
+        {% elif params.image == true or params.image.placeholderURL %}
+          <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
+        {% endif %}
       {%- endif -%}
-          <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}}" id="{{ params.id }}">
-              {{ params.title }}
-          </h{{ titleSize }}>
-          {%- if params.image -%}
-            {% if params.image.smallSrc %}
-              <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="200" width="303"{% if params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
-            {% elif params.image == true or params.image.placeholderURL %}
-              <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
-            {% endif %}
-          {%- endif -%}
-      {%- if params.url -%}
-        </a>
-      {%- endif -%}
+    </a>
 
     <p id="{{ params.textId }}">{{ params.text }}</p>
 

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -6,16 +6,16 @@
 
   <div class="ons-card">
     <a href="{{ params.url }}" class="ons-card__link">
-      <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}}" id="{{ params.id }}">
-          {{ params.title }}
-      </h{{ titleSize }}>
       {%- if params.image -%}
         {% if params.image.smallSrc %}
-          <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="200" width="303"{% if params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
+          <img class="ons-card__image ons-u-mb-s" height="200" width="303"{% if params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
         {% elif params.image == true or params.image.placeholderURL %}
-          <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
+          <img class="ons-card__image ons-u-mb-s " height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
         {% endif %}
       {%- endif -%}
+      <h{{ titleSize }} class="ons-card__title {{ params.titleClasses | default('ons-u-fs-m')}}" id="{{ params.id }}">
+          {{ params.title }}
+      </h{{ titleSize }}>
     </a>
 
     <p id="{{ params.textId }}">{{ params.text }}</p>

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -6,35 +6,22 @@
 
   <div class="ons-card">
 
-    {%- if params.image -%}
       {%- if params.url -%}
         <a href="{{ params.url }}" class="ons-card__link">
       {%- endif -%}
-          <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}} ons-card__remove--margin" id="{{ params.id }}">
+          <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}}" id="{{ params.id }}">
               {{ params.title }}
           </h{{ titleSize }}>
-          {% if params.image.smallSrc %}
-            <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="200" width="303"{% if params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
-          {% elif params.image == true or params.image.placeholderURL %}
-            <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
-          {% endif %}
+          {%- if params.image -%}
+            {% if params.image.smallSrc %}
+              <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="200" width="303"{% if params.image.largeSrc %} srcset="{{ params.image.smallSrc }} 1x, {{ params.image.largeSrc }} 2x"{% endif %} src="{{ params.image.smallSrc }}" alt="{{ params.image.alt }}" loading="lazy">
+            {% elif params.image == true or params.image.placeholderURL %}
+              <img class="ons-card__image ons-u-mb-s ons-card__image--reorder" height="100" width="303" srcset="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png 1x, {{ params.image.placeholderURL if params.image.placeholderURL }}/img/large/placeholder-card.png 2x" src="{{ params.image.placeholderURL if params.image.placeholderURL }}/img/small/placeholder-card.png" alt="" loading="lazy">
+            {% endif %}
+          {%- endif -%}
       {%- if params.url -%}
         </a>
       {%- endif -%}
-
-    {%- else -%}
-
-      {%- if params.url -%}
-        <a class="ons-card__link" href="{{ params.url }}">
-      {%- endif -%}
-        <h{{ titleSize }} class="ons-card__title ons-card__title--reorder {{ params.titleClasses | default('ons-u-fs-m')}} ons-card__remove--margin" id="{{ params.id }}">
-          {{ params.title }}
-        </h{{ titleSize }}>
-      {%- if params.url -%}
-        </a>
-      {%- endif -%}
-
-    {%- endif -%}
 
     <p id="{{ params.textId }}">{{ params.text }}</p>
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #2818

Issue was within the card component. Previously, card's components would scale to the width of the whole card, but now scale to just their contents. Additionally, incorrect margin's were being applied to headings within the card, so removing that bring design back in line with other components when tabbing. 

### How to review this PR

Pressing tab on the card components should reveal new boundaries for focussed states within the card.

Before and After for components changed when focussed:

![Screenshot 2023-10-05 at 10 52 07](https://github.com/ONSdigital/design-system/assets/56112669/38d8bfd0-7568-46b0-86e1-19e48cc9f2c7)
![Screenshot 2023-10-05 at 10 53 29](https://github.com/ONSdigital/design-system/assets/56112669/8024a79e-5a48-40c4-b0b1-b07bde7800e9)

![Screenshot 2023-10-05 at 10 52 22](https://github.com/ONSdigital/design-system/assets/56112669/1e8ae1d4-27a3-415f-a4f2-2aa6e8c08c78)
![Screenshot 2023-10-05 at 10 53 42](https://github.com/ONSdigital/design-system/assets/56112669/0fd776ca-dca1-4350-a417-fd3abf433287)


### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Project for this PR (Design System) and selected the correct status
- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
