### PR TITLE
Refactor share-page macro for compatibility Jinja2 templates

### DIFF
--- a/src/components/share-page/_macro.njk
+++ b/src/components/share-page/_macro.njk
@@ -17,8 +17,6 @@
                 "target": '_blank'
             }
          %}
-
-        {% set list = (list.push(facebook), list) %}
     {% endif %}
     {% if params.twitter and params.twitter == true %}
         {% set twitter =
@@ -30,17 +28,13 @@
                 "target": '_blank'
             }
          %}
-
-        {% set list = (list.push(twitter), list) %}
-
     {% endif %}
-
     {{
         onsList({
             "variants": 'inline',
             "iconPosition": 'before',
             "iconSize": params.iconSize | default("xxl"),
-            "itemsList": list
+            "itemsList": [facebook, twitter]
         })
     }}
 {% endmacro %}

--- a/src/components/share-page/_macro.njk
+++ b/src/components/share-page/_macro.njk
@@ -6,7 +6,6 @@
         <{{ titleTag }} class="ons-u-fs-r--b ons-u-mb-xs">{{ params.title }}</{{ titleTag }}>
     {% endif %}
 
-    {% set list = [] %}
     {% if params.facebook and params.facebook == true %}
         {% set facebook =
             {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

#3170... Removed `.push` method which was used for adding facebook and twitter icons to a list. This is done to make share-page work in Jinja templates.

### How to review this PR

- Test the changes in Design system
- Pull the latest PR ([link](https://github.com/ONSdigital/design-system-python-flask-demo/pull/3)) which is in review. Follow the updated readme.
- Update the macro and test it in Flask.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
