### PR TITLE
Increase search button height on small screens

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -28,11 +28,9 @@ $button-shadow-size: 3px;
 
     &--search {
         .ons-icon {
-            @include mq(s, l) {
-                margin-right: 0.5rem;
-            }
-            @include mq(xs, 499px) {
-                margin: 0.125rem 0;
+            margin: 0.125rem 0.5rem 0.125rem 0;
+            @include mq(xs, s) {
+                margin-right: 0;
             }
         }
     }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -31,6 +31,9 @@ $button-shadow-size: 3px;
             @include mq(s, l) {
                 margin-right: 0.5rem;
             }
+            @include mq(xs, 499px) {
+                margin: 0.125rem 0;
+            }
         }
     }
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: #3457 [ONSDESYS-233](https://jira.ons.gov.uk/browse/ONSDESYS-233)

The button height is set by the height of the text in the button so when the button has only an icon the button is smaller. I have added a margin top and bottom to the icon to stop the shrinking of the button. To do this I have flipped the logic for the margin right so that the margin right is always set and then is overridden and set to 0 on smaller screens.

### How to review this PR

Use the `example-header-external-with-navigation-and-search` example and see that on `main` the search button is smaller than the menu button when you reduce the window width to > 500px. See that on this branch that in the same situation the button is now the same height.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
