### PR TITLE
Fixed misalignment of circle inside radio input

### DIFF
--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -11,7 +11,6 @@
     &::after {
       display: none;
     }
-    &:focus,
     &:checked {
       background-color: var(--ons-color-input-border);
     }

--- a/src/components/radios/_radio.scss
+++ b/src/components/radios/_radio.scss
@@ -9,15 +9,11 @@
     box-shadow: inset 0 0 0 3px var(--ons-color-input-bg);
 
     &::after {
+      display: none;
+    }
+    &:focus,
+    &:checked {
       background-color: var(--ons-color-input-border);
-      border-radius: 50%;
-      border-width: 0;
-      height: 12px;
-      left: 50%;
-      margin-left: -6px;
-      margin-top: -6px;
-      top: 50%;
-      width: 12px;
     }
   }
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

This fixes : #3133 

I have changed the way the circle inside the radio input is populated by removing the current after pseudo element and changing the background colour of the input itself to black on click or focus. This will fix the issue of misalignment. 
I have tried changing the positioning of the after element but it did get out of alignment at different zoom levels (90% and below and between 125% and 150%).

### How to review this PR

Open the netlify preview and check all the radios example. Confirm that the inside circle remain centered at every zoom level. 

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
