### PR TITLE
Updated color of check icon for summary list variant in list component

### DIFF
--- a/src/components/list/_macro.njk
+++ b/src/components/list/_macro.njk
@@ -48,7 +48,7 @@
 
             {%- if item.prefix or (params.iconPosition == 'before') -%}
                 <span
-                    class="ons-list__prefix {{ 'ons-list__prefix--icon-check' if params.variants == 'summary' and itemIconType == 'check' }}"
+                    class="ons-list__prefix{{ ' ons-list__prefix--icon-check' if params.variants == 'summary' and itemIconType == 'check' }}"
                     {% if listEl != 'ol' %}aria-hidden="true"{% endif %}
                 >
                     {%- if item.prefix -%}
@@ -90,7 +90,7 @@
             {%- endif -%}
             {%- if item.suffix or (params.iconPosition == 'after') -%}
                 <span
-                    class="ons-list__suffix {{ 'ons-list__suffix--icon-check' if params.variants == 'summary' and itemIconType == 'check' }}"
+                    class="ons-list__suffix{{ ' ons-list__suffix--icon-check' if params.variants == 'summary' and itemIconType == 'check' }}"
                     {% if listEl != 'ol' %}aria-hidden="true"{% endif %}
                 >
                     {%- if item.suffix -%}

--- a/src/components/list/_macro.njk
+++ b/src/components/list/_macro.njk
@@ -48,7 +48,7 @@
 
             {%- if item.prefix or (params.iconPosition == 'before') -%}
                 <span
-                    class="ons-list__prefix {{ 'ons-list__prefix--icon-check' if params.variants == 'summary' and params.iconType == 'check' }}"
+                    class="ons-list__prefix {{ 'ons-list__prefix--icon-check' if params.variants == 'summary' and itemIconType == 'check' }}"
                     {% if listEl != 'ol' %}aria-hidden="true"{% endif %}
                 >
                     {%- if item.prefix -%}
@@ -90,7 +90,7 @@
             {%- endif -%}
             {%- if item.suffix or (params.iconPosition == 'after') -%}
                 <span
-                    class="ons-list__suffix {{ 'ons-list__suffix--icon-check' if params.variants == 'summary' and params.iconType == 'check' }}"
+                    class="ons-list__suffix {{ 'ons-list__suffix--icon-check' if params.variants == 'summary' and itemIconType == 'check' }}"
                     {% if listEl != 'ol' %}aria-hidden="true"{% endif %}
                 >
                     {%- if item.suffix -%}


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

As per this ticket https://github.com/ONSdigital/design-system/issues/3311..., the default color of check icon for the summary variant in list component is changed to green. This PR changes the color of check icon to green when the icon is set on each individual list item as well

### How to review this PR

Add the check icon to each individual item and check that color of the icon is green

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
