### PR TITLE
Ignore build files from Jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ const config = {
   verbose: true,
   preset: process.env.TEST_WITH_PUPPETEER ? 'jest-puppeteer' : undefined,
   snapshotResolver: `${process.cwd()}/src/tests/helpers/snapshotResolver.js`,
+  modulePathIgnorePatterns: ['templates/components', 'build'],
 };
 
 module.exports = config;


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #2941

If build files are present in your local repo after running `yarn cdn-bundle` command running `yarn test` will have some failing tests which fail on some JS imports. This is down to the files in the build directory also being run by jest but because these files are copies of the actual ones we want to run. But because these copies are in a different directory and the imports are using relative paths these paths no longer work so the tests fail.

This PR changes the Jest config so that those files in the build and templates folders are ignored by Jest, we don't want to run the tests in these folders as we would be running the same tests twice.

### How to review this PR

- Run `yarn test` on the main branch check that tests pass
- Run `RELEASE_VERSION=70.0.4 yarn cdn-bundle` to create the cdn bundle files in your local repo
- Run `yarn build` to create the build files in your local repo
- Run `yarn test` on the main branch and see that the tests now fail
- Switch to this branch and run `yarn test` again to see that the files in the build folders are now ignored and the tests pass

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
