### PR TITLE
Revert to using macOS 12 for VR tests

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   run-visual-regression-tests:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3159

Github seems to have recently updated their `macos-latest` runner to use macOS 14 (as explained here April 24 - https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/). These runners use the new Apple silicon CPUs which are currently incompatible with running colima (https://github.com/abiosoft/colima/issues/970) which is what we use to run our VR tests.

This PR specifies that we use macOS 12 rather than "Latest".

### How to review this PR

- Check the VR tests on another PR see the colima error
- See that the VR tests run and pass on this PR

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
