### PR TITLE
Implement jinja's `tojson` filter to securely escape JSON data

### DIFF
--- a/lib/create-nunjucks-environment.js
+++ b/lib/create-nunjucks-environment.js
@@ -2,6 +2,7 @@ import nunjucks from 'nunjucks';
 
 import setAttribute from './filters/set-attribute.js';
 import setAttributes from './filters/set-attributes.js';
+import tojson from './filters/tojson';
 
 export default function createNunjucksEnvironment(loader) {
     const templatePaths = ['src'];
@@ -11,6 +12,7 @@ export default function createNunjucksEnvironment(loader) {
 
     nunjucksEnvironment.addFilter('setAttribute', setAttribute);
     nunjucksEnvironment.addFilter('setAttributes', setAttributes);
+    nunjucksEnvironment.addFilter('tojson', tojson);
 
     return nunjucksEnvironment;
 }

--- a/lib/filters/tojson.js
+++ b/lib/filters/tojson.js
@@ -1,0 +1,16 @@
+import nunjucks from 'nunjucks';
+
+/**
+ * Implement Jinja2's `tojson` filter, and should be used where possible over `| dump`.
+ *
+ * The returned string is safe to render in HTML documents and <script> tags.
+ *
+ * See also: https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.tojson
+ *
+ * Upstream issue: https://github.com/mozilla/nunjucks/issues/1483.
+ */
+export default function tojson(data) {
+    return new nunjucks.runtime.SafeString(
+        JSON.stringify(data).replaceAll('<', '\\u003c').replaceAll('>', '\\u003e').replaceAll('&', '\\u0026').replaceAll("'", '\\u0027'),
+    );
+}

--- a/lib/filters/tojson.spec.js
+++ b/lib/filters/tojson.spec.js
@@ -1,0 +1,12 @@
+import tojson from './tojson';
+
+describe('tojson', () => {
+    it('converts data to JSON', () => {
+        expect(tojson({ foo: 1 }).toString()).toBe('{"foo":1}');
+    });
+    it('escapes complex data', () => {
+        expect(tojson('"ba&r\'').toString()).toBe('"\\"ba\\u0026r\\u0027"');
+        expect(tojson('<bar>').toString()).toBe('"\\u003cbar\\u003e"');
+        expect(tojson("'''").toString()).toBe('"\\u0027\\u0027\\u0027"');
+    });
+});


### PR DESCRIPTION
### What is the context of this PR?

This PR implements jinja's [`tojson`](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.tojson) filter to securely embed complex objects in pages, especially when passing data down to client-side JS.

- https://jira.ons.gov.uk/browse/ONSDESYS-344

Suggested usage:

```html
<script id="hello-data" type="application/json">{{ data|tojson }}</script>

<script>
  const data = JSON.parse(document.getElementById('hello-data').textContent);
</script>
```

(Django implements this as a separate [`json_script`](https://docs.djangoproject.com/en/5.1/ref/templates/builtins/#json-script) filter, which I can implement if we think it would be useful?)

### How to review this PR

- [jinja2's implementation](https://github.com/pallets/jinja/blob/6aeab5d1da0bc0793406d7b402693e779b6cca7a/src/jinja2/utils.py#L668-674)
- [jinja2's tests](https://github.com/pallets/jinja/blob/220e67ae999c24e4077d7bf5bdc932757b65a338/tests/test_filters.py#L816)

### Checklist

This needs to be completed by the person raising the PR.

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
