### PR TITLE
Update eslint config to include unused imports and indenting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "@babel/eslint-parser",
-  "plugins": ["prettier"],
+  "plugins": ["prettier", "unused-imports"],
   "extends": ["prettier"],
   "env": {
     "es6": true,
@@ -24,6 +24,17 @@
     "one-var": [0],
     "max-len": [0, { "code": 140, "ignoreUrls": true }],
     "comma-dangle": ["error", "always-multiline"],
-    "arrow-parens": 1
+    "arrow-parens": 1,
+    "indent": ["error", 2],
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-cli": "^1.1.1",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-unused-imports": "^3.1.0",
     "express": "^4.17.1",
     "front-matter": "^4.0.2",
     "fs-extra": "^11.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4413,6 +4413,18 @@ eslint-plugin-prettier@^5.0.0:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.8.5"
 
+eslint-plugin-unused-imports@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.1.0.tgz#db015b569d3774e17a482388c95c17bd303bc602"
+  integrity sha512-9l1YFCzXKkw1qtAru1RWUtG2EVDZY0a0eChKXcL+EZ5jitG7qxdctu4RnvhOJHv4xfmUf7h+JJPINlVpGhZMrw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Updates the eslint config to automatically fix indenting and unused imports for .js files.

This sets the indenting for js files at 2 spaces just because thats what we have currently. We use 4 spaces for other files such as the nunjucks ones. We should have a discussion before this is merged to decide on what we think is the right level of indenting. Personally I prefer 4 spaces as I think it is more readable.

### How to review this PR

- Checkout this PR
- Make some changes to a js file which includes making indenting errors and adding imports in that aren't being used
- Create a new branch from this one with the changes and try committing
- See that the indenting and imports are automatically fixed 

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [ ] I have selected the correct Assignee
- [ ] I have linked the correct Issue
