### PR TITLE
Update setup-node to use Node 20 in actions

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
       - name: Install dependencies

--- a/.github/workflows/macro-and-script-tests.yml
+++ b/.github/workflows/macro-and-script-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
       - name: Install dependencies

--- a/.github/workflows/npm-bundle.yml
+++ b/.github/workflows/npm-bundle.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: ${{ github.event.release.target_commitish }}
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
       - name: Install dependencies


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3051 

Updates the DS github actions to use setup-node v4 so that it uses Node 20 for actions.

### How to review this PR

All actions pass and when going into the action summary there is no warning in the annotations section.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
