### PR TITLE
Fix lighthouse address input test

### DIFF
--- a/src/components/autosuggest/autosuggest.spec.js
+++ b/src/components/autosuggest/autosuggest.spec.js
@@ -609,6 +609,8 @@ describe('script: autosuggest', () => {
                 expect(resultsItemCount).toBe(1);
                 const warningText = await page.$eval('.ons-autosuggest__warning', (node) => node.textContent);
                 expect(warningText.trim()).toBe('!Sorry, there is a problem.');
+                const warningContainer = await page.$eval('.ons-autosuggest__warning', (node) => node.id);
+                expect(warningContainer).toBe('country-of-birth-listbox');
             });
 
             it('the list and results element should be removed from the page', async () => {
@@ -657,7 +659,7 @@ describe('script: autosuggest', () => {
                 await page.type('.ons-js-autosuggest-input', 'England', { delay: 20 });
                 await page.keyboard.press('ArrowUp');
                 await page.keyboard.press('Enter');
-                // Defocus the autosuggest input.
+                // Unfocus the autosuggest input
                 await page.keyboard.press('Tab');
                 await page.focus('.ons-js-autosuggest-input');
 

--- a/src/components/autosuggest/autosuggest.ui.js
+++ b/src/components/autosuggest/autosuggest.ui.js
@@ -511,6 +511,7 @@ export default class AutosuggestUI {
         const warningSpanElement = document.createElement('span');
         const warningBodyElement = document.createElement('div');
 
+        warningContainer.id = this.listbox.getAttribute('id');
         warningContainer.className = 'ons-autosuggest__warning';
         warningElement.className = 'ons-panel ons-panel--warn ons-autosuggest__panel';
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: ONSdigital/design-team#215

This change adds an id to the warning container so that when the warning is displayed the `aria-owns` and `aria-controls` attributes on the input have valid values because the id will now exist on the page and not just when there is no error. Before this the results container had an id but the error panel didnt.

### How to review this PR

- Check the lighthouse tests in the github actions and see that the result for the test for the `example-address-input` example is now 100
- Also run the test locally on this branch in chrome and on the main branch to see that this issue is now fixed.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
