### PR TITLE
Change html font size to 100% so browser font size settings are respe…

### DIFF
--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -1,7 +1,7 @@
 html {
     @include font-smoothing;
 
-    font-size: 100%;
+    font-size: calc((100% / 16) * strip-unit($base));
 }
 
 body {

--- a/src/scss/base/_typography.scss
+++ b/src/scss/base/_typography.scss
@@ -1,7 +1,7 @@
 html {
     @include font-smoothing;
 
-    font-size: $base;
+    font-size: 100%;
 }
 
 body {

--- a/src/scss/helpers/_mq.scss
+++ b/src/scss/helpers/_mq.scss
@@ -57,7 +57,7 @@
 /// @return {Number} - Unitless number
 @function strip-unit($number) {
     @if meta.type-of($number) == 'number' and not math.is-unitless($number) {
-        @return $number / ($number * 0 + 1);
+        @return math.div($number, ($number * 0 + 1));
     }
 
     @return $number;


### PR DESCRIPTION
### What is the context of this PR?

Fixes: [ONSDESYS-229](https://jira.ons.gov.uk/browse/ONSDESYS-229)

When changing the font size settings in Chrome this had no impact on the font sizes displayed on the web page. A change has been made so the browser settings are respected.

Initially I set the font size on the html to be 100% but this then ignored ability to set the value of the `$base` font size. I've now updated this so the `$base` font size is still taken in to account.

### How to review this PR

1. Open a design system page in Chrome
2. Open Chrome settings
3. Go to the Appearance tab
4. Alter the Font size settings
5. Check this has updated the font sizes on the design system page
6. Update the value of `$base` inside `src/scss/vars/_typography.scss` and make sure this value is respected

The visual regression tests should not fail.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
