### PR TITLE
Add hidden context for icons in rows for summary tables

### DIFF
--- a/backstop_data/bitmaps_reference/ds-vr-test__components_summary_example-summary-hub-minimal_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_summary_example-summary-hub-minimal_0_document_0_desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59ac148264c529103d70c6fb6a327a0c14e1bd88bad0254b1a8c225ca01cae5b
+size 29219

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_summary_example-summary-hub-minimal_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_summary_example-summary-hub-minimal_0_document_1_tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7b572c7a3cb42ff1c56d7372fadbbc170fdb3b54c5ea5846dc161faefb26993
+size 23265

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_summary_example-summary-hub-minimal_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_summary_example-summary-hub-minimal_0_document_2_mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31a03471295fb153a633609a79f1dcfdd5337216d17d3b81fd3894222a2db447
+size 19909

--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -34,15 +34,16 @@
 
 ## SummaryRowItem
 
-| Name               | Type                   | Required | Description                                                                                 |
-| ------------------ | ---------------------- | -------- | ------------------------------------------------------------------------------------------- |
-| id                 | string                 | false    | The HTML `id` of the row item                                                               |
-| iconType           | string                 | false    | Adds an icon before the row title, by setting the [icon type](/foundations/icons#icon-type) |
-| rowTitle           | string                 | false    | The title for the row item                                                                  |
-| rowTitleAttributes | object                 | false    | HTML attributes (for example, data attributes) to add to the rowTitle                       |
-| valueList          | Array`<SummaryValue>`  | false    | An array of [value(s)](#summaryvalue) for the row item                                      |
-| actions            | Array`<SummaryAction>` | false    | Settings for the row [action links](#summaryaction)                                         |
-| attributes         | object                 | false    | HTML attributes (for example, data attributes) to add to the row item                       |
+| Name                   | Type                   | Required | Description                                                                                 |
+| ---------------------- | ---------------------- | -------- | ------------------------------------------------------------------------------------------- |
+| id                     | string                 | false    | The HTML `id` of the row item                                                               |
+| iconType               | string                 | false    | Adds an icon before the row title, by setting the [icon type](/foundations/icons#icon-type) |
+| iconVisuallyHiddenText | string                 | false    | Visually hidden text in a span under the icon to add more context for screen readers        |
+| rowTitle               | string                 | false    | The title for the row item                                                                  |
+| rowTitleAttributes     | object                 | false    | HTML attributes (for example, data attributes) to add to the rowTitle                       |
+| valueList              | Array`<SummaryValue>`  | false    | An array of [value(s)](#summaryvalue) for the row item                                      |
+| actions                | Array`<SummaryAction>` | false    | Settings for the row [action links](#summaryaction)                                         |
+| attributes             | object                 | false    | HTML attributes (for example, data attributes) to add to the row item                       |
 
 ## SummaryValue
 

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -12,7 +12,7 @@
     {% if params.classes %}
          {% set className = className + " " + params.classes %}
     {% endif %}
-    
+
     <div class="{{ className }}">
         {% for summary in params.summaries %}
             {% if summary.summaryTitle %}
@@ -51,6 +51,9 @@
                                                                 "iconType": rowItem.iconType
                                                             })
                                                         -}}
+                                                        {% if rowItem.iconVisuallyHiddenText %}
+                                                            <span class="ons-u-vh">{{ rowItem.iconVisuallyHiddenText }}</span>
+                                                        {% endif %}
                                                     </span>
                                                 {% endif %}
 

--- a/src/components/summary/_macro.spec.js
+++ b/src/components/summary/_macro.spec.js
@@ -22,6 +22,7 @@ const EXAMPLE_SUMMARY_ROWS = {
             b: 'bbb',
           },
           iconType: 'check',
+          iconVisuallyHiddenText: 'Section completed',
           id: 'item-id-1',
           valueList: [
             {
@@ -430,6 +431,12 @@ describe('macro: summary', () => {
         const $ = cheerio.load(renderComponent('summary', EXAMPLE_SUMMARY_BASIC));
 
         expect($('.ons-summary__item-title-icon').hasClass('ons-summary__item-title-icon--check')).toBe(true);
+      });
+
+      it('has the visually hidden text <span> text when `iconType` is `check`', () => {
+        const $ = cheerio.load(renderComponent('summary', EXAMPLE_SUMMARY_BASIC));
+
+        expect($('.ons-summary__item-title-icon').text().trim()).toBe('Section completed');
       });
 
       it('has the correct item text class when `iconType` is provided', () => {

--- a/src/components/summary/example-summary-hub-minimal.njk
+++ b/src/components/summary/example-summary-hub-minimal.njk
@@ -1,0 +1,75 @@
+{% from "components/summary/_macro.njk" import onsSummary %}
+
+{{ onsSummary({
+    "variant": "hub",
+    "summaries": [
+            {
+                "groups": [
+                    {
+                    "rows": [
+                        {
+                            "rowTitle": "People who live here",
+                            "rowItems": [
+                                {
+                                    "iconType": "check",
+                                    "iconVisuallyHiddenText": "Section complete",
+                                    "actions": [
+                                        {
+                                            "text": "View answers",
+                                            "visuallyHiddenText": "View answers for People who live here",
+                                            "url": "#0"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "rowTitle": "Mary Smith (You)",
+                            "rowItems": [
+                                {
+                                    "iconType": "check",
+                                    "iconVisuallyHiddenText": "Section complete",
+                                    "actions": [
+                                        {
+                                            "text": "View answers",
+                                            "visuallyHiddenText": "View answers for Mary Smith",
+                                            "url": "#0"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "rowTitle": "John Smith",
+                            "rowItems": [
+                                {
+                                    "actions": [
+                                        {
+                                            "text": "Continue with section",
+                                            "visuallyHiddenText": "Continue with John Smith's section",
+                                            "url": "#0"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "rowTitle": "Billy Smith",
+                            "rowItems": [
+                                {
+                                    "actions": [
+                                        {
+                                            "text": "Start section",
+                                            "visuallyHiddenText": "Start Billy Smith's section",
+                                            "url": "#0"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}) }}


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3030

This PR fixes the lack of context in summary tables where there is no status column and only an icon which in the case of the ticket, were checks for completion. Following from the DAC advice, we are now adding a visually hidden `<span>` to the icon's `<div>` to enable adding additional contextual information. This done by setting the `"iconVisuallyHiddenText": {string}` param in `rowItems` adjacent to `"iconType": {icon}`. The service can input the appropriate text to add context to whichever icon is being used. 

Please make sure that this param is set when there is no other context on the row indicating section completion status (see the new minimal example).

### How to review this PR

Check the new example-minimal for the summary table and see if the new span tag with section completed is there. Sense check the output from the screen reader

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue