### PR TITLE
Updated color of check icon for summary variant in list component to green

### DIFF
--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -1390,7 +1390,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         
     
 
-    
 
     
         
@@ -1456,7 +1455,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         
     
 
-    
 
     
         
@@ -1522,7 +1520,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         
     
 
-    
 
     
         
@@ -1604,7 +1601,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         
     
 
-    
 
     
         

--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -1390,7 +1390,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         
     
 
-
     
         
     
@@ -1455,7 +1454,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         
     
 
-
     
         
     
@@ -1519,7 +1517,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
         
     
-
 
     
         
@@ -1600,7 +1597,6 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
         
     
-
 
     
         

--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -1391,11 +1391,12 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
 
     
+
+    
         
     
     
     
-
     <ul class="ons-list ons-u-mb-no ons-list--bare">
         
         
@@ -1456,11 +1457,12 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
 
     
+
+    
         
     
     
     
-
     <ul class="ons-list ons-u-mb-no ons-list--bare">
         
         
@@ -1521,11 +1523,12 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
 
     
+
+    
         
     
     
     
-
     <ul class="ons-list ons-u-mb-no ons-list--bare">
         
         
@@ -1602,11 +1605,12 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
 
     
+
+    
         
     
     
     
-
     <ul class="ons-list ons-u-mb-s ons-footer--rows ons-list--bare ons-list--inline">
         
         

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -63,9 +63,6 @@
     &__prefix,
     &__suffix {
         font-family: $font-mono;
-        .ons-icon--check-green {
-            fill: var(--ons-color-leaf-green);
-        }
     }
 
     &--prefix,
@@ -109,6 +106,12 @@
             @extend .ons-u-pt-s;
             @extend .ons-u-pb-s;
             @extend .ons-u-m-no;
+        }
+        .ons-list__prefix,
+        .ons-list__suffix {
+            &--icon-check .ons-icon {
+                fill: var(--ons-color-leaf-green) !important;
+            }
         }
     }
 }

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -63,8 +63,7 @@
     &__prefix,
     &__suffix {
         font-family: $font-mono;
-        .ons-icon {
-            &--check-green {
+        .ons-icon--check-green {
                 fill: var(--ons-color-leaf-green);
             }
         }

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -64,8 +64,7 @@
     &__suffix {
         font-family: $font-mono;
         .ons-icon--check-green {
-                fill: var(--ons-color-leaf-green);
-            }
+            fill: var(--ons-color-leaf-green);
         }
     }
 

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -63,6 +63,11 @@
     &__prefix,
     &__suffix {
         font-family: $font-mono;
+        .ons-icon {
+            &--check-green {
+                fill: var(--ons-color-leaf-green);
+            }
+        }
     }
 
     &--prefix,

--- a/src/components/list/_macro-options.md
+++ b/src/components/list/_macro-options.md
@@ -8,6 +8,7 @@
 | iconPosition | string            | false    | Sets position of icon to “before” or “after” each list item                                                                                            |
 | iconType     | string            | false    | Adds an icon to all the list items when set to the name of one of the [available icons](/foundations/icons#a-to-z). Requires `iconPosition` to be set. |
 | iconSize     | string            | false    | Icon size can be set to match the size of the list item text as detailed in the [typography type scale](/foundations/typography/#type-scale).          |
+| iconClasses  | string            | false    | Adds on option to pass icon classes fron list component.                                                                                               |
 | attributes   | object            | false    | HTML attributes (for example, data attributes) to add to wrapping element                                                                              |
 
 ## ListItem

--- a/src/components/list/_macro-options.md
+++ b/src/components/list/_macro-options.md
@@ -8,7 +8,6 @@
 | iconPosition | string            | false    | Sets position of icon to “before” or “after” each list item                                                                                            |
 | iconType     | string            | false    | Adds an icon to all the list items when set to the name of one of the [available icons](/foundations/icons#a-to-z). Requires `iconPosition` to be set. |
 | iconSize     | string            | false    | Icon size can be set to match the size of the list item text as detailed in the [typography type scale](/foundations/typography/#type-scale).          |
-| iconClasses  | string            | false    | Adds on option to pass icon classes fron list component.                                                                                               |
 | attributes   | object            | false    | HTML attributes (for example, data attributes) to add to wrapping element                                                                              |
 
 ## ListItem

--- a/src/components/list/_macro.njk
+++ b/src/components/list/_macro.njk
@@ -13,11 +13,6 @@
         {% set otherClasses = '' %}
     {% endif %}
 
-    {% if params.iconType == 'check-green' %}
-        {% set iconType = 'check' %}
-        {% set iconClasses = "ons-icon--check-green" %}
-    {% endif %}
-
     {% if params.element and listLength > 1 %}
         {% set listEl = params.element | lower %}
     {% elif (params.element == 'ol') and listLength < 2 %}
@@ -52,7 +47,10 @@
             {% endif %}
 
             {%- if item.prefix or (params.iconPosition == 'before') -%}
-                <span class="ons-list__prefix" {% if listEl != 'ol' %}aria-hidden="true"{% endif %}>
+                <span
+                    class="ons-list__prefix {{ 'ons-list__prefix--icon-check' if params.variants == 'summary' and params.iconType == 'check' }}"
+                    {% if listEl != 'ol' %}aria-hidden="true"{% endif %}
+                >
                     {%- if item.prefix -%}
                         {{- item.prefix -}}.
                     {% elif params.iconPosition == 'before' %}
@@ -60,8 +58,7 @@
                         {{-
                             onsIcon({
                                 "iconType": itemIconType,
-                                "iconSize": params.iconSize,
-                                "classes": iconClasses
+                                "iconSize": params.iconSize
                             })
                         -}}
                     {%- endif -%}
@@ -92,7 +89,10 @@
                 {{- itemText | safe -}}
             {%- endif -%}
             {%- if item.suffix or (params.iconPosition == 'after') -%}
-                <span class="ons-list__suffix" {% if listEl != 'ol' %}aria-hidden="true"{% endif %}>
+                <span
+                    class="ons-list__suffix {{ 'ons-list__suffix--icon-check' if params.variants == 'summary' and params.iconType == 'check' }}"
+                    {% if listEl != 'ol' %}aria-hidden="true"{% endif %}
+                >
                     {%- if item.suffix -%}
                         {{- item.suffix -}}
                     {%- elif (item.index and listEl != 'ol') or (item.index and listEl == 'ol' and 'bare' in variants) -%}
@@ -102,8 +102,7 @@
                         {{-
                             onsIcon({
                                 "iconType": itemIconType,
-                                "iconSize": params.iconSize,
-                                "classes": iconClasses
+                                "iconSize": params.iconSize
                             })
                         -}}
                     {%- endif -%}</span

--- a/src/components/list/_macro.njk
+++ b/src/components/list/_macro.njk
@@ -56,7 +56,8 @@
                         {{-
                             onsIcon({
                                 "iconType": itemIconType,
-                                "iconSize": params.iconSize
+                                "iconSize": params.iconSize,
+                                "classes": params.iconClasses
                             })
                         -}}
                     {%- endif -%}
@@ -97,7 +98,8 @@
                         {{-
                             onsIcon({
                                 "iconType": itemIconType,
-                                "iconSize": params.iconSize
+                                "iconSize": params.iconSize,
+                                "classes": params.iconClasses
                             })
                         -}}
                     {%- endif -%}</span

--- a/src/components/list/_macro.njk
+++ b/src/components/list/_macro.njk
@@ -13,6 +13,11 @@
         {% set otherClasses = '' %}
     {% endif %}
 
+    {% if params.iconType == 'check-green' %}
+        {% set iconType = 'check' %}
+        {% set iconClasses = "ons-icon--check-green" %}
+    {% endif %}
+
     {% if params.element and listLength > 1 %}
         {% set listEl = params.element | lower %}
     {% elif (params.element == 'ol') and listLength < 2 %}
@@ -22,7 +27,6 @@
     {% endif %}
     {% set openingTag = "<" + listEl %}
     {% set closingTag = "</" + listEl + ">" %}
-
     {{ openingTag | safe }}{% if params.id %}{{ ' ' }}id="{{ params.id }}"{% endif %}
     class="ons-list{{ ' ons-list--p' if listEl == 'p' }}{{ ' ' + params.classes if params.classes else '' }}{% if params.variants %}{% if params.variants is not string %}{% for variant in variants %}{{ ' ' }}ons-list--{{ variant }}{% endfor %}{% else %}{{ ' ' }}ons-list--{{ variants }}{% endif %}{% endif %}{{ ' ' + otherClasses if otherClasses else '' }}"{% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ ' ' }}{{ attribute }}{% if value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}>
     {%- for item in params.itemsList -%}
@@ -57,7 +61,7 @@
                             onsIcon({
                                 "iconType": itemIconType,
                                 "iconSize": params.iconSize,
-                                "classes": params.iconClasses
+                                "classes": iconClasses
                             })
                         -}}
                     {%- endif -%}
@@ -99,7 +103,7 @@
                             onsIcon({
                                 "iconType": itemIconType,
                                 "iconSize": params.iconSize,
-                                "classes": params.iconClasses
+                                "classes": iconClasses
                             })
                         -}}
                     {%- endif -%}</span

--- a/src/components/list/_macro.spec.js
+++ b/src/components/list/_macro.spec.js
@@ -569,6 +569,21 @@ describe('macro: list', () => {
             expect(iconsSpy.occurrences[1]).toEqual({ iconType: 'check', iconSize: 'xl' });
         });
 
+        it.each([['before'], ['after']])('renders green check icon when iconType is set to check-green', (iconPosition) => {
+            const faker = templateFaker();
+            const iconsSpy = faker.spy('icon');
+
+            faker.renderComponent('list', {
+                ...EXAMPLE_LIST_TEXT_ITEMS,
+                iconPosition,
+                iconType: 'check-green',
+                iconSize: 'xl',
+            });
+
+            expect(iconsSpy.occurrences[0]).toEqual({ iconType: 'check', iconSize: 'xl', classes: 'ons-icon--check-green' });
+            expect(iconsSpy.occurrences[1]).toEqual({ iconType: 'check', iconSize: 'xl', classes: 'ons-icon--check-green' });
+        });
+
         it.each([['before'], ['after']])('renders a custom icon on specific list items when icon is positioned %s', (iconPosition) => {
             const faker = templateFaker();
             const iconsSpy = faker.spy('icon');

--- a/src/components/list/_macro.spec.js
+++ b/src/components/list/_macro.spec.js
@@ -109,6 +109,32 @@ describe('macro: list', () => {
             expect($('.ons-list').hasClass('ons-list--icons')).toBe(true);
         });
 
+        it('has the correct icon class when variants is `summary`, `iconType` is `check` and `iconPosition` is before', () => {
+            const $ = cheerio.load(
+                renderComponent('list', {
+                    ...EXAMPLE_LIST_TEXT_ITEMS,
+                    iconPosition: 'before',
+                    iconType: 'check',
+                    variants: 'summary',
+                }),
+            );
+
+            expect($('.ons-list__prefix').hasClass('ons-list__prefix--icon-check')).toBe(true);
+        });
+
+        it('has the correct icon class when variants is `summary`, `iconType` is `check` and `iconPosition` is `after`', () => {
+            const $ = cheerio.load(
+                renderComponent('list', {
+                    ...EXAMPLE_LIST_TEXT_ITEMS,
+                    iconPosition: 'after',
+                    iconType: 'check',
+                    variants: 'summary',
+                }),
+            );
+
+            expect($('.ons-list__suffix').hasClass('ons-list__suffix--icon-check')).toBe(true);
+        });
+
         it('renders a <ul> element by default', () => {
             const $ = cheerio.load(renderComponent('list', EXAMPLE_LIST_TEXT_ITEMS));
 
@@ -567,21 +593,6 @@ describe('macro: list', () => {
 
             expect(iconsSpy.occurrences[0]).toEqual({ iconType: 'check', iconSize: 'xl' });
             expect(iconsSpy.occurrences[1]).toEqual({ iconType: 'check', iconSize: 'xl' });
-        });
-
-        it.each([['before'], ['after']])('renders green check icon when iconType is set to check-green', (iconPosition) => {
-            const faker = templateFaker();
-            const iconsSpy = faker.spy('icon');
-
-            faker.renderComponent('list', {
-                ...EXAMPLE_LIST_TEXT_ITEMS,
-                iconPosition,
-                iconType: 'check-green',
-                iconSize: 'xl',
-            });
-
-            expect(iconsSpy.occurrences[0]).toEqual({ iconType: 'check', iconSize: 'xl', classes: 'ons-icon--check-green' });
-            expect(iconsSpy.occurrences[1]).toEqual({ iconType: 'check', iconSize: 'xl', classes: 'ons-icon--check-green' });
         });
 
         it.each([['before'], ['after']])('renders a custom icon on specific list items when icon is positioned %s', (iconPosition) => {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

#3311...

As per the ticket, the defualt color of check icon for the summary variant in list component is changed to green. 

### How to review this PR

Add the check icon in example-summary-list and check that the icon's color is in green

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
