### PR TITLE
Fix lighthouse hub and spoke test

### DIFF
--- a/src/components/summary/_macro-options.md
+++ b/src/components/summary/_macro-options.md
@@ -54,12 +54,12 @@
 
 ## SummaryAction
 
-| Name               | Type   | Required | Description                                                                                 |
-| ------------------ | ------ | -------- | ------------------------------------------------------------------------------------------- |
-| text               | string | true     | Text for the action link                                                                    |
-| url                | string | true     | The URL for the HTML `href` attribute of the link used to change the value of the row item  |
-| attributes         | object | false    | HTML attributes (for example, data attributes) to add to the action link                    |
-| visuallyHiddenText | string | false    | Visually hidden text in a span under the action link to add more context for screen readers |
+| Name               | Type   | Required | Description                                                                                                                      |
+| ------------------ | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| text               | string | true     | Text for the action link                                                                                                         |
+| url                | string | true     | The URL for the HTML `href` attribute of the link used to change the value of the row item                                       |
+| attributes         | object | false    | HTML attributes (for example, data attributes) to add to the action link                                                         |
+| visuallyHiddenText | string | false    | Visually hidden text in a span under the action link to add more context for screen readers, , defaults the text in `text` param |
 
 ## SummaryLink
 

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -112,12 +112,10 @@
                                                         class="ons-summary__button"
                                                         {% if action.attributes %}{% for attribute, value in (action.attributes.items() if action.attributes is mapping and action.attributes.items else action.attributes) %}{{ ' ' }}{{ attribute }}="{{ value }}"{% endfor %}{% endif %}
                                                     >
-                                                        <span class="ons-summary__button-text" aria-hidden="true">
-                                                            {{- action.text -}}
-                                                        </span>
-                                                        <span class="ons-u-vh">
-                                                            {{ action.visuallyHiddenText | default (action.text) }}
-                                                        </span>
+                                                        <span class="ons-summary__button-text" aria-hidden="true">{{- action.text -}}</span>
+                                                        <span class="ons-u-vh"
+                                                            >{{ action.visuallyHiddenText | default (action.text) }}</span
+                                                        >
                                                     </a>
                                                 {% endfor %}
                                             </dd>

--- a/src/components/summary/_macro.njk
+++ b/src/components/summary/_macro.njk
@@ -119,7 +119,9 @@
                                                             <span class="ons-summary__button-text" aria-hidden="true">
                                                                 {{- action.text -}}
                                                             </span>
-                                                            <span class="ons-u-vh">{{ action.visuallyHiddenText }}</span>
+                                                            <span class="ons-u-vh"
+                                                                >{{ action.visuallyHiddenText | default (action.text) }}</span
+                                                            >
                                                         </a>
                                                     {% endfor %}
                                                 </dd>


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: ONSdigital/design-team#224

Lighthouse tests on summary component are failing because the context is missing on the action links because the `visuallyHiddenText` param isnt being set in the examples. So this PR makes the change so that `visuallyHiddenText` can still be set but it is defaulted to what the `text` param is being set to so that there will be some context set.

### How to review this PR

- Check the lighthouse tests in the github actions and see that the result for the test for the hub and spoke examples is now at least 91. The summary PR (ONSdigital/design-team#219) will make the other fixes to take it up to 100.
- Also run the test locally on this branch in chrome and on the main branch to see that this issue is now fixed

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
