### PR TITLE
Allow "Breaking changes" label alongside other labels on PRs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,6 +13,7 @@ changelog:
     - title: Enhancements
       labels:
         - Enhancement
+        - CI/CD
     - title: Fixes
       labels:
         - Bug

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -19,6 +19,7 @@ changelog:
     - title: Documentation
       labels:
         - Documentation
+        - Example
     - title: Dependency updates
       labels:
         - Dependencies

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: docker://onsdigital/github-pr-label-checker:latest
         with:
-          one_of: Accessibility,Bug,Documentation,Dependencies,Enhancement,Example,Component,Pattern
+          one_of: Accessibility,Bug,Documentation,Dependencies,Enhancement,Example,Component,Pattern,CI/CD
           none_of: Awaiting resource,Do not merge,Duplicate,Needs validating,Not doing
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -15,8 +15,8 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: docker://onsdigital/github-pr-label-checker:v1.2.7
+      - uses: docker://onsdigital/github-pr-label-checker:latest
         with:
-          one_of: Breaking changes,Accessibility,Bug,Documentation,Dependencies,Enhancement,Example,Component,Pattern
+          one_of: Accessibility,Bug,Documentation,Dependencies,Enhancement,Example,Component,Pattern
           none_of: Awaiting resource,Do not merge,Duplicate,Needs validating,Not doing
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3184

Ive removed the "Breaking changes" label from the `one_of` label checker category this will mean that if the breaking change label is added alongside one of the others the github action wont fail.

I have also updated the label checker to always use the latest version, added the "Example" label to the documentation category in the release notes and added a new CI/CD label.

### How to review this PR

Check changes make sense

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [x] I have selected the correct Assignee
- [x] I have linked the correct Issue
