### PR TITLE
Split out global chart options from ones specific to the colour theme or chart type

### DIFF
--- a/src/components/charts/chart.js
+++ b/src/components/charts/chart.js
@@ -1,4 +1,5 @@
-import ChartOptions from './chart-options';
+import CommonChartOptions from './common-chart-options';
+import SpecificChartOptions from './specific-chart-options';
 import LineChartPlotOptions from './line-chart';
 import Highcharts from 'highcharts';
 import Accessibility from 'highcharts/modules/accessibility';
@@ -19,10 +20,18 @@ class HighchartsBaseChart {
 
         this.config = JSON.parse(this.node.querySelector(`[data-highcharts-config--${this.uuid}]`).textContent);
 
-        this.commonChartOptions = new ChartOptions(this.theme, this.title, this.chartType);
+        this.commonChartOptions = new CommonChartOptions();
+        this.specificChartOptions = new SpecificChartOptions(this.theme, this.chartType);
 
-        this.setCommonChartOptions();
-        console.log(Highcharts.getOptions());
+        // Sets some options globally for all charts
+        // Only needs to be done once
+        // todo: use a suitable namespace for this
+        if (window.commonOptionsDefined === undefined) {
+            this.setCommonChartOptions();
+            window.commonOptionsDefined = true;
+        }
+        this.setSpecificChartOptions();
+
         Accessibility.Highcharts = Highcharts;
         Highcharts.chart(chartNode, this.config);
     }
@@ -30,11 +39,22 @@ class HighchartsBaseChart {
     // Set up the global Highcharts options
     setCommonChartOptions = () => {
         const chartOptions = this.commonChartOptions.getOptions();
-        chartOptions.plotOptions = {
+        Highcharts.setOptions(chartOptions);
+    };
+
+    // Set up the chart specific options
+    // This is done for each chart as the options vary
+    setSpecificChartOptions = () => {
+        const specificChartOptions = this.specificChartOptions.getOptions();
+        // loop over specificChartOptions and add to config
+        for (const option in specificChartOptions) {
+            this.config[option] = specificChartOptions[option];
+        }
+        // Sets line chart options
+        this.config.plotOptions = {
             line: new LineChartPlotOptions().plotOptions.line,
         };
-
-        Highcharts.setOptions(chartOptions);
+        console.log(this.config);
     };
 }
 

--- a/src/components/charts/common-chart-options.js
+++ b/src/components/charts/common-chart-options.js
@@ -2,10 +2,6 @@
 class CommonChartOptions {
     constructor() {
         this.constants = {
-            primaryTheme: ['#206095', '#27a0cc', '#003c57', '#118c7b', '#a8bd3a', '#871a5b', '#f66068', '#746cb1', '#22d0b6'],
-            // Alternate theme colours from https://service-manual.ons.gov.uk/data-visualisation/colours/using-colours-in-charts
-            alternateTheme: ['#206095', '#27A0CC', '#871A5B', '#A8BD3A', '#F66068'],
-            labelColor: '#414042',
             axisLabelColor: '#707071',
             gridLineColor: '#d9d9d9',
             zeroLineColor: '#b3b3b3',

--- a/src/components/charts/common-chart-options.js
+++ b/src/components/charts/common-chart-options.js
@@ -1,6 +1,6 @@
 /* this contains global options for all charts */
-class ChartOptions {
-    constructor(theme, title, type) {
+class CommonChartOptions {
+    constructor() {
         this.constants = {
             primaryTheme: ['#206095', '#27a0cc', '#003c57', '#118c7b', '#a8bd3a', '#871a5b', '#f66068', '#746cb1', '#22d0b6'],
             // Alternate theme colours from https://service-manual.ons.gov.uk/data-visualisation/colours/using-colours-in-charts
@@ -16,25 +16,11 @@ class ChartOptions {
 
         // These options can be set globally for all charts
         this.options = {
-            colors: theme === 'primary' ? this.constants.primaryTheme : this.constants.alternateTheme,
             chart: {
                 backgroundColor: 'transparent',
                 style: {
                     fontFamily: '"OpenSans", "Helvetica Neue", arial, sans-serif',
                     color: '#222222',
-                },
-            },
-            legend: {
-                align: 'left',
-                verticalAlign: 'top',
-                layout: 'horizontal',
-                symbolWidth: type === 'line' ? 20 : 12,
-                symbolHeight: type === 'line' ? 3 : 12,
-                margin: 30,
-                itemStyle: {
-                    color: this.constants.labelColor,
-                    fontSize: this.constants.desktopFontSize,
-                    fontWeight: 'normal',
                 },
             },
             // chart title is rendered in wagtail
@@ -115,4 +101,4 @@ class ChartOptions {
     getOptions = () => this.options;
 }
 
-export default ChartOptions;
+export default CommonChartOptions;

--- a/src/components/charts/specific-chart-options.js
+++ b/src/components/charts/specific-chart-options.js
@@ -1,0 +1,40 @@
+/* this contains global options for all charts */
+class SpecificChartOptions {
+    constructor(theme, type) {
+        this.constants = {
+            primaryTheme: ['#206095', '#27a0cc', '#003c57', '#118c7b', '#a8bd3a', '#871a5b', '#f66068', '#746cb1', '#22d0b6'],
+            // Alternate theme colours from https://service-manual.ons.gov.uk/data-visualisation/colours/using-colours-in-charts
+            alternateTheme: ['#206095', '#27A0CC', '#871A5B', '#A8BD3A', '#F66068'],
+            labelColor: '#414042',
+            axisLabelColor: '#707071',
+            gridLineColor: '#d9d9d9',
+            zeroLineColor: '#b3b3b3',
+            // Responsive font sizes
+            mobileFontSize: '0.875rem',
+            desktopFontSize: '1rem',
+        };
+
+        // These options vary according to the chart type or theme,
+        // so need to be set for each chart
+        this.options = {
+            colors: theme === 'primary' ? this.constants.primaryTheme : this.constants.alternateTheme,
+            legend: {
+                align: 'left',
+                verticalAlign: 'top',
+                layout: 'horizontal',
+                symbolWidth: type === 'line' ? 20 : 12,
+                symbolHeight: type === 'line' ? 3 : 12,
+                margin: 30,
+                itemStyle: {
+                    color: this.constants.labelColor,
+                    fontSize: this.constants.desktopFontSize,
+                    fontWeight: 'normal',
+                },
+            },
+        };
+    }
+
+    getOptions = () => this.options;
+}
+
+export default SpecificChartOptions;

--- a/src/components/charts/specific-chart-options.js
+++ b/src/components/charts/specific-chart-options.js
@@ -6,11 +6,7 @@ class SpecificChartOptions {
             // Alternate theme colours from https://service-manual.ons.gov.uk/data-visualisation/colours/using-colours-in-charts
             alternateTheme: ['#206095', '#27A0CC', '#871A5B', '#A8BD3A', '#F66068'],
             labelColor: '#414042',
-            axisLabelColor: '#707071',
-            gridLineColor: '#d9d9d9',
-            zeroLineColor: '#b3b3b3',
             // Responsive font sizes
-            mobileFontSize: '0.875rem',
             desktopFontSize: '1rem',
         };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -31,6 +31,4 @@ import '../components/timeout-modal/timeout-modal.dom';
 import '../components/timeout-panel/timeout-panel.dom';
 import '../components/video/video.dom';
 import '../components/charts/chart';
-import '../components/charts/chart-options';
-import '../components/charts/line-chart';
 import '../components/charts/chart.dom';


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Demo for @precious-onyenaucheya-ons to show how we might split the chart options into ones that are global, for all chart types, and ones that need to be updated for each chart.

### How to review this PR

Have a look at the code changes and test them to see if they make sense.
Either merge them to your PR if you would like to, or copy and adapt if you would prefer.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [ ] I have selected the correct Assignee
-   [ ] I have linked the correct Issue
