### PR TITLE
Alter string concatenation based on recommendation in ticket ONSDESYS…

### DIFF
--- a/src/components/footer/_macro.njk
+++ b/src/components/footer/_macro.njk
@@ -207,7 +207,7 @@
                 </div>
                 {% if params.copyrightDeclaration %}
                     <!-- Copyright -->
-                    {% set copyrightDeclaration = '&copy; ' + params.copyrightDeclaration.copyright + '<br /> ' + params.copyrightDeclaration.text %}
+                    {% set copyrightDeclaration = '&copy; ' ~ params.copyrightDeclaration.copyright ~ '<br /> ' ~ params.copyrightDeclaration.text %}
                     <div class="ons-grid ons-grid-flex ons-grid-flex--between">
                         <div class="ons-grid__col">
                             <p class="ons-u-fs-s ons-u-mb-l ons-footer__copyright">{{- copyrightDeclaration | safe -}}</p>


### PR DESCRIPTION
### What is the context of this PR?

Applies the change suggested in [ONSDESYS-231](https://jira.ons.gov.uk/browse/ONSDESYS-231)

I wasn't sure how to test this locally to see if it fixes the specific issue raised but applying the suggested fix doesn't appear to break anything. 

Unfortunately I couldn't find anything in the nunjucks documentation around string concatenation but I believe Nunjucks is based on Jinja and the [`~` is used for string concatenation](https://jinja.palletsprojects.com/en/stable/templates/#other-operators). A ChatGPT solution suggested `~` is the correct way to concatenate strings.

### How to review this PR

Run the tests and check nothing breaks.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
