### PR TITLE
Update  parameter from linkText to videoLinkText in Video Component

### DIFF
--- a/src/components/tabs/example-tabs-details.njk
+++ b/src/components/tabs/example-tabs-details.njk
@@ -16,7 +16,7 @@
             "alt": "Youtube video"
         },
         "title": 'Transforming the way we produce statistics | Explaining the Dynamic Population Model | BSL',
-        "linkText": 'Watch “Transforming the way we produce statistics | Explaining the Dynamic Population Model | BSL“ on Youtube'
+        "videoLinkText": 'Watch “Transforming the way we produce statistics | Explaining the Dynamic Population Model | BSL“ on Youtube'
         })
     }}
     {% from "components/tabs/_macro.njk" import onsTabs %}

--- a/src/components/video/_macro-options.md
+++ b/src/components/video/_macro-options.md
@@ -3,7 +3,7 @@
 | videoEmbedUrl | string          | true     | The embed URL to the video hosted on YouTube or Vimeo, for example, `https://www.youtube.com/embed/{ video ID }` or `https://player.vimeo.com/video/{ video ID }`                                              |
 | videoLinkUrl  | string          | true     | The URL to the video hosted on YouTube or Vimeo, for example, `https://www.youtube.com/watch?v={ video ID }` or `https://vimeo.com/video/{ video ID }`. Used to link to the video when cookies are not enabled |
 | title         | string          | true     | Set a descriptive title for the video set by the HTML `title` attribute of the embedded video `<iframe>`                                                                                                       |
-| linkText      | string          | true     | The text to be shown when cookies are not enabled e.g. "Watch the {title} on Youtube"                                                                                                                          |
+| videoLinkText | string          | true     | The text to be shown when cookies are not enabled e.g. "Watch the {title} on Youtube"                                                                                                                          |
 | image         | `Object<Image>` | true     | An object containing path attributes for [the video cover image](#image) when cookies are not enabled                                                                                                          |
 
 ## Image

--- a/src/components/video/_macro.njk
+++ b/src/components/video/_macro.njk
@@ -11,7 +11,7 @@
                 loading="lazy"
             />
         {% endif %}
-        <span class="ons-video__link-text ons-u-mt-xs">{{ params.linkText }}</span>
+        <span class="ons-video__link-text ons-u-mt-xs">{{ params.videoLinkText }}</span>
     {% endset %}
 
     <div class="ons-video ons-js-video">

--- a/src/components/video/_macro.spec.js
+++ b/src/components/video/_macro.spec.js
@@ -9,7 +9,7 @@ const EXAMPLE_VIDEO_YOUTUBE = {
     videoEmbedUrl: 'https://www.youtube.com/embed/_EGJlvkgbPo',
     videoLinkURL: 'https://www.youtube.com/watch?v=_EGJlvkgbPo',
     title: 'Census 2021 promotional TV advert',
-    linkText: 'Example link text',
+    videoLinkText: 'Example link text',
     image: {
         smallSrc: 'example-small.png',
         largeSrc: 'example-large.png',

--- a/src/components/video/example-video.njk
+++ b/src/components/video/example-video.njk
@@ -9,6 +9,6 @@
             "alt": "Youtube video"
         },
         "title": 'Transforming the way we produce statistics | Explaining the Dynamic Population Model | BSL',
-        "linkText": 'Watch “Transforming the way we produce statistics | Explaining the Dynamic Population Model | BSL“ on Youtube'
+        "videoLinkText": 'Watch “Transforming the way we produce statistics | Explaining the Dynamic Population Model | BSL“ on Youtube'
     })
 }}

--- a/src/components/video/video.spec.js
+++ b/src/components/video/video.spec.js
@@ -3,12 +3,12 @@ import { renderComponent, setTestPage } from '../../tests/helpers/rendering';
 const EXAMPLE_VIDEO_YOUTUBE = {
     videoEmbedUrl: 'https://www.youtube.com/embed/_EGJlvkgbPo',
     title: 'Census 2021 promotional TV advert',
-    linkText: 'Example link text',
+    videoLinkText: 'Example link text',
 };
 const EXAMPLE_VIDEO_VIMEO = {
     videoEmbedUrl: 'https://player.vimeo.com/video/838454524?h=24551a3754',
     title: 'Vimeo Video',
-    linkText: 'Example link text',
+    videoLinkText: 'Example link text',
 };
 
 const EXAMPLE_APPROVED_COOKIE = JSON.stringify({ campaigns: true }).replace(/"/g, "'");


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

[77](https://github.com/ONSdigital/design-team/issues/77)

As per the ticket tech notes, renamed the param name from `linkText` to `videoLinkText` in the video component. 
Updated _macro-options.md file

_BREAKING CHANGES_

- **Description of change:** `linkText` parameter is named to `videoLinkText`
- **Reason for change:** This update helps to standardise the parameter names within the project.
- **Migration steps:**
     1. Locate all instances of `linkText` parameter in video component
     2. Replace `linkText` to `videoLinkText`.

    <details>
    <summary><b>Click for example</b></summary>
           
          OLD
          {{
              onsVideo({
                   "linkText": "Example link text"
              })
          }}
    
          NEW
          {{
              onsVideo({
                  "videoLinkText": "Example link text"
              })
          }}


### How to review this PR

Check that all the references to the parameters have been updated
Check that all the visual tests pass

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
