### PR TITLE
Update param name from title to text in section navigation component

### DIFF
--- a/src/components/section-navigation/_macro-options.md
+++ b/src/components/section-navigation/_macro-options.md
@@ -24,12 +24,12 @@
 | ------- | ---------------- | -------- | -------------------------------------------------- |
 | classes | string           | false    | Additional classes for the list item element       |
 | url     | string           | true     | The URL for the HTML `href` attribute for the link |
-| title   | string           | true     | The text for the link                              |
+| text    | string           | true     | The text for the link                              |
 | anchors | `Array<Anchors>` | false    | An array of [sub-section list anchors](#anchors)   |
 
 ## Anchors
 
-| Name  | Type   | Required | Description                                             |
-| ----- | ------ | -------- | ------------------------------------------------------- |
-| url   | string | true     | The HTML `id` of the heading tag on the page to link to |
-| title | string | true     | The text for the anchor link                            |
+| Name | Type   | Required | Description                                             |
+| ---- | ------ | -------- | ------------------------------------------------------- |
+| url  | string | true     | The HTML `id` of the heading tag on the page to link to |
+| text | string | true     | The text for the anchor link                            |

--- a/src/components/section-navigation/_macro.njk
+++ b/src/components/section-navigation/_macro.njk
@@ -22,7 +22,7 @@
                     {% endif %}
                     <ul class="ons-section-nav__list">
                         {% for item in section.itemsList %}
-                            {% if (params.currentPath and item.url == params.currentPath) or (params.tabQuery and params.tabQuery == item.title | lower) %}
+                            {% if (params.currentPath and item.url == params.currentPath) or (params.tabQuery and params.tabQuery == item.text | lower) %}
                                 {% set isCurrent = true %}
                             {% else %}
                                 {% set isCurrent = false %}
@@ -33,16 +33,16 @@
                                 {% if isCurrent == true %}
                                     {{ openingHeadingTag | replace(headingLevel, sectionItemHeadingLevel | string) | safe }}
                                     class="ons-section-nav__link ons-section-nav__item-header" href="{{ item.url }}"
-                                    aria-current="location">{{ item.title }}{{ closingHeadingTag | replace(headingLevel, sectionItemHeadingLevel | string) | safe }}
+                                    aria-current="location">{{ item.text }}{{ closingHeadingTag | replace(headingLevel, sectionItemHeadingLevel | string) | safe }}
                                 {% else %}
-                                    <a class="ons-section-nav__link" href="{{ item.url }}">{{ item.title }}</a>
+                                    <a class="ons-section-nav__link" href="{{ item.url }}">{{ item.text }}</a>
                                 {% endif %}
                                 {% if item.anchors and isCurrent == true %}
                                     <ul class="ons-section-nav__sub-items ons-list ons-list--dashed ons-u-mt-xs ons-u-mb-xs">
                                         {% for anchor in item.anchors %}
                                             <li class="ons-section-nav__item ons-list__item">
                                                 <a href="{{ anchor.url }}" class="ons-section-nav__link ons-list__link"
-                                                    >{{ anchor.title }}</a
+                                                    >{{ anchor.text }}</a
                                                 >
                                             </li>
                                         {% endfor %}
@@ -62,7 +62,7 @@
             <ul class="ons-section-nav__list">
                 {% for item in params.itemsList %}
                     {% set sectionItemHeadingLevel = headingLevel + 2 if params.title else headingLevel + 1 %}
-                    {% if (params.currentPath and item.url == params.currentPath) or (params.tabQuery and params.tabQuery == item.title | lower) %}
+                    {% if (params.currentPath and item.url == params.currentPath) or (params.tabQuery and params.tabQuery == item.text | lower) %}
                         {% set isCurrent = true %}
                     {% else %}
                         {% set isCurrent = false %}
@@ -73,15 +73,15 @@
                         {% if isCurrent == true %}
                             {{ openingHeadingTag | replace(headingLevel, sectionItemHeadingLevel | string) | safe }}
                             class="ons-section-nav__link ons-section-nav__item-header" href="{{ item.url }}"
-                            aria-current="location">{{ item.title }}{{ closingHeadingTag | replace(headingLevel, sectionItemHeadingLevel | string) | safe }}
+                            aria-current="location">{{ item.text }}{{ closingHeadingTag | replace(headingLevel, sectionItemHeadingLevel | string) | safe }}
                         {% else %}
-                            <a class="ons-section-nav__link" href="{{ item.url }}">{{ item.title }}</a>
+                            <a class="ons-section-nav__link" href="{{ item.url }}">{{ item.text }}</a>
                         {% endif %}
                         {% if item.anchors %}
                             <ul class="ons-section-nav__sub-items ons-list ons-list--dashed ons-u-mt-xs ons-u-mb-xs">
                                 {% for anchor in item.anchors %}
                                     <li class="ons-section-nav__item ons-list__item">
-                                        <a href="{{ anchor.url }}" class="ons-section-nav__link ons-list__link">{{ anchor.title }}</a>
+                                        <a href="{{ anchor.url }}" class="ons-section-nav__link ons-list__link">{{ anchor.text }}</a>
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/src/components/section-navigation/_macro.spec.js
+++ b/src/components/section-navigation/_macro.spec.js
@@ -11,11 +11,11 @@ const EXAMPLE_SECTION_NAVIGATION = {
     currentPath: '/results',
     itemsList: [
         {
-            title: 'Results',
+            text: 'Results',
             url: '/results',
         },
         {
-            title: 'Dashboard',
+            text: 'Dashboard',
             url: '/results/dashboard',
         },
     ],
@@ -26,29 +26,29 @@ const EXAMPLE_SECTION_NAVIGATION_VERTICAL = {
     currentPath: '#section-2',
     itemsList: [
         {
-            title: 'Section 1',
+            text: 'Section 1',
             url: '#section-1',
         },
         {
-            title: 'Section 2',
+            text: 'Section 2',
             url: '#section-2',
             anchors: [
                 {
-                    title: 'Sub section 1',
+                    text: 'Sub section 1',
                     url: '#sub-section-1',
                 },
                 {
-                    title: 'Sub section 2',
+                    text: 'Sub section 2',
                     url: '#sub-section-2',
                 },
                 {
-                    title: 'Sub section 3',
+                    text: 'Sub section 3',
                     url: '#sub-section-3',
                 },
             ],
         },
         {
-            title: 'Section 3',
+            text: 'Section 3',
             url: '#0',
         },
     ],
@@ -62,29 +62,29 @@ const EXAMPLE_SECTION_NAVIGATION_VERTICAL_WITH_SECTIONS = {
             title: 'Section Title',
             itemsList: [
                 {
-                    title: 'Section 1',
+                    text: 'Section 1',
                     url: '#section-1',
                 },
                 {
-                    title: 'Section 2',
+                    text: 'Section 2',
                     url: '#section-2',
                     anchors: [
                         {
-                            title: 'Sub section 1',
+                            text: 'Sub section 1',
                             url: '#sub-section-1',
                         },
                         {
-                            title: 'Sub section 2',
+                            text: 'Sub section 2',
                             url: '#sub-section-2',
                         },
                         {
-                            title: 'Sub section 3',
+                            text: 'Sub section 3',
                             url: '#sub-section-3',
                         },
                     ],
                 },
                 {
-                    title: 'Section 3',
+                    text: 'Section 3',
                     url: '#0',
                 },
             ],
@@ -159,7 +159,7 @@ describe('macro: section-navigation', () => {
                     itemsList: [
                         {
                             classes: 'extra-class another-extra-class',
-                            title: 'Section 1',
+                            text: 'Section 1',
                             url: '#section-1',
                         },
                     ],

--- a/src/components/section-navigation/example-section-navigation-single-vertical-with-title.njk
+++ b/src/components/section-navigation/example-section-navigation-single-vertical-with-title.njk
@@ -7,15 +7,15 @@
         "title": "Sections title",
         "itemsList": [
             {
-                "title": "Section 1",
+                "text": "Section 1",
                 "url": "#section-1"
             },
             {
-                "title": "Section 2",
+                "text": "Section 2",
                 "url": "#0"
             },
             {
-                "title": "Section 3",
+                "text": "Section 3",
                 "url": "#0"
             }
         ]

--- a/src/components/section-navigation/example-section-navigation-vertical.njk
+++ b/src/components/section-navigation/example-section-navigation-vertical.njk
@@ -9,33 +9,33 @@
                 "title": "Section Title",
                 "itemsList": [
                     {
-                        "title": "Section 1",
+                        "text": "Section 1",
                         "url": "#section-1",
                         "anchors": [
                             {
-                                "title": "Sub section 1",
+                                "text": "Sub section 1",
                                 "url": "#sub-section-1"
                             },
                             {
-                                "title": "Sub section 2",
+                                "text": "Sub section 2",
                                 "url": "#sub-section-2"
                             },
                             {
-                                "title": "Sub section 3",
+                                "text": "Sub section 3",
                                 "url": "#sub-section-3"
                             }
                         ]
                     },
                     {
-                        "title": "Section 2",
+                        "text": "Section 2",
                         "url": "#section-2"
                     },
                     {
-                        "title": "Section 3",
+                        "text": "Section 3",
                         "url": "#section-3"
                     },
                     {
-                        "title": "Section 4",
+                        "text": "Section 4",
                         "url": "#section-4"
                     }
                 ]
@@ -44,33 +44,33 @@
                 "title": "Section Title",
                 "itemsList": [
                     {
-                        "title": "Section 5",
+                        "text": "Section 5",
                         "url": "#section-5"
                     },
                     {
-                        "title": "Section 6",
+                        "text": "Section 6",
                         "url": "#section-6",
                         "anchors": [
                             {
-                                "title": "Sub section 1",
+                                "text": "Sub section 1",
                                 "url": "#sub-section-1"
                             },
                             {
-                                "title": "Sub section 2",
+                                "text": "Sub section 2",
                                 "url": "#sub-section-2"
                             },
                             {
-                                "title": "Sub section 3",
+                                "text": "Sub section 3",
                                 "url": "#sub-section-3"
                             }
                         ]
                     },
                     {
-                        "title": "Section 7",
+                        "text": "Section 7",
                         "url": "#0"
                     },
                     {
-                        "title": "Section 8",
+                        "text": "Section 8",
                         "url": "#0"
                     }
                 ]

--- a/src/components/section-navigation/example-section-navigation.njk
+++ b/src/components/section-navigation/example-section-navigation.njk
@@ -5,15 +5,15 @@
         "currentPath": "#section-1",
         "itemsList": [
             {
-                "title": "Section 1",
+                "text": "Section 1",
                 "url": "#section-1"
             },
             {
-                "title": "Section 2",
+                "text": "Section 2",
                 "url": "#0"
             },
             {
-                "title": "Section 3",
+                "text": "Section 3",
                 "url": "#0"
             }
         ]


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?
[83](https://github.com/orgs/ONSdigital/projects/21/views/1?pane=issue&itemId=70478852)

As per the ticket tech notes, renamed the param name from title to text.
Updated _macro-options.md file

_BREAKING CHANGES_

- **Description of change:** The `title` parameter for the objects itemsList and anchor is renamed to `text`
- **Reason for change:** This update helps to standardise the parameter names within the project.
- **Migration steps:**
     1. Locate all instances of the `title` parameter in the objects itemList and anchor
     2. Replace `title` with `text`.

    <details>
    <summary><b>Click for example</b></summary>
           
          OLD
          {{
           onsSectionNavigation({
               "sections":[{
                    "itemsList": [{
                        "title": "Section 1"
                        "anchors": [{
                                "title": "Sub section 1"
                          }]
                      }]
                 }]
             })
           }}
          NEW
          {{
           onsSectionNavigation({
               "sections":[{
                    "itemsList": [{
                        "text": "Section 1"
                        "anchors": [{
                                "text": "Sub section 1"
                          }]
                      }]
                 }]
             })
           }}


### How to review this PR

Check that all the references to the parameters have been updated
Check that all the visual tests pass.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
