### PR TITLE
Document id param on autosuggest component

### DIFF
--- a/src/components/autosuggest/_macro-options.md
+++ b/src/components/autosuggest/_macro-options.md
@@ -17,3 +17,4 @@
 | resultsTitleId      | string                               | true     | ID for the results title. The ID is used in the results `aria-labelledby` to provide context for the results                                                 |
 | input               | `Input` [_(ref)_](/components/input) | true     | Configuration object for the input                                                                                                                           |
 | language            | string                               | false    | The ISO 639-1 Code will override the default language in page. Please note that only 'en', 'cy' and 'ni' is currently supported                              |
+| id                  | string                               | false    | The `id` if the input                                                                                                                                        |

--- a/src/components/back-to-top/_macro-options.md
+++ b/src/components/back-to-top/_macro-options.md
@@ -1,4 +1,4 @@
 | Name        | Type   | Required | Description                                                    |
 | ----------- | ------ | -------- | -------------------------------------------------------------- |
 | description | string | false    | The text label added to the button. Defaults to "Back to Top"  |
-| anchor      | string | false    | The 'id' of the element the button jumps to. Defaults to "Top" |
+| anchor      | string | false    | The `id` of the element the button jumps to. Defaults to "Top" |


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3360 
Adds the id param for the autosuggest component to the documentation.

### How to review this PR

Check that the documentation makes sense

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [ ] I have selected the correct Assignee
-   [ ] I have linked the correct Issue
