### PR TITLE
Fix/2995/bug misalignment of summary values with long strings during resizing

### DIFF
--- a/src/components/summary/_summary.scss
+++ b/src/components/summary/_summary.scss
@@ -178,10 +178,10 @@ $hub-row-spacing: 1.3rem;
     &__item-title,
     &__values,
     &__actions {
+      overflow: auto;
       flex: 5 1 33%;
       padding-top: $summary-row-spacing;
       vertical-align: top;
-
       &:not(:last-child) {
         padding-right: $summary-col-spacing;
       }

--- a/src/components/summary/example-summary.njk
+++ b/src/components/summary/example-summary.njk
@@ -85,7 +85,7 @@
                                         "id": "sales-detail",
                                         "valueList": [
                                             {
-                                                "text": "alessio.venturini@ext.ons.gov.uk"
+                                                "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
                                             }
                                         ],
                                         "actions": [

--- a/src/components/summary/example-summary.njk
+++ b/src/components/summary/example-summary.njk
@@ -85,7 +85,7 @@
                                         "id": "sales-detail",
                                         "valueList": [
                                             {
-                                                "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                                                "text": "alessio.venturini@ext.ons.gov.uk"
                                             }
                                         ],
                                         "actions": [


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes:#2995

I have added an overflow auto to the summary title , values and actions to push very long strings to wrap to the next line when moving to a smaller viewport. 

### How to review this PR

Pull this branch and edit one of the summary examples values with a very long string. Test that on resize the string breaks to the next line and all the columns keep their width. 

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
