### PR TITLE
Inconsistent key names for same properties#723

### DIFF
--- a/src/components/navigation/_macro.spec.js
+++ b/src/components/navigation/_macro.spec.js
@@ -13,14 +13,14 @@ const PARAMS = {
   currentPageTitle: 'main nav item 2',
   itemsList: [
     {
-      title: 'Main nav item 1',
+      text: 'Main nav item 1',
       ariaLabel: 'Main nav ariaLabel 1',
       url: '#0',
       classes: 'custom-class-main-item-1',
       id: 'main-item-1',
     },
     {
-      title: 'Main nav item 2',
+      text: 'Main nav item 2',
       ariaLabel: 'Main nav ariaLabel 2',
       url: '#1',
       classes: 'custom-class-main-item-2',
@@ -34,14 +34,14 @@ const PARAMS = {
     ariaLabel: 'Section menu',
     itemsList: [
       {
-        title: 'Sub nav item 1',
+        text: 'Sub nav item 1',
         ariaLabel: 'Sub nav ariaLabel 1',
         url: '/sub-item-1',
         classes: 'custom-class-sub-item-1',
         id: 'sub-item-1',
       },
       {
-        title: 'Sub nav item 2',
+        text: 'Sub nav item 2',
         ariaLabel: 'Sub nav ariaLabel 2',
         url: '/sub-item-2',
         classes: 'custom-class-sub-item-2',
@@ -51,13 +51,13 @@ const PARAMS = {
             sectionTitle: 'Section 1',
             children: [
               {
-                title: 'Child item 1',
+                text: 'Child item 1',
                 ariaLabel: 'Child item ariaLabel 1',
                 url: '/sub-item-2/child-item-1',
                 id: 'child-item-1',
               },
               {
-                title: 'Child item 2',
+                text: 'Child item 2',
                 ariaLabel: 'Child item ariaLabel 2',
                 url: '/sub-item-2/child-item-2',
                 id: 'child-item-2',

--- a/src/components/navigation/navigation.spec.js
+++ b/src/components/navigation/navigation.spec.js
@@ -8,13 +8,13 @@ const EXAMPLE_NAVIGATION = {
     currentPath: '#0',
     itemsList: [
       {
-        title: 'Main nav item 1',
+        text: 'Main nav item 1',
         url: '#0',
         classes: 'custom-class-main-item-1',
         id: 'main-item-1',
       },
       {
-        title: 'Main nav item 2',
+        text: 'Main nav item 2',
         url: '#1',
         classes: 'custom-class-main-item-2',
         id: 'main-item-2',
@@ -35,13 +35,13 @@ const EXAMPLE_NAVIGATION_WITH_SUBNAVIGATION = {
     currentPageTitle: 'Main nav item 2',
     itemsList: [
       {
-        title: 'Main nav item 1',
+        text: 'Main nav item 1',
         url: '#0',
         classes: 'custom-class-main-item-1',
         id: 'main-item-1',
       },
       {
-        title: 'Main nav item 2',
+        text: 'Main nav item 2',
         url: '#1',
         classes: 'custom-class-main-item-2',
         id: 'main-item-2',
@@ -55,13 +55,13 @@ const EXAMPLE_NAVIGATION_WITH_SUBNAVIGATION = {
       currentPath: '#1',
       itemsList: [
         {
-          title: 'Sub nav item 1',
+          text: 'Sub nav item 1',
           url: '#0',
           classes: 'custom-class-sub-item-1',
           id: 'sub-item-1',
         },
         {
-          title: 'Sub nav item 2',
+          text: 'Sub nav item 2',
           url: '#1',
           classes: 'custom-class-sub-item-2',
           id: 'sub-item-2',
@@ -70,11 +70,11 @@ const EXAMPLE_NAVIGATION_WITH_SUBNAVIGATION = {
               sectionTitle: 'Section 1',
               children: [
                 {
-                  title: 'Child item 1',
+                  text: 'Child item 1',
                   url: '#0',
                 },
                 {
-                  title: 'Child item 2',
+                  text: 'Child item 2',
                   url: '#1',
                 },
               ],

--- a/src/components/section-navigation/_macro.spec.js
+++ b/src/components/section-navigation/_macro.spec.js
@@ -11,11 +11,11 @@ const EXAMPLE_SECTION_NAVIGATION = {
   currentPath: '/results',
   itemsList: [
     {
-      title: 'Results',
+      text: 'Results',
       url: '/results',
     },
     {
-      title: 'Dashboard',
+      text: 'Dashboard',
       url: '/results/dashboard',
     },
   ],
@@ -26,29 +26,29 @@ const EXAMPLE_SECTION_NAVIGATION_VERTICAL = {
   currentPath: '#section-2',
   itemsList: [
     {
-      title: 'Section 1',
+      text: 'Section 1',
       url: '#section-1',
     },
     {
-      title: 'Section 2',
+      text: 'Section 2',
       url: '#section-2',
       anchors: [
         {
-          title: 'Sub section 1',
+          text: 'Sub section 1',
           url: '#sub-section-1',
         },
         {
-          title: 'Sub section 2',
+          text: 'Sub section 2',
           url: '#sub-section-2',
         },
         {
-          title: 'Sub section 3',
+          text: 'Sub section 3',
           url: '#sub-section-3',
         },
       ],
     },
     {
-      title: 'Section 3',
+      text: 'Section 3',
       url: '#0',
     },
   ],
@@ -62,29 +62,29 @@ const EXAMPLE_SECTION_NAVIGATION_VERTICAL_WITH_SECTIONS = {
       title: 'Section Title',
       itemsList: [
         {
-          title: 'Section 1',
+          text: 'Section 1',
           url: '#section-1',
         },
         {
-          title: 'Section 2',
+          text: 'Section 2',
           url: '#section-2',
           anchors: [
             {
-              title: 'Sub section 1',
+              text: 'Sub section 1',
               url: '#sub-section-1',
             },
             {
-              title: 'Sub section 2',
+              text: 'Sub section 2',
               url: '#sub-section-2',
             },
             {
-              title: 'Sub section 3',
+              text: 'Sub section 3',
               url: '#sub-section-3',
             },
           ],
         },
         {
-          title: 'Section 3',
+          text: 'Section 3',
           url: '#0',
         },
       ],

--- a/src/components/section-navigation/_macro.spec.js
+++ b/src/components/section-navigation/_macro.spec.js
@@ -11,11 +11,11 @@ const EXAMPLE_SECTION_NAVIGATION = {
   currentPath: '/results',
   itemsList: [
     {
-      text: 'Results',
+      title: 'Results',
       url: '/results',
     },
     {
-      text: 'Dashboard',
+      title: 'Dashboard',
       url: '/results/dashboard',
     },
   ],
@@ -26,29 +26,29 @@ const EXAMPLE_SECTION_NAVIGATION_VERTICAL = {
   currentPath: '#section-2',
   itemsList: [
     {
-      text: 'Section 1',
+      title: 'Section 1',
       url: '#section-1',
     },
     {
-      text: 'Section 2',
+      title: 'Section 2',
       url: '#section-2',
       anchors: [
         {
-          text: 'Sub section 1',
+          title: 'Sub section 1',
           url: '#sub-section-1',
         },
         {
-          text: 'Sub section 2',
+          title: 'Sub section 2',
           url: '#sub-section-2',
         },
         {
-          text: 'Sub section 3',
+          title: 'Sub section 3',
           url: '#sub-section-3',
         },
       ],
     },
     {
-      text: 'Section 3',
+      title: 'Section 3',
       url: '#0',
     },
   ],
@@ -62,29 +62,29 @@ const EXAMPLE_SECTION_NAVIGATION_VERTICAL_WITH_SECTIONS = {
       title: 'Section Title',
       itemsList: [
         {
-          text: 'Section 1',
+          title: 'Section 1',
           url: '#section-1',
         },
         {
-          text: 'Section 2',
+          title: 'Section 2',
           url: '#section-2',
           anchors: [
             {
-              text: 'Sub section 1',
+              title: 'Sub section 1',
               url: '#sub-section-1',
             },
             {
-              text: 'Sub section 2',
+              title: 'Sub section 2',
               url: '#sub-section-2',
             },
             {
-              text: 'Sub section 3',
+              title: 'Sub section 3',
               url: '#sub-section-3',
             },
           ],
         },
         {
-          text: 'Section 3',
+          title: 'Section 3',
           url: '#0',
         },
       ],

--- a/src/components/section-navigation/example-section-navigation-vertical.njk
+++ b/src/components/section-navigation/example-section-navigation-vertical.njk
@@ -9,7 +9,7 @@
                 "title": "Section Title",
                 "itemsList": [
                     {
-                        "title": "Section 1",
+                        "text": "Section 1",
                         "url": "#section-1",
                         "anchors": [
                             {

--- a/src/components/section-navigation/example-section-navigation-vertical.njk
+++ b/src/components/section-navigation/example-section-navigation-vertical.njk
@@ -13,29 +13,29 @@
                         "url": "#section-1",
                         "anchors": [
                             {
-                                "title": "Sub section 1",
+                                "text": "Sub section 1",
                                 "url": "#sub-section-1"
                             },
                             {
-                                "title": "Sub section 2",
+                                "text": "Sub section 2",
                                 "url": "#sub-section-2"
                             },
                             {
-                                "title": "Sub section 3",
+                                "text": "Sub section 3",
                                 "url": "#sub-section-3"
                             }
                         ]
                     },
                     {
-                        "title": "Section 2",
+                        "text": "Section 2",
                         "url": "#section-2"
                     },
                     {
-                        "title": "Section 3",
+                        "text": "Section 3",
                         "url": "#section-3"
                     },
                     {
-                        "title": "Section 4",
+                        "text": "Section 4",
                         "url": "#section-4"
                     }
                 ]
@@ -44,33 +44,33 @@
                 "title": "Section Title",
                 "itemsList": [
                     {
-                        "title": "Section 5",
+                        "text": "Section 5",
                         "url": "#section-5"
                     },
                     {
-                        "title": "Section 6",
+                        "text": "Section 6",
                         "url": "#section-6",
                         "anchors": [
                             {
-                                "title": "Sub section 1",
+                                "text": "Sub section 1",
                                 "url": "#sub-section-1"
                             },
                             {
-                                "title": "Sub section 2",
+                                "text": "Sub section 2",
                                 "url": "#sub-section-2"
                             },
                             {
-                                "title": "Sub section 3",
+                                "text": "Sub section 3",
                                 "url": "#sub-section-3"
                             }
                         ]
                     },
                     {
-                        "title": "Section 7",
+                        "text": "Section 7",
                         "url": "#0"
                     },
                     {
-                        "title": "Section 8",
+                        "text": "Section 8",
                         "url": "#0"
                     }
                 ]

--- a/src/components/section-navigation/example-section-navigation.njk
+++ b/src/components/section-navigation/example-section-navigation.njk
@@ -5,15 +5,15 @@
         "currentPath": "#section-1",
         "itemsList": [
             {
-                "title": "Section 1",
+                "text": "Section 1",
                 "url": "#section-1"
             },
             {
-                "title": "Section 2",
+                "text": "Section 2",
                 "url": "#0"
             },
             {
-                "title": "Section 3",
+                "text": "Section 3",
                 "url": "#0"
             }
         ]


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

This PR updates to a consistent naming convention in some of the components. All the keys are updated to `text` from `title`

### How to review this PR

Check that the components that uses some text and a href keys are defined as `text` and `url`

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue

