### PR TITLE
Add a packageManager line to package.json as required by yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,5 +132,6 @@
     },
     "publishConfig": {
         "access": "public"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

When running any `yarn` command, or switching branches, `package.json` automatically gets updated with a `packageManager` line.

The following message is displayed in the terminal:

```
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
```

This PR commits the automatically added line, as recommended in various places:

https://github.com/mdn/content/issues/33630
https://github.com/ionic-team/vscode-ionic/issues/151

### How to review this PR

Check out the branch and try running `yarn` commands.

`package.json` should no longer get automatically updated.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
