### PR TITLE
Improve the path of issues replace project setting with workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,8 +1,7 @@
 name: Bug Report
 description: File a bug report
 title: "[Bug]: "
-labels: ["Bug", "Triage"]
-projects: ["ONS Design System project", "ONS Design Team community backlog"]
+labels: ["Bug", "Community backlog"]
 assignees: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,8 +1,7 @@
 name: New feature proposal
 description: Propose a new component, pattern, foundation or documentation to add to the ONS Design System
 title: "[Feature]: "
-labels: ["New feature proposal", "Triage"]
-projects: ["ONS Design System project", "ONS Design Team community backlog"]
+labels: ["New feature proposal", "Community backlog"]
 assignees: []
 body:
   - type: markdown


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

This is a follow up PR to #2851 and part of the fix for #2797. This change removes the setting of projects, instead I have set up a workflow to automatically add the issues in the github project. This also adds the "Community backlog" label so that issues are added to that part of the board too.

### How to review this PR

- check project board workflow looks correct
- check changes in this PR look correct
- create a test issue and see that it gets added to the board
- delete test issue

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [ ] I have selected the correct Project for this PR (Design System) and selected the correct status
- [ ] I have selected the correct Assignee
- [ ] I have linked the correct Issue
