### PR TITLE
Fix adding custom list item attributes where items aren't links

### DIFF
--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -266,8 +266,8 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m ">
-                                    <main id="main-content" class="ons-page__main ">
+                                <div class="ons-grid__col ons-col-12@m">
+                                    <main id="main-content" class="ons-page__main">
                                         
                                     </main>
                                 </div>
@@ -505,8 +505,8 @@ exports[`base page template matches the footer block override snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m ">
-                                    <main id="main-content" class="ons-page__main ">
+                                <div class="ons-grid__col ons-col-12@m">
+                                    <main id="main-content" class="ons-page__main">
                                         
                                     </main>
                                 </div>
@@ -1302,8 +1302,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m ">
-                                    <main id="main-content" class="ons-page__main ">
+                                <div class="ons-grid__col ons-col-12@m">
+                                    <main id="main-content" class="ons-page__main">
                                         
     <h1>Page Title</h1>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -1393,13 +1393,19 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
         
     
+
+    
+        
     
     
+    
+
     <ul class="ons-list ons-u-mb-no ons-list--bare">
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1407,13 +1413,15 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">About our surveys</a>
+            
+                    <a href="#0" class="ons-list__link">About our surveys</a>
         </li>
         
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1421,13 +1429,15 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Lists of all surveys</a>
+            
+                    <a href="#0" class="ons-list__link">Lists of all surveys</a>
         </li>
         
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1435,7 +1445,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Respondent Charter</a>
+            
+                    <a href="#0" class="ons-list__link">Respondent Charter</a>
         </li>
         </ul>
 
@@ -1457,13 +1468,19 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
         
     
+
+    
+        
     
     
+    
+
     <ul class="ons-list ons-u-mb-no ons-list--bare">
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1471,13 +1488,15 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">What we do</a>
+            
+                    <a href="#0" class="ons-list__link">What we do</a>
         </li>
         
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1485,13 +1504,15 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Transparency and governance</a>
+            
+                    <a href="#0" class="ons-list__link">Transparency and governance</a>
         </li>
         
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1499,7 +1520,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Contact us</a>
+            
+                    <a href="#0" class="ons-list__link">Contact us</a>
         </li>
         </ul>
 
@@ -1521,13 +1543,19 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
         
     
+
+    
+        
     
     
+    
+
     <ul class="ons-list ons-u-mb-no ons-list--bare">
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1549,6 +1577,7 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1556,13 +1585,15 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Release calendar</a>
+            
+                    <a href="#0" class="ons-list__link">Release calendar</a>
         </li>
         
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1570,7 +1601,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">News</a>
+            
+                    <a href="#0" class="ons-list__link">News</a>
         </li>
         </ul>
 
@@ -1601,13 +1633,19 @@ exports[`base page template matches the full configuration snapshot 1`] = `
     
         
     
+
+    
+        
     
     
+    
+
     <ul class="ons-list ons-u-mb-s ons-footer--rows ons-list--bare ons-list--inline">
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1615,13 +1653,15 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Cookies</a>
+            
+                    <a href="#0" class="ons-list__link">Cookies</a>
         </li>
         
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1629,13 +1669,15 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Accessibility statement</a>
+            
+                    <a href="#0" class="ons-list__link">Accessibility statement</a>
         </li>
         
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1643,13 +1685,15 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Privacy and data protection</a>
+            
+                    <a href="#0" class="ons-list__link">Privacy and data protection</a>
         </li>
         
         
         
 
         
+            
             <li class="ons-list__item">
         
             
@@ -1657,7 +1701,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
             
 
             
-            <a href="#0" class="ons-list__link">Terms and conditions</a>
+            
+                    <a href="#0" class="ons-list__link">Terms and conditions</a>
         </li>
         </ul>
 
@@ -1967,8 +2012,8 @@ exports[`base page template matches the meta block override snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m ">
-                                    <main id="main-content" class="ons-page__main ">
+                                <div class="ons-grid__col ons-col-12@m">
+                                    <main id="main-content" class="ons-page__main">
                                         
                                     </main>
                                 </div>
@@ -2190,8 +2235,8 @@ exports[`base page template matches the social block override snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m ">
-                                    <main id="main-content" class="ons-page__main ">
+                                <div class="ons-grid__col ons-col-12@m">
+                                    <main id="main-content" class="ons-page__main">
                                         
                                     </main>
                                 </div>

--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -266,8 +266,8 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m">
-                                    <main id="main-content" class="ons-page__main">
+                                <div class="ons-grid__col ons-col-12@m ">
+                                    <main id="main-content" class="ons-page__main ">
                                         
                                     </main>
                                 </div>
@@ -505,8 +505,8 @@ exports[`base page template matches the footer block override snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m">
-                                    <main id="main-content" class="ons-page__main">
+                                <div class="ons-grid__col ons-col-12@m ">
+                                    <main id="main-content" class="ons-page__main ">
                                         
                                     </main>
                                 </div>
@@ -1302,8 +1302,8 @@ exports[`base page template matches the full configuration snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m">
-                                    <main id="main-content" class="ons-page__main">
+                                <div class="ons-grid__col ons-col-12@m ">
+                                    <main id="main-content" class="ons-page__main ">
                                         
     <h1>Page Title</h1>
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
@@ -2012,8 +2012,8 @@ exports[`base page template matches the meta block override snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m">
-                                    <main id="main-content" class="ons-page__main">
+                                <div class="ons-grid__col ons-col-12@m ">
+                                    <main id="main-content" class="ons-page__main ">
                                         
                                     </main>
                                 </div>
@@ -2235,8 +2235,8 @@ exports[`base page template matches the social block override snapshot 1`] = `
                                 
                             
                             <div class="ons-grid">
-                                <div class="ons-grid__col ons-col-12@m">
-                                    <main id="main-content" class="ons-page__main">
+                                <div class="ons-grid__col ons-col-12@m ">
+                                    <main id="main-content" class="ons-page__main ">
                                         
                                     </main>
                                 </div>

--- a/src/components/list/_macro.njk
+++ b/src/components/list/_macro.njk
@@ -15,7 +15,7 @@
 
     {% if params.element and listLength > 1 %}
         {% set listEl = params.element | lower %}
-    {% elif listLength < 2 %}
+    {% elif (params.element == 'ol') and listLength < 2 %}
         {% set listEl = 'p' %}
     {% else %}
         {% set listEl = 'ul' %}

--- a/src/components/list/_macro.njk
+++ b/src/components/list/_macro.njk
@@ -15,15 +15,22 @@
 
     {% if params.element and listLength > 1 %}
         {% set listEl = params.element | lower %}
-    {% elif (params.element == 'ol') and listLength < 2 %}
+    {% elif listLength < 2 %}
         {% set listEl = 'p' %}
     {% else %}
         {% set listEl = 'ul' %}
     {% endif %}
+
+    {% if listLength < 2 %}
+        {% set attributes = params.itemsList[0].attributes %}
+    {% else %}
+        {% set attributes = params.attributes %}
+    {% endif %}
     {% set openingTag = "<" + listEl %}
     {% set closingTag = "</" + listEl + ">" %}
+
     {{ openingTag | safe }}{% if params.id %}{{ ' ' }}id="{{ params.id }}"{% endif %}
-    class="ons-list{{ ' ons-list--p' if listEl == 'p' }}{{ ' ' + params.classes if params.classes else '' }}{% if params.variants %}{% if params.variants is not string %}{% for variant in variants %}{{ ' ' }}ons-list--{{ variant }}{% endfor %}{% else %}{{ ' ' }}ons-list--{{ variants }}{% endif %}{% endif %}{{ ' ' + otherClasses if otherClasses else '' }}"{% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ ' ' }}{{ attribute }}{% if value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}>
+    class="ons-list{{ ' ons-list--p' if listEl == 'p' }}{{ ' ' + params.classes if params.classes else '' }}{% if params.variants %}{% if params.variants is not string %}{% for variant in variants %}{{ ' ' }}ons-list--{{ variant }}{% endfor %}{% else %}{{ ' ' }}ons-list--{{ variants }}{% endif %}{% endif %}{{ ' ' + otherClasses if otherClasses else '' }}"{% if params.attributes or params.itemsList[0].attributes %}{% for attribute, value in (attributes.items() if attributes is mapping and attributes.items else attributes) %}{{ ' ' }}{{ attribute }}{% if value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}>
     {%- for item in params.itemsList -%}
         {% set sublistClasses = item.listClasses if item.listClasses %}
         {%
@@ -48,7 +55,7 @@
 
             {%- if item.prefix or (params.iconPosition == 'before') -%}
                 <span
-                    class="ons-list__prefix {{ 'ons-list__prefix--icon-check' if params.variants == 'summary' and params.iconType == 'check' }}"
+                    class="ons-list__prefix{{ ' ons-list__prefix--icon-check' if params.variants == 'summary' and params.iconType == 'check' }}"
                     {% if listEl != 'ol' %}aria-hidden="true"{% endif %}
                 >
                     {%- if item.prefix -%}
@@ -74,6 +81,7 @@
                         })
                     }}
                 {%- else -%}
+                    {# Remove setting attributes on link in future update #}
                     <a
                         href="{{ item.url }}"
                         class="ons-list__link{{ ' ons-js-inpagelink' if item.variants == 'inPageLink' }}{{ ' ' + item.classes if item.classes else '' }}"
@@ -90,7 +98,7 @@
             {%- endif -%}
             {%- if item.suffix or (params.iconPosition == 'after') -%}
                 <span
-                    class="ons-list__suffix {{ 'ons-list__suffix--icon-check' if params.variants == 'summary' and params.iconType == 'check' }}"
+                    class="ons-list__suffix{{ ' ons-list__suffix--icon-check' if params.variants == 'summary' and params.iconType == 'check' }}"
                     {% if listEl != 'ol' %}aria-hidden="true"{% endif %}
                 >
                     {%- if item.suffix -%}
@@ -115,9 +123,11 @@
         {% endset %}
 
         {% if listLength > 1 or listEl == 'ul' %}
+            {# Remove if not item.url in future update #}
             <li
                 class="ons-list__item{{ ' ' + item.listClasses if item.listClasses else '' }}"
                 {% if item.current %}aria-current="true"{% endif %}
+                {% if not item.url %}{% if item.attributes %}{% for attribute, value in (item.attributes.items() if item.attributes is mapping and item.attributes.items else item.attributes) %}{{ ' ' }}{{ attribute }}{% if value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}{% endif %}
             >
                 {{- listItem | safe -}}
             </li>


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes #3326 

The refactor now continues to support adding attributes to the link element when the url param is set but also when the url param is not set the attributes will now be set on the `<li>` element which wouldn't happen before.

It also adds a couple of comments to the code to mark where we would remove code when we want to make the breaking change to fix this in a better way which would mean that attributes are always set on the `<li>` element whether url is set or not.

### How to review this PR

- Test adding custom attributes to list items when the url param is set and not set, check that they are then set on the correct elements compare this with the main branch

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
