### PR TITLE
Remove double error panel on text area component

### DIFF
--- a/src/components/textarea/_macro.njk
+++ b/src/components/textarea/_macro.njk
@@ -64,13 +64,7 @@
                 "error": params.error
             })
         %}
-            {%
-                call onsField({
-                    "error": params.error
-                })
-            %}
-                {{ field | safe }}
-            {% endcall %}
+            {{ field | safe }}
         {% endcall %}
     {% else %}
         {%

--- a/src/components/textarea/_macro.spec.js
+++ b/src/components/textarea/_macro.spec.js
@@ -285,16 +285,5 @@ describe('macro: textarea', () => {
                 error: EXAMPLE_TEXTAREA_WITH_MUTUALLY_EXCLUSIVE_WITH_ERROR.error,
             });
         });
-
-        it('still renders field component', () => {
-            const faker = templateFaker();
-            const fieldSpy = faker.spy('field');
-
-            faker.renderComponent('textarea', EXAMPLE_TEXTAREA_WITH_MUTUALLY_EXCLUSIVE_WITH_ERROR);
-
-            expect(fieldSpy.occurrences).toContainEqual({
-                error: EXAMPLE_TEXTAREA_WITH_MUTUALLY_EXCLUSIVE_WITH_ERROR.error,
-            });
-        });
     });
 });


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes #3244 
An extra field is included  in the text-area component. This PR removes the call to extra onsField and removes the test that verifies the field component still renders.

### How to review this PR
Using the example provided in the ticket, ensure that no additional error panel is displayed.
Verify that all tests pass.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
