### PR TITLE
Update VSCode Extensions links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ yarn build
 ## Recommended Visual Studio Code plugins for this project
 
 - [axe Accessibility Linter](https://marketplace.visualstudio.com/items?itemName=deque-systems.vscode-axe-linter)
-- [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
+- [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [Nunjucks](https://marketplace.visualstudio.com/items?itemName=ronnidc.nunjucks)
 - [Prettier - Code Formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)

--- a/README.md
+++ b/README.md
@@ -146,13 +146,15 @@ yarn build
 
 ## Recommended Visual Studio Code plugins for this project
 
-- [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
+- [axe Accessibility Linter](https://marketplace.visualstudio.com/items?itemName=deque-systems.vscode-axe-linter)
+- [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 - [Nunjucks](https://marketplace.visualstudio.com/items?itemName=ronnidc.nunjucks)
 - [Prettier - Code Formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-- [Sass](https://marketplace.visualstudio.com/items?itemName=robinbentley.sass-indented)
+- [remark](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-remark)
+- [SonarLint](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode)
+- [Sass](https://marketplace.visualstudio.com/items?itemName=Syler.sass-indented)
 - [Stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
-- [vscode-remark-lint](https://marketplace.visualstudio.com/items?itemName=drewbourne.vscode-remark-lint)
 
 ## Recommended Visual Studio Code settings for this project
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Generate a build into `./build`.
 yarn build
 ```
 
-## Recommended Visual Studio Code plugins for this project
+## Recommended Visual Studio Code Extensions for this project
 
 - [axe Accessibility Linter](https://marketplace.visualstudio.com/items?itemName=deque-systems.vscode-axe-linter)
 - [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3185

Updates the VSCode Extension links in the readme and adds "axe Accessibility Linter" and "SonarLint".
Also updates the title because these are now called Extensions.

### How to review this PR

- Check links work, make sense and go to the correct VSCode Extensions
- Ideally these should be installed in all our IDEs

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
