### PR TITLE
Remove spacing around abbreviation text on inputs

### DIFF
--- a/src/components/input/_macro.njk
+++ b/src/components/input/_macro.njk
@@ -103,7 +103,7 @@
                             aria-label="{{ abbr.title }}" role="figure"
                         {% endif %}
                         {% if abbr.title %}title="{{ abbr.title }}"{% endif %}
-                        >{{ abbr.text }}
+                        >{{- abbr.text -}}
                         {{ endTag | safe }}
                     </span>
                 </span>


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3312

Adds Nunjucks syntax to strip the spacing around abbreviation text on inputs

### How to review this PR

- Check the example `example-input-number-prefixed` on the main branch to see that the space is there in the HTML after the pound sign
- Check that the space is gone on this branch

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
