### PR TITLE
Fix button logic for when `noIcon` param is set to false

### DIFF
--- a/src/components/button/_macro.njk
+++ b/src/components/button/_macro.njk
@@ -11,7 +11,7 @@
             {# Default icon position before label #}
             {% set iconPosition = "before" %}
         {% endif %}
-    {% elif params.iconType is not defined and params.noIcon is not defined %}
+    {% elif params.iconType is not defined and params.noIcon != true %}
         {% if params.url and params.newWindow %}
             {# CTA link opening in new tab #}
             {% set iconType = "external-link" %}

--- a/src/components/button/_macro.spec.js
+++ b/src/components/button/_macro.spec.js
@@ -360,7 +360,7 @@ describe('macro: button', () => {
                 noIcon: true,
             });
 
-            expect(iconsSpy.occurrences[0]).toBe(undefined);
+            expect(iconsSpy.occurrences[0]).toBeUndefined();
         });
 
         it('has default `arrow-next` icon when noIcon is set to false', () => {

--- a/src/components/button/_macro.spec.js
+++ b/src/components/button/_macro.spec.js
@@ -351,6 +351,30 @@ describe('macro: button', () => {
             expect(iconsSpy.occurrences[0].iconType).toBe('arrow-next');
         });
 
+        it('has no icon when noIcon is set to true', () => {
+            const faker = templateFaker();
+            const iconsSpy = faker.spy('icon');
+
+            faker.renderComponent('button', {
+                url: 'http://example.com',
+                noIcon: true,
+            });
+
+            expect(iconsSpy.occurrences[0]).toBe(undefined);
+        });
+
+        it('has default `arrow-next` icon when noIcon is set to false', () => {
+            const faker = templateFaker();
+            const iconsSpy = faker.spy('icon');
+
+            faker.renderComponent('button', {
+                url: 'http://example.com',
+                noIcon: false,
+            });
+
+            expect(iconsSpy.occurrences[0].iconType).toBe('arrow-next');
+        });
+
         it('opens in a new window when `newWindow` is `true`', () => {
             const $ = cheerio.load(
                 renderComponent('button', {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3417 

Fixes the logic around the `noIcon` param so that it does show the arrow icon on link buttons when `noIcon` is set to false.

### How to review this PR

Test using the button component with url set and `noIcon` set to true and false, and without being set at all and see that the arrow icon is displayed for when it is set to false or not set and not displayed when it is set to true

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
