### PR TITLE
Fix list summary variant spacing to match summary component

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Zip templates
               run: zip -r templates.zip templates/*
             - name: Release
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@v2
               with:
                   files: templates.zip
               env:

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_list_example-summary-list_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_list_example-summary-list_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb13667ddddf83ddda3c6386854e6d69e2f7c7fea3a8a32120af5ed95ed450df
-size 16478
+oid sha256:a80837903241b6c9c9046cb9734b16944c992969e90625a964320f0f473d7ee3
+size 16714

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_list_example-summary-list_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_list_example-summary-list_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ead2dab152a3bbdd2af28b6465d62ac4553dc4721e3c2e48c260d7b874f671c6
-size 11399
+oid sha256:ee9c3aedb9fc7ecbd54df53141be63e18085387efa1396b2b2cb7ba8f5ac6bf4
+size 11625

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_list_example-summary-list_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_list_example-summary-list_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dad0ab15906634fa5fd940c8c1cc8b85d184f84db30d6c27039870900815bf4e
-size 8326
+oid sha256:13ec35b4dd6ee7546d0671f19b1e48b6e8089218f2f8c0e6cca3acdf292e8f95
+size 8534

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -109,8 +109,10 @@
         }
         .ons-list__prefix,
         .ons-list__suffix {
+            margin-right: 0;
             &--icon-check .ons-icon {
                 fill: var(--ons-color-leaf-green) !important;
+                margin-right: 1rem;
             }
         }
     }

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -109,10 +109,10 @@
         }
         .ons-list__prefix,
         .ons-list__suffix {
-            margin-right: 0;
+            @extend .ons-u-m-no;
             &--icon-check .ons-icon {
                 fill: var(--ons-color-leaf-green) !important;
-                margin-right: 1rem;
+                @extend .ons-u-mr-s;
             }
         }
     }

--- a/src/components/list/example-summary-list.njk
+++ b/src/components/list/example-summary-list.njk
@@ -1,10 +1,12 @@
 {% from "components/list/_macro.njk" import onsList %}
 {{
     onsList({
+        "iconPosition": "before",
         "variants": "summary",
         "itemsList": [
             {
-              "text": 'birth certificate'
+                "text": 'birth certificate',
+                "iconType": "check"
             },
             {
                 "text": 'national insurance number'


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3358 

Updates the spacing for the list component summary variant to match the spacing for the summary component when using icons.

Also updated the example to include an icon so that any changes can be captured by tests.

### How to review this PR

Look at the difference in the issue and compare the differences between this branch and main for the summary component and list component when using icons

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
