### PR TITLE
 rename confusing parameters in summary component

### DIFF
--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -6,10 +6,10 @@
 
 ## Summaries
 
-| Name         | Type                  | Required | Description                                          |
-| ------------ | --------------------- | -------- | ---------------------------------------------------- |
-| groups       | Array`<SummaryGroup>` | true     | An array of [groups](#summarygroup) within a summary |
-| summaryTitle | string                | false    | The `h2` title heading for a group of summaries      |
+| Name   | Type                  | Required | Description                                          |
+| ------ | --------------------- | -------- | ---------------------------------------------------- |
+| groups | Array`<SummaryGroup>` | true     | An array of [groups](#summarygroup) within a summary |
+| title  | string                | false    | The `h2` title heading for a group of summaries      |
 
 ## SummaryGroup
 
@@ -17,7 +17,7 @@
 | --------------- | -------------------- | ------------------------------------------- | ------------------------------------------------------------------------------ |
 | rows            | Array`<SummaryRow>`  | true (unless `placeholderText` set)         | An array of [rows](#summaryrow) within a group                                 |
 | placeholderText | string               | true (unless `rows` set)                    | A message to be shown as a placeholder if there are no rows in the summary     |
-| groupTitle      | string               | false (`true` if variant is set to `card` ) | The title heading for a summary within a group                                 |
+| title           | string               | false (`true` if variant is set to `card` ) | The title heading for a summary within a group                                 |
 | id              | string               | false                                       | The HTML `id` of the group                                                     |
 | summaryLink     | Array`<SummaryLink>` | false                                       | Settings for the [summary link](#summarylink) used to a new row to the summary |
 
@@ -27,7 +27,7 @@
 | ------------ | ----------------------- | -------- | ------------------------------------------------------------------- |
 | id           | string                  | false    | The HTML `id` of the row                                            |
 | rowItems     | Array`<SummaryRowItem>` | true     | An array of [items for the row](#summaryrowitem)                    |
-| rowTitle     | string                  | false    | The title for the row                                               |
+| title        | string                  | false    | The title for the row                                               |
 | error        | boolean                 | false    | Set to “true” display an [error](/components/error) on a row        |
 | errorMessage | string                  | false    | The error message for the row                                       |
 | total        | boolean                 | false    | Set to “true” to display row as a calculated total of previous rows |
@@ -39,8 +39,8 @@
 | id                     | string                 | false    | The HTML `id` of the row item                                                               |
 | iconType               | string                 | false    | Adds an icon before the row title, by setting the [icon type](/foundations/icons#icon-type) |
 | iconVisuallyHiddenText | string                 | false    | Visually hidden text in a span under the icon to add more context for screen readers        |
-| rowTitle               | string                 | false    | The title for the row item                                                                  |
-| rowTitleAttributes     | object                 | false    | HTML attributes (for example, data attributes) to add to the rowTitle                       |
+| title                  | string                 | false    | The title for the row item                                                                  |
+| titleAttributes        | object                 | false    | HTML attributes (for example, data attributes) to add to the row title                      |
 | valueList              | Array`<SummaryValue>`  | false    | An array of [value(s)](#summaryvalue) for the row item                                      |
 | actions                | Array`<SummaryAction>` | false    | Settings for the row [action links](#summaryaction)                                         |
 | attributes             | object                 | false    | HTML attributes (for example, data attributes) to add to the row item                       |

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -15,14 +15,14 @@
 
     <div class="{{ className }}">
         {% for summary in params.summaries %}
-            {% if summary.summaryTitle %}
-                <h2 class="ons-summary__title ons-u-mb-m{{ " ons-u-mt-m" if loop.index > 1 else "" }}">{{ summary.summaryTitle }}</h2>
+            {% if summary.title %}
+                <h2 class="ons-summary__title ons-u-mb-m{{ " ons-u-mt-m" if loop.index > 1 else "" }}">{{ summary.title }}</h2>
                 {% set headingLevel = 3 %}
             {% endif %}
             {% for group in summary.groups %}
                 <div {% if group.id %}id="{{ group.id }}" {% endif %} class="ons-summary__group{{ variantClasses }}">
-                    {% if group.groupTitle %}
-                        <h{{ headingLevel }} class="ons-summary__group-title">{{ group.groupTitle }}</h{{ headingLevel }}>
+                    {% if group.title %}
+                        <h{{ headingLevel }} class="ons-summary__group-title">{{ group.title }}</h{{ headingLevel }}>
                     {% endif %}
                     {% if group.rows %}
                         <dl class="ons-summary__items">
@@ -34,14 +34,14 @@
                                     {% if row.errorMessage %}
                                         <div class="ons-summary__row-title--error ons-u-fs-r">{{ row.errorMessage }}</div>
                                     {% endif %}
-                                    {% if row.rowItems | length > 1 and row.rowTitle %}
-                                        <div class="ons-summary__row-title ons-summary__row-title--no-group-title ons-u-fs-r">{{ row.rowTitle }}</div>
+                                    {% if row.rowItems | length > 1 and row.title %}
+                                        <div class="ons-summary__row-title ons-summary__row-title--no-group-title ons-u-fs-r">{{ row.title }}</div>
                                     {% endif %}
 
                                     {% for rowItem in row.rowItems %}
                                         <div class="ons-summary__row{{ " ons-summary__row--has-values" if rowItem.valueList else "" }}"{% if rowItem.id %} id="{{ rowItem.id }}"{% endif %}>
                                             <dt class="ons-summary__item-title"
-                                                {% if rowItem.rowTitleAttributes %}{% for attribute, value in (rowItem.rowTitleAttributes.items() if rowItem.rowTitleAttributes is mapping and rowItem.rowTitleAttributes.items else rowItem.rowTitleAttributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
+                                                {% if rowItem.titleAttributes %}{% for attribute, value in (rowItem.titleAttributes.items() if rowItem.titleAttributes is mapping and rowItem.titleAttributes.items else rowItem.titleAttributes) %}{{attribute}}="{{value}}" {% endfor %}{% endif %}
                                             >
                                                 {% if rowItem.iconType %}
                                                     {% from "components/icon/_macro.njk" import onsIcon %}
@@ -58,7 +58,7 @@
                                                 {% endif %}
 
                                                 <div class="ons-summary__item--text{{ ' ons-summary__item-title--text' if rowItem.iconType else "" }}">
-                                                    {{- rowItem.rowTitle | default(row.rowTitle) | safe -}}
+                                                    {{- rowItem.title | default(row.title) | safe -}}
                                                 </div>
 
                                                 {# Render section status for mobile if is hub #}

--- a/src/components/summary/_macro.spec.js
+++ b/src/components/summary/_macro.spec.js
@@ -10,10 +10,10 @@ const EXAMPLE_SUMMARY_ROWS = {
     {
       // Contains - row with icon, attributes and rowTitleAttributes, other value, no action
       id: 'row-id-1',
-      rowTitle: 'row title 1',
+      title: 'row title 1',
       rowItems: [
         {
-          rowTitleAttributes: {
+          titleAttributes: {
             a: 123,
             b: 456,
           },
@@ -36,7 +36,7 @@ const EXAMPLE_SUMMARY_ROWS = {
     {
       // Contains - row with error and multiple actions
       id: 'row-id-2',
-      rowTitle: 'row title 2',
+      title: 'row title 2',
       error: true,
       errorMessage: 'there are errors',
       rowItems: [
@@ -69,7 +69,7 @@ const EXAMPLE_SUMMARY_ROWS = {
     {
       // Contains - row with multiple rows and multiple values
       id: 'row-id-3',
-      rowTitle: 'row title 3',
+      title: 'row title 3',
       rowItems: [
         {
           id: 'item-id-3',
@@ -95,7 +95,7 @@ const EXAMPLE_SUMMARY_ROWS = {
     {
       // Contains - row with total
       id: 'row-id-4',
-      rowTitle: 'row title 4',
+      title: 'row title 4',
       total: true,
       rowItems: [
         {
@@ -115,7 +115,7 @@ const EXAMPLE_SUMMARY_GROUPS = {
   groups: [
     {
       id: 'group-id-1',
-      groupTitle: 'group title',
+      title: 'group title',
       ...EXAMPLE_SUMMARY_ROWS,
     },
   ],
@@ -141,7 +141,7 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
     {
       rowItems: [
         {
-          rowTitle: 'row item 1',
+          title: 'row item 1',
           valueList: [
             {
               text: 'list item 1',
@@ -161,7 +161,7 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           ],
         },
         {
-          rowTitle: 'row item 2',
+          title: 'row item 2',
           valueList: [
             {
               text: 'list item 2',
@@ -176,7 +176,7 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           ],
         },
         {
-          rowTitle: 'row item 3',
+          title: 'row item 3',
           valueList: [
             {
               text: 'list item 3',
@@ -195,7 +195,7 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
     {
       rowItems: [
         {
-          rowTitle: 'row item 4',
+          title: 'row item 4',
           valueList: [
             {
               text: 'list item 4',
@@ -215,7 +215,7 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           ],
         },
         {
-          rowTitle: 'row item 5',
+          title: 'row item 5',
           valueList: [
             {
               text: 'list item 5',
@@ -230,7 +230,7 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
           ],
         },
         {
-          rowTitle: 'row item 6',
+          title: 'row item 6',
           valueList: [
             {
               text: 'list item 6',
@@ -264,7 +264,7 @@ const EXAMPLE_SUMMARY_BASIC = {
 const EXAMPLE_SUMMARY_WITH_TITLE = {
   summaries: [
     {
-      summaryTitle: 'summary title',
+      title: 'summary title',
       ...EXAMPLE_SUMMARY_GROUPS,
     },
   ],
@@ -273,7 +273,7 @@ const EXAMPLE_SUMMARY_WITH_TITLE = {
 const EXAMPLE_SUMMARY_WITH_NO_ROWS = {
   summaries: [
     {
-      summaryTitle: 'summary title',
+      title: 'summary title',
       ...EXAMPLE_SUMMARY_GROUPS_NO_ROWS,
     },
   ],
@@ -282,21 +282,21 @@ const EXAMPLE_SUMMARY_WITH_NO_ROWS = {
 const EXAMPLE_SUMMARY_MULTIPLE_GROUPS = {
   summaries: [
     {
-      summaryTitle: 'summary title',
+      title: 'summary title',
       groups: [
         {
           id: 'group-id-1',
-          groupTitle: 'group title',
+          title: 'group title',
           ...EXAMPLE_SUMMARY_ROWS,
         },
         {
           id: 'group-id-2',
-          groupTitle: 'group title',
+          title: 'group title',
           ...EXAMPLE_SUMMARY_HOUSEHOLD_GROUP,
         },
         {
           id: 'group-id-3',
-          groupTitle: 'group title',
+          title: 'group title',
           ...EXAMPLE_SUMMARY_ROWS,
         },
       ],

--- a/src/components/summary/example-summary-card-grouped.njk
+++ b/src/components/summary/example-summary-card-grouped.njk
@@ -5,13 +5,13 @@
         "variant": "card",
         "summaries": [
             {
-                "summaryTitle": "John Doe",
+                "title": "John Doe",
                 "groups": [
                     {
-                        "groupTitle": "Personal details",
+                        "title": "Personal details",
                         "rows": [
                             {
-                                "rowTitle": "Are you John Doe?",
+                                "title": "Are you John Doe?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -30,7 +30,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What's your date of birth?",
+                                "title": "What's your date of birth?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -49,7 +49,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What is your sex?",
+                                "title": "What is your sex?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -70,10 +70,10 @@
                         ]
                     },
                     {
-                        "groupTitle": "Identity and health",
+                        "title": "Identity and health",
                         "rows": [
                             {
-                                "rowTitle": "What is your country of birth?",
+                                "title": "What is your country of birth?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -92,7 +92,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What passports do you hold?",
+                                "title": "What passports do you hold?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -113,10 +113,10 @@
                         ]
                     },
                     {
-                        "groupTitle": "Qualifications",
+                        "title": "Qualifications",
                         "rows": [
                             {
-                                "rowTitle": "Have you completed an apprenticeship?",
+                                "title": "Have you completed an apprenticeship?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -135,7 +135,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "Have you achieved a GCSE or equivalent qualification?",
+                                "title": "Have you achieved a GCSE or equivalent qualification?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -156,12 +156,12 @@
                         ]
                     },
                     {
-                        "groupTitle": "Employment history",
+                        "title": "Employment history",
                         "rows": [
                             {
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Name of UK company",
+                                        "title": "Name of UK company",
                                         "valueList": [
                                             {
                                                 "text": "Company A"
@@ -181,7 +181,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Head office location",
+                                        "title": "Head office location",
                                         "valueList": [
                                             {
                                                 "text": "Cardiff"
@@ -196,7 +196,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Is this UK company your current employer?",
+                                        "title": "Is this UK company your current employer?",
                                         "valueList": [
                                             {
                                                 "text": "No"
@@ -215,7 +215,7 @@
                             {
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Name of UK company",
+                                        "title": "Name of UK company",
                                         "valueList": [
                                             {
                                                 "text": "Company A"
@@ -235,7 +235,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Head office location",
+                                        "title": "Head office location",
                                         "valueList": [
                                             {
                                                 "text": "Newport"
@@ -250,7 +250,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Is this UK company your current employer?",
+                                        "title": "Is this UK company your current employer?",
                                         "valueList": [
                                             {
                                                 "text": "Yes"
@@ -276,13 +276,13 @@
                         }
                     },
                     {
-                        "groupTitle": "Spending",
+                        "title": "Spending",
                         "rows": [
                             {
-                                "rowTitle": "What are your monthly household expenses?",
+                                "title": "What are your monthly household expenses?",
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Food",
+                                        "title": "Food",
                                         "valueList": [
                                             {
                                                 "text": "£50.00"
@@ -297,7 +297,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Utilities",
+                                        "title": "Utilities",
                                         "valueList": [
                                             {
                                                 "text": "£65.00"
@@ -312,7 +312,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Transport",
+                                        "title": "Transport",
                                         "valueList": [
                                             {
                                                 "text": "£70.00"
@@ -327,7 +327,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Other",
+                                        "title": "Other",
                                         "valueList": [
                                             {
                                                 "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."

--- a/src/components/summary/example-summary-grouped-total.njk
+++ b/src/components/summary/example-summary-grouped-total.njk
@@ -5,12 +5,12 @@
             {
                 "groups": [
                     {
-                        "groupTitle": "Summary - Section Title",
+                        "title": "Summary - Section Title",
                         "rows": [
                             {
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Total value of acquisitions for transport assets and equipment",
+                                        "title": "Total value of acquisitions for transport assets and equipment",
                                         "valueList": [
                                             {
                                                 "text": "£9,000.00"
@@ -29,7 +29,7 @@
                             {
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Total value of acquisitions for computers and peripheral devices (hardware)",
+                                        "title": "Total value of acquisitions for computers and peripheral devices (hardware)",
                                         "valueList": [
                                             {
                                                 "text": "£225,000.00"
@@ -49,7 +49,7 @@
                                 "total": true,
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Grand total for value of acquisitions",
+                                        "title": "Grand total for value of acquisitions",
                                         "valueList": [
                                             {
                                                 "text": "£234,000.00"

--- a/src/components/summary/example-summary-grouped-with-errors.njk
+++ b/src/components/summary/example-summary-grouped-with-errors.njk
@@ -5,10 +5,10 @@
             {
                 "groups": [
                     {
-                        "groupTitle": "Summary - Section Title",
+                        "title": "Summary - Section Title",
                         "rows": [
                             {
-                                "rowTitle": "For the period 1 May 2017 to 31 May 2017, what was the total turnover of Essential Enterprise Ltd?",
+                                "title": "For the period 1 May 2017 to 31 May 2017, what was the total turnover of Essential Enterprise Ltd?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -27,7 +27,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What was the value of the business's total sales of food?",
+                                "title": "What was the value of the business's total sales of food?",
                                 "errorMessage": "Change one or more of the figures so they sum to £600",
                                 "error": true,
                                 "rowItems": [
@@ -48,7 +48,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
+                                "title": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
                                 "error": true,
                                 "rowItems": [
                                     {
@@ -68,7 +68,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What was the value of the business's total sales of clothing and footwear?",
+                                "title": "What was the value of the business's total sales of clothing and footwear?",
                                 "error": true,
                                 "rowItems": [
                                     {

--- a/src/components/summary/example-summary-grouped.njk
+++ b/src/components/summary/example-summary-grouped.njk
@@ -6,13 +6,13 @@
     onsSummary({
         "summaries": [
             {
-                "summaryTitle": "John Doe",
+                "title": "John Doe",
                 "groups": [
                     {
-                        "groupTitle": "Personal details",
+                        "title": "Personal details",
                         "rows": [
                             {
-                                "rowTitle": "Are you John Doe?",
+                                "title": "Are you John Doe?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -31,7 +31,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What's your date of birth?",
+                                "title": "What's your date of birth?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -50,7 +50,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What is your sex?",
+                                "title": "What is your sex?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -71,10 +71,10 @@
                         ]
                     },
                     {
-                        "groupTitle": "Identity and health",
+                        "title": "Identity and health",
                         "rows": [
                             {
-                                "rowTitle": "What is your country of birth?",
+                                "title": "What is your country of birth?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -93,7 +93,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "What passports do you hold?",
+                                "title": "What passports do you hold?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -114,10 +114,10 @@
                         ]
                     },
                     {
-                        "groupTitle": "Qualifications",
+                        "title": "Qualifications",
                         "rows": [
                             {
-                                "rowTitle": "Have you completed an apprenticeship?",
+                                "title": "Have you completed an apprenticeship?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -136,7 +136,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "Have you achieved a GCSE or equivalent qualification?",
+                                "title": "Have you achieved a GCSE or equivalent qualification?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -157,12 +157,12 @@
                         ]
                     },
                     {
-                        "groupTitle": "Employment history",
+                        "title": "Employment history",
                         "rows": [
                             {
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Name of UK company",
+                                        "title": "Name of UK company",
                                         "valueList": [
                                             {
                                                 "text": "Company A"
@@ -182,7 +182,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Head office location",
+                                        "title": "Head office location",
                                         "valueList": [
                                             {
                                                 "text": "Cardiff"
@@ -197,7 +197,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Is this UK company your current employer?",
+                                        "title": "Is this UK company your current employer?",
                                         "valueList": [
                                             {
                                                 "text": "No"
@@ -216,7 +216,7 @@
                             {
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Name of UK company",
+                                        "title": "Name of UK company",
                                         "valueList": [
                                             {
                                                 "text": "Company A"
@@ -236,7 +236,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Head office location",
+                                        "title": "Head office location",
                                         "valueList": [
                                             {
                                                 "text": "Newport"
@@ -251,7 +251,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Is this UK company your current employer?",
+                                        "title": "Is this UK company your current employer?",
                                         "valueList": [
                                             {
                                                 "text": "Yes"
@@ -277,13 +277,13 @@
                         }
                     },
                     {
-                        "groupTitle": "Spending",
+                        "title": "Spending",
                         "rows": [
                             {
-                                "rowTitle": "What are your monthly household expenses?",
+                                "title": "What are your monthly household expenses?",
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Food",
+                                        "title": "Food",
                                         "valueList": [
                                             {
                                                 "text": "£50.00"
@@ -298,7 +298,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Utilities",
+                                        "title": "Utilities",
                                         "valueList": [
                                             {
                                                 "text": "£65.00"
@@ -313,7 +313,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Transport",
+                                        "title": "Transport",
                                         "valueList": [
                                             {
                                                 "text": "£70.00"
@@ -328,7 +328,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Other",
+                                        "title": "Other",
                                         "valueList": [
                                             {
                                                 "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."

--- a/src/components/summary/example-summary-household.njk
+++ b/src/components/summary/example-summary-household.njk
@@ -8,7 +8,7 @@
                 {
                     "rows": [
                         {
-                            "rowTitle": "Joe Bloggs (You)",
+                            "title": "Joe Bloggs (You)",
                             "rowItems": [
                                 {
                                     "iconType": "person",
@@ -23,7 +23,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Barry Scott",
+                            "title": "Barry Scott",
                             "rowItems": [
                                 {
                                     "iconType": "person",
@@ -43,7 +43,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Wilhelmina Susannah Clementine-Smith",
+                            "title": "Wilhelmina Susannah Clementine-Smith",
                             "rowItems": [
                                 {
                                     "iconType": "person",

--- a/src/components/summary/example-summary-hub-minimal.njk
+++ b/src/components/summary/example-summary-hub-minimal.njk
@@ -8,7 +8,7 @@
                     {
                     "rows": [
                         {
-                            "rowTitle": "People who live here",
+                            "title": "People who live here",
                             "rowItems": [
                                 {
                                     "iconType": "check",
@@ -24,7 +24,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Mary Smith (You)",
+                            "title": "Mary Smith (You)",
                             "rowItems": [
                                 {
                                     "iconType": "check",
@@ -40,7 +40,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "John Smith",
+                            "title": "John Smith",
                             "rowItems": [
                                 {
                                     "actions": [
@@ -54,7 +54,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Billy Smith",
+                            "title": "Billy Smith",
                             "rowItems": [
                                 {
                                     "actions": [

--- a/src/components/summary/example-summary-hub.njk
+++ b/src/components/summary/example-summary-hub.njk
@@ -8,7 +8,7 @@
                     {
                     "rows": [
                         {
-                            "rowTitle": "People who live here",
+                            "title": "People who live here",
                             "rowItems": [
                                 {
                                     "iconType": "check",
@@ -28,7 +28,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Accommodation",
+                            "title": "Accommodation",
                             "rowItems": [
                                 {
                                     "iconType": "check",
@@ -48,7 +48,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Mary Smith (You)",
+                            "title": "Mary Smith (You)",
                             "rowItems": [
                                 {
                                     "iconType": "check",
@@ -68,7 +68,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "John Smith",
+                            "title": "John Smith",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -87,7 +87,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Billy Smith",
+                            "title": "Billy Smith",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -106,7 +106,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Sally Smith",
+                            "title": "Sally Smith",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -125,7 +125,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Wilhelmina Susannah Clementine-Smith (Visitor)",
+                            "title": "Wilhelmina Susannah Clementine-Smith (Visitor)",
                             "rowItems": [
                                 {
                                     "valueList": [
@@ -144,7 +144,7 @@
                             ]
                         },
                         {
-                            "rowTitle": "Vera Jones (Visitor)",
+                            "title": "Vera Jones (Visitor)",
                             "rowItems": [
                                 {
                                     "valueList": [

--- a/src/components/summary/example-summary-multiple.njk
+++ b/src/components/summary/example-summary-multiple.njk
@@ -3,15 +3,15 @@
     onsSummary({
         "summaries": [
             {
-                "summaryTitle": "Summary - Section Title",
+                "title": "Summary - Section Title",
                 "groups": [
                     {
                         "rows": [
                             {
-                                "rowTitle": "What are your monthly household expenses?",
+                                "title": "What are your monthly household expenses?",
                                 "rowItems": [
                                     {
-                                        "rowTitle": "Food",
+                                        "title": "Food",
                                         "valueList": [
                                             {
                                                 "text": "£50.00"
@@ -26,7 +26,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Utilities",
+                                        "title": "Utilities",
                                         "valueList": [
                                             {
                                                 "text": "£65.00"
@@ -41,7 +41,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Transport",
+                                        "title": "Transport",
                                         "valueList": [
                                             {
                                                 "text": "£70.00"
@@ -56,7 +56,7 @@
                                         ]
                                     },
                                     {
-                                        "rowTitle": "Other",
+                                        "title": "Other",
                                         "valueList": [
                                             {
                                                 "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."

--- a/src/components/summary/example-summary-no-action.njk
+++ b/src/components/summary/example-summary-no-action.njk
@@ -5,10 +5,10 @@
             {
                 "groups": [
                     {
-                        "groupTitle": "Turnover",
+                        "title": "Turnover",
                         "rows": [
                             {
-                                "rowTitle": "What are the dates of the sales period you are reporting for?",
+                                "title": "What are the dates of the sales period you are reporting for?",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -20,7 +20,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "Total turnover",
+                                "title": "Total turnover",
                                 "rowItems": [
                                     {
                                         "valueList": [

--- a/src/components/summary/example-summary.njk
+++ b/src/components/summary/example-summary.njk
@@ -8,11 +8,11 @@
                     {
                         "placeholderText": 'test',
                         "id": "turnover",
-                        "groupTitle": "Turnover",
+                        "title": "Turnover",
                         "rows": [
                             {
                                 "id": "sales-dates-row",
-                                "rowTitle": "What are the dates of the sales period you are reporting for?",
+                                "title": "What are the dates of the sales period you are reporting for?",
                                 "rowItems": [
                                     {
                                         "id": "sales-dates",
@@ -32,7 +32,7 @@
                                 ]
                             },
                             {
-                                "rowTitle": "For the period 1 January 2015 to 2 February 2017, what was the value of your total turnover, excluding VAT?",
+                                "title": "For the period 1 January 2015 to 2 February 2017, what was the value of your total turnover, excluding VAT?",
                                 "id": "sales-value-row",
                                 "rowItems": [
                                     {
@@ -54,7 +54,7 @@
                             },
                             {
                                 "id": "sales-reasons-row",
-                                "rowTitle": "Please indicate the reasons for any changes in the total turnover",
+                                "title": "Please indicate the reasons for any changes in the total turnover",
                                 "rowItems": [
                                     {
                                         "id": "sales-reasons",
@@ -79,7 +79,7 @@
                             },
                             {
                                 "id": "sales-detail-row",
-                                "rowTitle": "Please describe the changes in total turnover in more detail",
+                                "title": "Please describe the changes in total turnover in more detail",
                                 "rowItems": [
                                     {
                                         "id": "sales-detail",

--- a/src/patterns/hub-and-spoke/example-hub-complete.njk
+++ b/src/patterns/hub-and-spoke/example-hub-complete.njk
@@ -35,7 +35,7 @@ layout: ~
                     {
                         "rows": [
                             {
-                                "rowTitle": "People who live here",
+                                "title": "People who live here",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -55,7 +55,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "Household accommodation",
+                                "title": "Household accommodation",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -75,7 +75,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "Mary Smith",
+                                "title": "Mary Smith",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -95,7 +95,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "John Smith",
+                                "title": "John Smith",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -115,7 +115,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "Billy Smith",
+                                "title": "Billy Smith",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -135,7 +135,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "Mary Susannah Smith (Visitor)",
+                                "title": "Mary Susannah Smith (Visitor)",
                                 "rowItems": [
                                     {
                                         "iconType": "check",

--- a/src/patterns/hub-and-spoke/example-hub.njk
+++ b/src/patterns/hub-and-spoke/example-hub.njk
@@ -28,7 +28,7 @@ layout: ~
                     {
                         "rows": [
                             {
-                                "rowTitle": "People who live here",
+                                "title": "People who live here",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -48,7 +48,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "Household accommodation",
+                                "title": "Household accommodation",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -68,7 +68,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "Mary Smith",
+                                "title": "Mary Smith",
                                 "rowItems": [
                                     {
                                         "iconType": "check",
@@ -88,7 +88,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "John Smith",
+                                "title": "John Smith",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -107,7 +107,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "Billy Smith",
+                                "title": "Billy Smith",
                                 "rowItems": [
                                     {
                                         "valueList": [
@@ -126,7 +126,7 @@ layout: ~
                                 ]
                             },
                             {
-                                "rowTitle": "Mary Susannah Smith (Visitor)",
+                                "title": "Mary Susannah Smith (Visitor)",
                                 "rowItems": [
                                     {
                                         "valueList": [

--- a/src/patterns/hub-and-spoke/example-spoke-summary.njk
+++ b/src/patterns/hub-and-spoke/example-spoke-summary.njk
@@ -34,7 +34,7 @@ layout: ~
                             {
                             "rows": [
                                 {
-                                    "rowTitle": "What type of accommodation is 68 Abingdon Road, Goathill?",
+                                    "title": "What type of accommodation is 68 Abingdon Road, Goathill?",
                                     "rowItems": [
                                         {
                                             "valueList": [
@@ -53,7 +53,7 @@ layout: ~
                                     ]
                                 },
                                 {
-                                    "rowTitle": "Are all the rooms in this accommodation, including the kitchen, bathroom and toilet, behind a door that only this household can use?",
+                                    "title": "Are all the rooms in this accommodation, including the kitchen, bathroom and toilet, behind a door that only this household can use?",
                                     "rowItems": [
                                         {
                                             "valueList": [
@@ -72,7 +72,7 @@ layout: ~
                                     ]
                                 },
                                 {
-                                    "rowTitle": "How many bedrooms are available for use only by this household?",
+                                    "title": "How many bedrooms are available for use only by this household?",
                                     "rowItems": [
                                         {
                                             "valueList": [
@@ -91,7 +91,7 @@ layout: ~
                                     ]
                                 },
                                 {
-                                    "rowTitle": "What type of central heating does have?",
+                                    "title": "What type of central heating does have?",
                                     "rowItems": [
                                         {
                                             "valueList": [
@@ -110,7 +110,7 @@ layout: ~
                                     ]
                                 },
                                 {
-                                    "rowTitle": "Does your household own or rent 68 Abingdon Road, Goathill?",
+                                    "title": "Does your household own or rent 68 Abingdon Road, Goathill?",
                                     "rowItems": [
                                         {
                                             "valueList": [
@@ -129,7 +129,7 @@ layout: ~
                                     ]
                                 },
                                 {
-                                    "rowTitle": "In total, how many cars or vans are owned, or available for use, by members of this household?",
+                                    "title": "In total, how many cars or vans are owned, or available for use, by members of this household?",
                                     "rowItems": [
                                         {
                                             "valueList": [


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

**BREAKING CHANGE**
Fixes #1730

In this PR, we are addressing an inconsistency in the naming of parameters within the summary component. This change aims to standardize the parameter names for clarity and consistency.

The following parameter renames are included:

- **summary.summaryTitle** is renamed to **summary.title**
- **group.groupTitle** is renamed to **group.title**
- **row.rowTitle** is renamed to **row.title**
- **rowItem.rowTitle** is renamed to **rowItem.title**
- **rowItem.rowTitleAttributes** is renamed to **rowItem.titleAttributes**

This change is a breaking change because it alters the existing parameter names, which will require updates wherever these parameters are used .

### How to Review this PR
1. Ensure all instances of the renamed parameters have been updated throughout the codebase.
2. Verify that the summary component works correctly after these changes.
3. Run all tests to ensure no functionality is broken by this update.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

- [ ] I have selected the correct Assignee
- [ ] I have linked the correct Issue
