### PR TITLE
Rename items summary param for compatibility with Jinja

### DIFF
--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -26,7 +26,7 @@
 | Name         | Type                    | Required | Description                                                         |
 | ------------ | ----------------------- | -------- | ------------------------------------------------------------------- |
 | id           | string                  | false    | The HTML `id` of the row                                            |
-| items        | Array`<SummaryRowItem>` | true     | An array of [items for the row](#summaryrowitem)                    |
+| itemsList    | Array`<SummaryRowItem>` | true     | An array of [items for the row](#summaryrowitem)                    |
 | title        | string                  | false    | The title for the row                                               |
 | error        | boolean                 | false    | Set to “true” display an [error](/components/error) on a row        |
 | errorMessage | string                  | false    | The error message for the row                                       |

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -37,13 +37,13 @@
                                     {% if row.errorMessage %}
                                         <div class="ons-summary__row-title--error ons-u-fs-r">{{ row.errorMessage }}</div>
                                     {% endif %}
-                                    {% if row.items | length > 1 and row.title %}
+                                    {% if row.itemsList | length > 1 and row.title %}
                                         <div class="ons-summary__row-title ons-summary__row-title--no-group-title ons-u-fs-r">
                                             {{- row.title -}}
                                         </div>
                                     {% endif %}
 
-                                    {% for item in row.items %}
+                                    {% for item in row.itemsList %}
                                         <div
                                             class="ons-summary__row{{ ' ons-summary__row--has-values' if item.valueList else "" }}"
                                             {% if item.id %}id="{{ item.id }}"{% endif %}

--- a/src/components/summary/_macro.spec.js
+++ b/src/components/summary/_macro.spec.js
@@ -11,7 +11,7 @@ const EXAMPLE_SUMMARY_ROWS = {
             // Contains - row with icon, attributes and titleAttributes, other value, no action
             id: 'row-id-1',
             title: 'row title 1',
-            items: [
+            itemsList: [
                 {
                     titleAttributes: {
                         a: 123,
@@ -39,7 +39,7 @@ const EXAMPLE_SUMMARY_ROWS = {
             title: 'row title 2',
             error: true,
             errorMessage: 'there are errors',
-            items: [
+            itemsList: [
                 {
                     id: 'item-id-2',
                     valueList: [
@@ -70,7 +70,7 @@ const EXAMPLE_SUMMARY_ROWS = {
             // Contains - row with multiple rows and multiple values
             id: 'row-id-3',
             title: 'row title 3',
-            items: [
+            itemsList: [
                 {
                     id: 'item-id-3',
                     valueList: [
@@ -97,7 +97,7 @@ const EXAMPLE_SUMMARY_ROWS = {
             id: 'row-id-4',
             title: 'row title 4',
             total: true,
-            items: [
+            itemsList: [
                 {
                     id: 'item-id-5',
                     valueList: [
@@ -139,7 +139,7 @@ const EXAMPLE_SUMMARY_GROUPS_NO_ROWS = {
 const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
     rows: [
         {
-            items: [
+            itemsList: [
                 {
                     title: 'row item 1',
                     valueList: [
@@ -193,7 +193,7 @@ const EXAMPLE_SUMMARY_HOUSEHOLD_GROUP = {
             ],
         },
         {
-            items: [
+            itemsList: [
                 {
                     title: 'row item 4',
                     valueList: [

--- a/src/components/summary/example-summary-card-grouped.njk
+++ b/src/components/summary/example-summary-card-grouped.njk
@@ -12,7 +12,7 @@
                         "rows": [
                             {
                                 "title": "Are you John Doe?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -31,7 +31,7 @@
                             },
                             {
                                 "title": "What's your date of birth?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -50,7 +50,7 @@
                             },
                             {
                                 "title": "What is your sex?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -74,7 +74,7 @@
                         "rows": [
                             {
                                 "title": "What is your country of birth?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -93,7 +93,7 @@
                             },
                             {
                                 "title": "What passports do you hold?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -117,7 +117,7 @@
                         "rows": [
                             {
                                 "title": "Have you completed an apprenticeship?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -136,7 +136,7 @@
                             },
                             {
                                 "title": "Have you achieved a GCSE or equivalent qualification?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -159,7 +159,7 @@
                         "title": "Employment history",
                         "rows": [
                             {
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Name of UK company",
                                         "valueList": [
@@ -213,7 +213,7 @@
                                 ]
                             },
                             {
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Name of UK company",
                                         "valueList": [
@@ -280,7 +280,7 @@
                         "rows": [
                             {
                                 "title": "What are your monthly household expenses?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Food",
                                         "valueList": [

--- a/src/components/summary/example-summary-grouped-total.njk
+++ b/src/components/summary/example-summary-grouped-total.njk
@@ -8,7 +8,7 @@
                         "title": "Summary - Section Title",
                         "rows": [
                             {
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Total value of acquisitions for transport assets and equipment",
                                         "valueList": [
@@ -27,7 +27,7 @@
                                 ]
                             },
                             {
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Total value of acquisitions for computers and peripheral devices (hardware)",
                                         "valueList": [
@@ -47,7 +47,7 @@
                             },
                             {
                                 "total": true,
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Grand total for value of acquisitions",
                                         "valueList": [

--- a/src/components/summary/example-summary-grouped-with-errors.njk
+++ b/src/components/summary/example-summary-grouped-with-errors.njk
@@ -9,7 +9,7 @@
                         "rows": [
                             {
                                 "title": "For the period 1 May 2017 to 31 May 2017, what was the total turnover of Essential Enterprise Ltd?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -30,7 +30,7 @@
                                 "title": "What was the value of the business's total sales of food?",
                                 "errorMessage": "Change one or more of the figures so they sum to £600",
                                 "error": true,
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -50,7 +50,7 @@
                             {
                                 "title": "What was the value of the business's total sales of alcohol, confectionery and tobacco?",
                                 "error": true,
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -70,7 +70,7 @@
                             {
                                 "title": "What was the value of the business's total sales of clothing and footwear?",
                                 "error": true,
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {

--- a/src/components/summary/example-summary-grouped.njk
+++ b/src/components/summary/example-summary-grouped.njk
@@ -13,7 +13,7 @@
                         "rows": [
                             {
                                 "title": "Are you John Doe?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -32,7 +32,7 @@
                             },
                             {
                                 "title": "What's your date of birth?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -51,7 +51,7 @@
                             },
                             {
                                 "title": "What is your sex?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -75,7 +75,7 @@
                         "rows": [
                             {
                                 "title": "What is your country of birth?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -94,7 +94,7 @@
                             },
                             {
                                 "title": "What passports do you hold?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -118,7 +118,7 @@
                         "rows": [
                             {
                                 "title": "Have you completed an apprenticeship?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -137,7 +137,7 @@
                             },
                             {
                                 "title": "Have you achieved a GCSE or equivalent qualification?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -160,7 +160,7 @@
                         "title": "Employment history",
                         "rows": [
                             {
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Name of UK company",
                                         "valueList": [
@@ -214,7 +214,7 @@
                                 ]
                             },
                             {
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Name of UK company",
                                         "valueList": [
@@ -281,7 +281,7 @@
                         "rows": [
                             {
                                 "title": "What are your monthly household expenses?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Food",
                                         "valueList": [

--- a/src/components/summary/example-summary-household.njk
+++ b/src/components/summary/example-summary-household.njk
@@ -10,7 +10,7 @@
                         "rows": [
                             {
                                 "title": "Joe Bloggs (You)",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "iconType": "person",
                                         "actions": [
@@ -25,7 +25,7 @@
                             },
                             {
                                 "title": "Barry Scott",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "iconType": "person",
                                         "actions": [
@@ -45,7 +45,7 @@
                             },
                             {
                                 "title": "Wilhelmina Susannah Clementine-Smith",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "iconType": "person",
                                         "actions": [

--- a/src/components/summary/example-summary-hub-minimal.njk
+++ b/src/components/summary/example-summary-hub-minimal.njk
@@ -10,7 +10,7 @@
                         "rows": [
                             {
                                 "title": "People who live here",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "iconType": "check",
                                         "iconVisuallyHiddenText": "Section complete",
@@ -26,7 +26,7 @@
                             },
                             {
                                 "title": "Mary Smith (You)",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "iconType": "check",
                                         "iconVisuallyHiddenText": "Section complete",
@@ -42,7 +42,7 @@
                             },
                             {
                                 "title": "John Smith",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "actions": [
                                             {
@@ -56,7 +56,7 @@
                             },
                             {
                                 "title": "Billy Smith",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "actions": [
                                             {

--- a/src/components/summary/example-summary-hub.njk
+++ b/src/components/summary/example-summary-hub.njk
@@ -10,7 +10,7 @@
                         "rows": [
                             {
                                 "title": "People who live here",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "iconType": "check",
                                         "valueList": [
@@ -30,7 +30,7 @@
                             },
                             {
                                 "title": "Accommodation",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "iconType": "check",
                                         "valueList": [
@@ -50,7 +50,7 @@
                             },
                             {
                                 "title": "Mary Smith (You)",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "iconType": "check",
                                         "valueList": [
@@ -70,7 +70,7 @@
                             },
                             {
                                 "title": "John Smith",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -89,7 +89,7 @@
                             },
                             {
                                 "title": "Billy Smith",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -108,7 +108,7 @@
                             },
                             {
                                 "title": "Sally Smith",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -127,7 +127,7 @@
                             },
                             {
                                 "title": "Wilhelmina Susannah Clementine-Smith (Visitor)",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -146,7 +146,7 @@
                             },
                             {
                                 "title": "Vera Jones (Visitor)",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {

--- a/src/components/summary/example-summary-multiple.njk
+++ b/src/components/summary/example-summary-multiple.njk
@@ -9,7 +9,7 @@
                         "rows": [
                             {
                                 "title": "What are your monthly household expenses?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "title": "Food",
                                         "valueList": [

--- a/src/components/summary/example-summary-no-action.njk
+++ b/src/components/summary/example-summary-no-action.njk
@@ -9,7 +9,7 @@
                         "rows": [
                             {
                                 "title": "What are the dates of the sales period you are reporting for?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {
@@ -21,7 +21,7 @@
                             },
                             {
                                 "title": "Total turnover",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "valueList": [
                                             {

--- a/src/components/summary/example-summary.njk
+++ b/src/components/summary/example-summary.njk
@@ -13,7 +13,7 @@
                             {
                                 "id": "sales-dates-row",
                                 "title": "What are the dates of the sales period you are reporting for?",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "id": "sales-dates",
                                         "valueList": [
@@ -34,7 +34,7 @@
                             {
                                 "title": "For the period 1 January 2015 to 2 February 2017, what was the value of your total turnover, excluding VAT?",
                                 "id": "sales-value-row",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "id": "sales-value",
                                         "valueList": [
@@ -55,7 +55,7 @@
                             {
                                 "id": "sales-reasons-row",
                                 "title": "Please indicate the reasons for any changes in the total turnover",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "id": "sales-reasons",
                                         "valueList": [
@@ -80,7 +80,7 @@
                             {
                                 "id": "sales-detail-row",
                                 "title": "Please describe the changes in total turnover in more detail",
-                                "items": [
+                                "itemsList": [
                                     {
                                         "id": "sales-detail",
                                         "valueList": [

--- a/src/patterns/hub-and-spoke/example-hub-complete.njk
+++ b/src/patterns/hub-and-spoke/example-hub-complete.njk
@@ -40,7 +40,7 @@ layout: ~
                             "rows": [
                                 {
                                     "title": "People who live here",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [
@@ -60,7 +60,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Household accommodation",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [
@@ -80,7 +80,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Mary Smith",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [
@@ -100,7 +100,7 @@ layout: ~
                                 },
                                 {
                                     "title": "John Smith",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [
@@ -120,7 +120,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Billy Smith",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [
@@ -140,7 +140,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Mary Susannah Smith (Visitor)",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [

--- a/src/patterns/hub-and-spoke/example-hub.njk
+++ b/src/patterns/hub-and-spoke/example-hub.njk
@@ -31,7 +31,7 @@ layout: ~
                             "rows": [
                                 {
                                     "title": "People who live here",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [
@@ -51,7 +51,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Household accommodation",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [
@@ -71,7 +71,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Mary Smith",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "iconType": "check",
                                             "valueList": [
@@ -91,7 +91,7 @@ layout: ~
                                 },
                                 {
                                     "title": "John Smith",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {
@@ -110,7 +110,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Billy Smith",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {
@@ -129,7 +129,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Mary Susannah Smith (Visitor)",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {

--- a/src/patterns/hub-and-spoke/example-spoke-summary.njk
+++ b/src/patterns/hub-and-spoke/example-spoke-summary.njk
@@ -36,7 +36,7 @@ layout: ~
                             "rows": [
                                 {
                                     "title": "What type of accommodation is 68 Abingdon Road, Goathill?",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {
@@ -55,7 +55,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Are all the rooms in this accommodation, including the kitchen, bathroom and toilet, behind a door that only this household can use?",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {
@@ -74,7 +74,7 @@ layout: ~
                                 },
                                 {
                                     "title": "How many bedrooms are available for use only by this household?",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {
@@ -93,7 +93,7 @@ layout: ~
                                 },
                                 {
                                     "title": "What type of central heating does have?",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {
@@ -112,7 +112,7 @@ layout: ~
                                 },
                                 {
                                     "title": "Does your household own or rent 68 Abingdon Road, Goathill?",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {
@@ -131,7 +131,7 @@ layout: ~
                                 },
                                 {
                                     "title": "In total, how many cars or vans are owned, or available for use, by members of this household?",
-                                    "items": [
+                                    "itemsList": [
                                         {
                                             "valueList": [
                                                 {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

`items` is a reserved word in python so this was causing an error when we used the param in a Python environment. Renaming is `itemsList` which is what we have used in other components solves this.

### How to review this PR

Test that the summary component in both nunjucks and jinja environments, make sure it works as expected

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
