### PR TITLE
Update migration guide version to 72

### DIFF
--- a/migration_guides/70.x.x-to-72.0.0-migration-guide.md
+++ b/migration_guides/70.x.x-to-72.0.0-migration-guide.md
@@ -4,7 +4,7 @@
 
 This document outlines the steps needed to migrate to version 72.0.0 of our Design System library from versions 70.x.x. This release includes several breaking-changes that may impact your projects. Please follow this guide to ensure a smooth transition.
 
-_\*\*Version 71.0.0 wasn't used due to having previously published a 71.0.0 to npm_\*\*
+Version 71.0.0 wasn't used due to having previously published a 71.0.0 to npm.
 
 ## Global changes
 

--- a/migration_guides/70.x.x-to-72.0.0-migration-guide.md
+++ b/migration_guides/70.x.x-to-72.0.0-migration-guide.md
@@ -4,7 +4,7 @@
 
 This document outlines the steps needed to migrate to version 72.0.0 of our Design System library from versions 70.x.x. This release includes several breaking-changes that may impact your projects. Please follow this guide to ensure a smooth transition.
 
-**_Version 71.0.0 wasn't used due to having previously published a 71.0.0 to npm._**
+**_Version 71.0.0 wasn't used due to having previously published a version 71.0.0 to npm._**
 
 ## Global changes
 

--- a/migration_guides/70.x.x-to-72.0.0-migration-guide.md
+++ b/migration_guides/70.x.x-to-72.0.0-migration-guide.md
@@ -1,8 +1,10 @@
-# Migration Guide from version 70.x.x to 71.0.0
+# Migration Guide from version 70.x.x to 72.0.0
 
 # Introduction
 
-This document outlines the steps needed to migrate to version 71.0.0 of our Design System library from versions 70.x.x. This release includes several breaking-changes that may impact your projects. Please follow this guide to ensure a smooth transition.
+This document outlines the steps needed to migrate to version 72.0.0 of our Design System library from versions 70.x.x. This release includes several breaking-changes that may impact your projects. Please follow this guide to ensure a smooth transition.
+
+Version 71.0.0 wasn't used due to having previously published a 71.0.0 to npm.
 
 ## Global changes
 

--- a/migration_guides/70.x.x-to-72.0.0-migration-guide.md
+++ b/migration_guides/70.x.x-to-72.0.0-migration-guide.md
@@ -4,13 +4,13 @@
 
 This document outlines the steps needed to migrate to version 72.0.0 of our Design System library from versions 70.x.x. This release includes several breaking-changes that may impact your projects. Please follow this guide to ensure a smooth transition.
 
-Version 71.0.0 wasn't used due to having previously published a 71.0.0 to npm.
+_\*\*Version 71.0.0 wasn't used due to having previously published a 71.0.0 to npm_\*\*
 
 ## Global changes
 
 This section will list the changes that will impact more than one component
 
-### **_New sizes introduced for margin and padding utility classes_**
+### _\*\*New sizes introduced for margin and padding utility classes_\*\*
 
 [**Link to PR**](https://github.com/ONSdigital/design-system/pull/3285)
 

--- a/migration_guides/70.x.x-to-72.0.0-migration-guide.md
+++ b/migration_guides/70.x.x-to-72.0.0-migration-guide.md
@@ -4,13 +4,13 @@
 
 This document outlines the steps needed to migrate to version 72.0.0 of our Design System library from versions 70.x.x. This release includes several breaking-changes that may impact your projects. Please follow this guide to ensure a smooth transition.
 
-Version 71.0.0 wasn't used due to having previously published a 71.0.0 to npm.
+**_Version 71.0.0 wasn't used due to having previously published a 71.0.0 to npm._**
 
 ## Global changes
 
 This section will list the changes that will impact more than one component
 
-### _\*\*New sizes introduced for margin and padding utility classes_\*\*
+### **_New sizes introduced for margin and padding utility classes_**
 
 [**Link to PR**](https://github.com/ONSdigital/design-system/pull/3285)
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

We need to skip version 71.0.0 due to a previous version 71.0.0 being published to npm. This is why we will remove that version and go straight to 72.0.0.

This PR updates the migration guide to reflect that.

### How to review this PR

Changes make sense

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
