### PR TITLE
Refactor access-code component test file to new format

### DIFF
--- a/src/components/access-code/_macro.spec.js
+++ b/src/components/access-code/_macro.spec.js
@@ -5,150 +5,184 @@ import * as cheerio from 'cheerio';
 import axe from '../../tests/helpers/axe';
 import { renderComponent } from '../../tests/helpers/rendering';
 
-describe('macro: access-code', () => {
-    it('passes jest-axe checks', async () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                id: 'example-access-code',
-                label: {
-                    text: 'Enter your 16-character access code',
-                    description: 'Keep this code safe. You will need to enter it every time you access your study',
-                },
-            }),
-        );
-
-        const results = await axe($.html());
-        expect(results).toHaveNoViolations();
+describe('FOR: access-code', () => {
+    describe('GIVEN: Params: required', () => {
+        describe('WHEN: all required params are provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    id: 'example-access-code',
+                    label: {
+                        text: 'Enter your 16-character access code',
+                        description: 'Keep this code safe. You will need to enter it every time you access your study',
+                    },
+                }),
+            );
+            test('THEN: jest-axe tests pass', async () => {
+                const results = await axe($.html());
+                expect(results).toHaveNoViolations();
+            });
+            test('THEN: autocomplete is disabled on text input', () => {
+                expect($('input').attr('autocomplete')).toBe('off');
+            });
+            test('THEN: text input has automatic capitalisation', () => {
+                expect($('input').attr('autocapitalize')).toBe('characters');
+            });
+        });
     });
-
-    it('has the provided `id` attribute', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                id: 'example-id',
-            }),
-        );
-
-        expect($('#example-id').length).toBe(1);
+    describe('GIVEN: Params: id', () => {
+        describe('WHEN: id is provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    id: 'example-id',
+                }),
+            );
+            test('THEN: renders with id provided', () => {
+                expect($('#example-id').length).toBe(1);
+            });
+        });
     });
-
-    it('has the provided `name` attribute', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                name: 'special-name',
-            }),
-        );
-
-        expect($('input').attr('name')).toBe('special-name');
+    describe('GIVEN: Params: classes', () => {
+        describe('WHEN: additional style classes are provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    classes: 'extra-class another-extra-class',
+                }),
+            );
+            test('THEN: renders with additional classes provided', () => {
+                expect($('.ons-panel--info').hasClass('extra-class')).toBe(true);
+                expect($('.ons-panel--info').hasClass('another-extra-class')).toBe(true);
+            });
+        });
     });
-
-    it('has a default `type` of "text"', () => {
-        const $ = cheerio.load(renderComponent('access-code'));
-
-        expect($('input').attr('type')).toBe('text');
+    describe('GIVEN: Params: label', () => {
+        describe('WHEN: label text and description params are provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    label: {
+                        text: 'Enter your 16-character access code',
+                        description: 'Keep this code safe. You will need to enter it every time you access your study',
+                    },
+                }),
+            );
+            test('THEN: renders with provided text and description', () => {
+                expect($('.ons-label--with-description').text()).toBe('Enter your 16-character access code');
+                expect($('.ons-input--with-description').text()).toBe(
+                    'Keep this code safe. You will need to enter it every time you access your study',
+                );
+            });
+        });
     });
-
-    it('has the provided `type` attribute', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                type: 'number',
-            }),
-        );
-
-        expect($('input').attr('inputmode')).toBe('numeric');
+    describe('GIVEN: Params: type', () => {
+        describe('WHEN: param is at default state', () => {
+            const $ = cheerio.load(renderComponent('access-code'));
+            test('THEN: renders with default type of "text"', () => {
+                expect($('input').attr('type')).toBe('text');
+            });
+        });
+        describe('WHEN: type param is provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    type: 'number',
+                }),
+            );
+            test('THEN: renders with provided type', () => {
+                expect($('input').attr('inputmode')).toBe('numeric');
+            });
+        });
     });
-
-    it('has additionally provided style classes', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                classes: 'extra-class another-extra-class',
-            }),
-        );
-
-        expect($('.ons-panel--info').hasClass('extra-class')).toBe(true);
-        expect($('.ons-panel--info').hasClass('another-extra-class')).toBe(true);
+    describe('GIVEN: Params: name', () => {
+        describe('WHEN: name param is provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    name: 'special-name',
+                }),
+            );
+            test('THEN: renders with provided name', () => {
+                expect($('input').attr('name')).toBe('special-name');
+            });
+        });
     });
-
-    it('has provided label text and description', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                label: {
-                    text: 'Enter your 16-character access code',
-                    description: 'Keep this code safe. You will need to enter it every time you access your study',
-                },
-            }),
-        );
-
-        expect($('.ons-label--with-description').text()).toBe('Enter your 16-character access code');
-        expect($('.ons-input--with-description').text()).toBe(
-            'Keep this code safe. You will need to enter it every time you access your study',
-        );
+    describe('GIVEN: Params: maxlength & groupSize', () => {
+        describe('WHEN: params are at default state', () => {
+            const $ = cheerio.load(renderComponent('access-code'));
+            test('THEN: renders input with total maxlength of 19', () => {
+                expect($('input').attr('maxlength')).toBe('19');
+            });
+            test('THEN: renders input with groupsize of 4', () => {
+                expect($('input').attr('data-group-size')).toBe('4');
+            });
+        });
+        describe('WHEN: maxlength param is provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    maxlength: 8,
+                }),
+            );
+            test('THEN: renders input with provided maxlength', () => {
+                expect($('input').attr('maxlength')).toBe('9');
+            });
+        });
+        describe('WHEN: groupsize param is provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    groupSize: 2,
+                }),
+            );
+            test('THEN: renders input with provided groupsize', () => {
+                expect($('input').attr('data-group-size')).toBe('2');
+            });
+        });
+        describe('WHEN: maxlength and groupsize params are provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    maxlength: 6,
+                    groupSize: 3,
+                }),
+            );
+            test('THEN: renders input with provided maxlength accounting for provided groupsize', () => {
+                expect($('input').attr('maxlength')).toBe('7');
+            });
+        });
     });
-
-    it('has provided maximum length attribute including spaces required for groupSize', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                maxlength: 6,
-                groupSize: 3,
-            }),
-        );
-
-        expect($('input').attr('maxlength')).toBe('7');
+    describe('GIVEN: Params: securityMessage', () => {
+        describe('WHEN: securityMessage param is provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    securityMessage: 'Example security message.',
+                }),
+            );
+            test('THEN: renders with provided security message', () => {
+                expect($('.ons-panel__body').text().trim()).toBe('Example security message.');
+            });
+        });
     });
-
-    it('has provided group size attribute', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                groupSize: 2,
-            }),
-        );
-
-        expect($('input').attr('data-group-size')).toBe('2');
+    describe('GIVEN: Params: postTextboxLinkText & postTextBoxLinkUrl', () => {
+        describe('WHEN: postTextboxLinkText & postTextBoxLinkUrl params are provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    postTextboxLinkText: 'Example link text',
+                    postTextboxLinkUrl: '#3',
+                }),
+            );
+            test('THEN: renders link with provided link and text', () => {
+                expect($('a[href="#3"]').text().trim()).toBe('Example link text');
+            });
+        });
     });
-
-    it('has autocomplete disabled on its text input', () => {
-        const $ = cheerio.load(renderComponent('access-code'));
-
-        expect($('input').attr('autocomplete')).toBe('off');
-    });
-
-    it('has automatic capitalization on its text input', () => {
-        const $ = cheerio.load(renderComponent('access-code'));
-
-        expect($('input').attr('autocapitalize')).toBe('characters');
-    });
-
-    it('has provided security message text', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                securityMessage: 'Example security message.',
-            }),
-        );
-
-        expect($('.ons-panel__body').text().trim()).toBe('Example security message.');
-    });
-
-    it('has provided `postTextBoxLinkText` and `postTextBoxLinkUrl`', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                postTextboxLinkText: 'Example link text',
-                postTextboxLinkUrl: '#3',
-            }),
-        );
-
-        expect($('a[href="#3"]').text().trim()).toBe('Example link text');
-    });
-
-    it('has provided `error` output', () => {
-        const $ = cheerio.load(
-            renderComponent('access-code', {
-                error: {
-                    id: 'access-code-error',
-                    text: 'Enter an access code',
-                },
-            }),
-        );
-
-        expect($('#access-code-error').length).toBe(1);
-        expect($('.ons-panel__error > strong').text()).toBe('Enter an access code');
+    describe('GIVEN: Params: error', () => {
+        describe('WHEN: error id & text params are provided', () => {
+            const $ = cheerio.load(
+                renderComponent('access-code', {
+                    error: {
+                        id: 'access-code-error',
+                        text: 'Enter an access code',
+                    },
+                }),
+            );
+            test('THEN: renders error with provided id and text', () => {
+                expect($('#access-code-error').length).toBe(1);
+                expect($('.ons-panel__error > strong').text()).toBe('Enter an access code');
+            });
+        });
     });
 });

--- a/src/components/access-code/_macro.spec.js
+++ b/src/components/access-code/_macro.spec.js
@@ -108,7 +108,7 @@ describe('FOR: access-code', () => {
             test('THEN: renders input with total maxlength of 19', () => {
                 expect($('input').attr('maxlength')).toBe('19');
             });
-            test('THEN: renders input with groupsize of 4', () => {
+            test('THEN: renders input with groupSize of 4', () => {
                 expect($('input').attr('data-group-size')).toBe('4');
             });
         });
@@ -122,24 +122,24 @@ describe('FOR: access-code', () => {
                 expect($('input').attr('maxlength')).toBe('9');
             });
         });
-        describe('WHEN: groupsize param is provided', () => {
+        describe('WHEN: groupSize param is provided', () => {
             const $ = cheerio.load(
                 renderComponent('access-code', {
                     groupSize: 2,
                 }),
             );
-            test('THEN: renders input with provided groupsize', () => {
+            test('THEN: renders input with provided groupSize', () => {
                 expect($('input').attr('data-group-size')).toBe('2');
             });
         });
-        describe('WHEN: maxlength and groupsize params are provided', () => {
+        describe('WHEN: maxlength and groupSize params are provided', () => {
             const $ = cheerio.load(
                 renderComponent('access-code', {
                     maxlength: 6,
                     groupSize: 3,
                 }),
             );
-            test('THEN: renders input with provided maxlength accounting for provided groupsize', () => {
+            test('THEN: renders input with provided maxlength accounting for provided groupSize', () => {
                 expect($('input').attr('maxlength')).toBe('7');
             });
         });


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes [#200](https://github.com/ONSdigital/design-team/issues/200) in the design team issues board

This PR refactors the macrospec testing file for the access-code component to follow the new testing format.

### How to review this PR

Ask yourself....
- Do we need any additional tests?
- Are the tests descriptions clear?
- Does the order of the test document make sense?
- Is it internally consistent?
- Is it consistent with the [guidelines for test refactoring](https://confluence.ons.gov.uk/display/SDC/Testing+Refactor+Guidance)? 

run this test command to view the test results:
`yarn test --testNamePattern="FOR: access-code"`

### Checklist

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
