### PR TITLE
Update parameter subject from text to object type in Message list component

### DIFF
--- a/src/components/message-list/_macro-options.md
+++ b/src/components/message-list/_macro-options.md
@@ -11,12 +11,18 @@
 
 ## Message
 
-| Name     | Type    | Required | Description                                                                      |
-| -------- | ------- | -------- | -------------------------------------------------------------------------------- |
-| id       | string  | true     | The HTML `id` for the message item                                               |
-| url      | string  | true     | The URL for the HTML `href` attribute to link to the message conversation thread |
-| subject  | string  | true     | Text displayed for the message subject                                           |
-| fromText | string  | true     | Value of the “From” sender name in the message metadata information              |
-| dateText | string  | true     | Value of the “Sent” date stamp in the message metadata information               |
-| body     | string  | true     | Text displayed for the message body snippet                                      |
-| unread   | boolean | false    | Set to “true” to display the unread message suffix after the `subject`           |
+| Name     | Type              | Required | Description                                                            |
+| -------- | ----------------- | -------- | ---------------------------------------------------------------------- |
+| id       | string            | true     | The HTML `id` for the message item                                     |
+| subject  | `Object<Subject>` | true     | Settings for the [Subject]                                             |
+| fromText | string            | true     | Value of the “From” sender name in the message metadata information    |
+| dateText | string            | true     | Value of the “Sent” date stamp in the message metadata information     |
+| body     | string            | true     | Text displayed for the message body snippet                            |
+| unread   | boolean           | false    | Set to “true” to display the unread message suffix after the `subject` |
+
+## Subject
+
+| Name | Type   | Required | Description                                                                      |
+| ---- | ------ | -------- | -------------------------------------------------------------------------------- |
+| text | string | true     | Text displayed for the message subject                                           |
+| url  | string | true     | The URL for the HTML `href` attribute to link to the message conversation thread |

--- a/src/components/message-list/_macro-options.md
+++ b/src/components/message-list/_macro-options.md
@@ -14,7 +14,7 @@
 | Name     | Type              | Required | Description                                                            |
 | -------- | ----------------- | -------- | ---------------------------------------------------------------------- |
 | id       | string            | true     | The HTML `id` for the message item                                     |
-| subject  | `Object<Subject>` | true     | Settings for the [Subject]                                             |
+| subject  | `Object<Subject>` | true     | Settings for the [Subject](#subject)                                   |
 | fromText | string            | true     | Value of the “From” sender name in the message metadata information    |
 | dateText | string            | true     | Value of the “Sent” date stamp in the message metadata information     |
 | body     | string            | true     | Text displayed for the message body snippet                            |

--- a/src/components/message-list/_macro.njk
+++ b/src/components/message-list/_macro.njk
@@ -3,7 +3,7 @@
         {% for message in params.messages %}
             <li class="ons-message-item" aria-labelledby="{{ message.id }}">
                 <h3 class="ons-message-item__subject" id="{{ message.id }}">
-                    <a href="{{ message.url }}" class="ons-u-fs-r--b">{{ message.subject }}</a>
+                    <a href="{{ message.subject.url }}" class="ons-u-fs-r--b">{{ message.subject.text }}</a>
                     {% if message.unread %}<span class="ons-message-item__unread ons-u-fs-s">({{ params.unreadText }})</span>{% endif %}
                 </h3>
                 <dl class="ons-message-item__metadata" aria-label="{{ params.ariaLabelMetaData | default("Message metadata") }}">
@@ -20,7 +20,7 @@
                     {{ message.body | safe }}
                 </div>
                 <div class="ons-message-item__link ons-u-vh">
-                    <a href="{{ message.url }}">{{ params.hiddenReadLabel }}: {{ message.subject }}</a>
+                    <a href="{{ message.subject.url }}">{{ params.hiddenReadLabel }}: {{ message.subject.text }}</a>
                 </div>
             </li>
         {% endfor %}

--- a/src/components/message-list/_macro.spec.js
+++ b/src/components/message-list/_macro.spec.js
@@ -14,16 +14,20 @@ const EXAMPLE_MESSAGE_LIST_MINIMAL = {
         {
             id: 'message1',
             unread: true,
-            url: 'https://example.com/message/1',
-            subject: 'Example message subject',
+            subject: {
+                url: 'https://example.com/message/1',
+                text: 'Example message subject',
+            },
             fromText: 'Example Sender 1',
             dateText: 'Tue 4 Jul 2020 at 7:47',
             body: 'An example message.',
         },
         {
             id: 'message2',
-            url: 'https://example.com/message/2',
-            subject: 'Another example message subject',
+            subject: {
+                url: 'https://example.com/message/2',
+                text: 'Another example message subject',
+            },
             fromText: 'Example Sender 2',
             dateText: 'Mon 1 Oct 2019 at 9:52',
             body: 'Another example message.',

--- a/src/patterns/send-and-reply-to-messages/example-message-list.njk
+++ b/src/patterns/send-and-reply-to-messages/example-message-list.njk
@@ -12,17 +12,21 @@
         "messages": [
             {
                 "id": "message-list-example-1",
+                "subject": {
+                    "url": "#0",
+                    "text": "BRES 2016 survey response query"
+                },
                 "unread": true,
-                "url": "#0",
-                "subject": "BRES 2016 survey response query",
                 "fromText": "ONS Business Surveys Team",
                 "dateText": "Tue 4 Jul 2020 at 7:47",
                 "body": "Hi Jacky. Thanks for that information. Your figures have allowed us to create more accurate…"
             },
             {
                 "id": "message-list-example-2",
-                "url": "#0",
-                "subject": "BRES 2015 Enquiry on data",
+                "subject":{
+                    "url": "#0",
+                    "text": "BRES 2015 Enquiry on data"
+                },
                 "fromText": "Jacky Turner",
                 "dateText": "Mon 1 Oct 2019 at 9:52",
                 "body": "Hi Jacky, Thank you for returning the Business Register and Employment Survey (BRES) 2016…"


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?
[#86](https://github.com/ONSdigital/design-team/issues/86)... 

As per the ticket tech notes, subject is made an object with text and url params.
Updated _macro-options.md file

_BREAKING CHANGES_

- **Description of change:** In Message List component, `subject` parameter is changed to an object which contains `text` and `url` parameter. `url` parameter is moved inside subject
- **Reason for change:** This update helps to standardise the parameter names within the project.
- **Migration steps:**
     1. Locate all instances of `subject` parameter, and include `text` and `url` within the `subject`. 
    <details>
    <summary><b>Click for example</b></summary>
        
       
           OLD    
               {{
                     onsMessageList({
                         "messages": [{
                                  "url": "#0",
                                   "subject": "survey response query",
                         }]
                     })
               }}

    
           NEW            
           {{
                   onsMessageList({
                         "messages": [{
                             "subject":{ 
                                "url": "#0",
                                "text":"survey response query",
                            } 
                        }]
                  })
            }}


 
### How to review this PR

Check that all the references to the parameters have been updated
Check that all the visual tests pass




### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
