### PR TITLE
alters the padding on autosuggest items to mattch input

### DIFF
--- a/src/components/autosuggest/_autosuggest.scss
+++ b/src/components/autosuggest/_autosuggest.scss
@@ -45,7 +45,7 @@
     cursor: pointer;
     margin: 0;
     outline: none;
-    padding: $input-padding-horizontal;
+    padding: $input-padding-vertical $input-padding-horizontal;
 
     &:not(:last-child) {
       border-bottom: 1px solid var(--ons-color-input-border);


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Changed the padding for items in list for auto suggest to match the search item.

Fixes: https://github.com/ONSdigital/design-system/issues/3058 

### How to review this PR

Spin it up and go to the autosuggest component, type something and have a look!

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
