### PR TITLE
Remove space from button newWindowDescription

### DIFF
--- a/src/components/button/_macro.njk
+++ b/src/components/button/_macro.njk
@@ -111,7 +111,7 @@
         {%- endif -%}
     </span>
     {% if params.url and params.newWindow %}
-        <span class="ons-btn__new-window-description ons-u-vh"> ({{ params.newWindowDescription | default("opens in a new tab") }})</span>
+        <span class="ons-btn__new-window-description ons-u-vh">({{ params.newWindowDescription | default("opens in a new tab") }})</span>
     {% endif %}
     {% if params.buttonContext %}
         <span class="ons-btn__context ons-u-vh">{{ params.buttonContext }}</span>

--- a/src/components/button/_macro.spec.js
+++ b/src/components/button/_macro.spec.js
@@ -393,7 +393,7 @@ describe('macro: button', () => {
                 }),
             );
 
-            expect($('.ons-btn__new-window-description').text()).toBe(' (opens in a new tab)');
+            expect($('.ons-btn__new-window-description').text()).toBe('(opens in a new tab)');
         });
 
         it('has a custom new window description when `newWindow` is `true` and `newWindowDescription` is provided', () => {
@@ -405,7 +405,7 @@ describe('macro: button', () => {
                 }),
             );
 
-            expect($('.ons-btn__new-window-description').text()).toBe(' (custom opens in a new window text)');
+            expect($('.ons-btn__new-window-description').text()).toBe('(custom opens in a new window text)');
         });
 
         it('has the `download` attribute when `variants` contains "download"', () => {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: 

Remove extra space from html when newWindowDescription is set

### How to review this PR

- Test example-button-new-window button example with and without screen reader
- Check space is gone from html

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [ ] I have selected the correct Assignee
-   [ ] I have linked the correct Issue
