### PR TITLE
Update parameter from linkText to text in external link component

### DIFF
--- a/src/components/external-link/_macro-options.md
+++ b/src/components/external-link/_macro-options.md
@@ -1,6 +1,6 @@
 | Name                 | Type   | Required | Description                                                                                        |
 | -------------------- | ------ | -------- | -------------------------------------------------------------------------------------------------- |
 | url                  | string | true     | The URL for the `href` attribute of the external link                                              |
-| linkText             | string | true     | Text for the external link                                                                         |
+| text                 | string | true     | Text for the external link                                                                         |
 | classes              | string | false    | Classes to apply to the link                                                                       |
 | newWindowDescription | string | false    | Use to set context after the `linkText` label for screen readers. Defaults to “opens in a new tab” |

--- a/src/components/external-link/_macro.njk
+++ b/src/components/external-link/_macro.njk
@@ -2,7 +2,7 @@
 
 {% macro onsExternalLink(params) %}
     <a href="{{ params.url }}" class="ons-external-link{{ ' ' + params.classes if params.classes else '' }}" target="_blank" rel="noopener">
-        <span class="ons-external-link__text"> {{- params.linkText | safe -}} </span
+        <span class="ons-external-link__text"> {{- params.text | safe -}} </span
         ><span class="ons-external-link__icon">&nbsp;{{- onsIcon({"iconType": 'external-link'}) -}} </span
         ><span class="ons-external-link__new-window-description ons-u-vh"
             >({{- params.newWindowDescription | default("opens in a new tab") -}})</span

--- a/src/components/external-link/_macro.spec.js
+++ b/src/components/external-link/_macro.spec.js
@@ -7,7 +7,7 @@ import { renderComponent, templateFaker } from '../../tests/helpers/rendering';
 
 const EXAMPLE_EXTERNAL_LINK = {
     url: 'http://example.com',
-    linkText: 'Example link',
+    text: 'Example link',
 };
 
 describe('macro: external-link', () => {

--- a/src/components/external-link/example-external-link.njk
+++ b/src/components/external-link/example-external-link.njk
@@ -5,7 +5,7 @@
     {{
         onsExternalLink({
             "url": "#0",
-            "linkText": "link to an external website"
+            "text": "link to an external website"
         })
     }}
 </p>

--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -147,7 +147,7 @@
                                         {{
                                             onsExternalLink({
                                                 "url": params.OGLLink.url | default('https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'),
-                                                "linkText": params.OGLLink.link | default('Drwydded Llywodraeth Leol v3.0')
+                                                "text": params.OGLLink.link | default('Drwydded Llywodraeth Leol v3.0')
                                             })
                                         }}{{ params.OGLLink.post | default(', oni bai y nodir fel arall') }}
                                     {% else %}
@@ -155,7 +155,7 @@
                                         {{
                                             onsExternalLink({
                                                 "url": params.OGLLink.url | default('https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/'),
-                                                "linkText": params.OGLLink.link | default('Open Government Licence v3.0')
+                                                "text": params.OGLLink.link | default('Open Government Licence v3.0')
                                             })
                                         }}{{ params.OGLLink.post | default(', except where otherwise stated') }}
                                     {% endif %}

--- a/src/components/footer/_macro.spec.js
+++ b/src/components/footer/_macro.spec.js
@@ -167,7 +167,7 @@ describe('macro: footer', () => {
             expect(externalLinkSpy.occurrences).toContainEqual(
                 expect.objectContaining({
                     url: 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
-                    linkText: 'Open Government Licence v3.0',
+                    text: 'Open Government Licence v3.0',
                 }),
             );
         });

--- a/src/components/list/_macro.njk
+++ b/src/components/list/_macro.njk
@@ -68,7 +68,7 @@
                     {{
                         onsExternalLink({
                             "url": item.url,
-                            "linkText": itemText
+                            "text": itemText
                         })
                     }}
                 {%- else -%}

--- a/src/components/list/_macro.spec.js
+++ b/src/components/list/_macro.spec.js
@@ -425,7 +425,7 @@ describe('macro: list', () => {
 
                 expect(externalLinkSpy.occurrences[0]).toEqual({
                     url: 'https://example.com/external-link',
-                    linkText: expectedItemText,
+                    text: expectedItemText,
                 });
             });
 

--- a/src/components/phase-banner/example-phase-banner-alpha.njk
+++ b/src/components/phase-banner/example-phase-banner-alpha.njk
@@ -9,7 +9,7 @@
     {{
         onsExternalLink({
             "url": "#0",
-            "linkText": "give feedback"
+            "text": "give feedback"
         })
     }}
 {% endset %}

--- a/src/components/phase-banner/example-phase-banner-beta.njk
+++ b/src/components/phase-banner/example-phase-banner-beta.njk
@@ -9,7 +9,7 @@
     {{
         onsExternalLink({
             "url": "#0",
-            "linkText": "give feedback"
+            "text": "give feedback"
         })
     }}
 {% endset %}

--- a/src/components/video/_macro.njk
+++ b/src/components/video/_macro.njk
@@ -19,7 +19,7 @@
             onsExternalLink({
                 "url": params.videoLinkURL,
                 "classes": "ons-video__link ons-js-video-placeholder ons-u-db",
-                "linkText": linkContents
+                "text": linkContents
             })
         }}
         <iframe


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

[96](https://github.com/ONSdigital/design-team/issues/96)

As per the ticket tech notes, renamed the param name from` linkText` to `text`. 
Updated _macro-options.md file

_BREAKING CHANGES_

- **Description of change:** `linkText` parameter is named to `text`
- **Reason for change:** This update helps to standardise the parameter names within the project.
- **Migration steps:**
     1. Locate all instances of `linkText` parameter in external link component
     2. Replace `linkText` to `text`.

    <details>
    <summary><b>Click for example</b></summary>
           
          OLD
          {{
              onsExternalLink({
                   "url": "#0",
                   "linkText": "link to an external website"
              })
          }}
    
          NEW
          {{
              onsExternalLink({
                  "url": "#0",
                  "text": "link to an external website"
              })
          }}


### How to review this PR

Check that all the references to the parameters have been updated
Check that all the visual tests pass

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
