### PR TITLE
Remove Google analytics not connected logging message

### DIFF
--- a/.github/workflows/macro-and-script-tests.yml
+++ b/.github/workflows/macro-and-script-tests.yml
@@ -21,4 +21,4 @@ jobs:
             - name: Clear jest cache
               run: yarn test:clear-cache
             - name: Run macro and script tests
-              run: yarn test
+              run: yarn test | grep -v "Google analytics not connected"


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

[ONSDESYS-134](https://jira.ons.gov.uk/browse/ONSDESYS-134)

I have added a filter for the test command(yarn test) to avoid Google analytics not connected logging

### How to review this PR

Compare the macro workflow of this PR with any other PR and confirm that "Google analytics not connected" is not present in this PR.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
