### PR TITLE
Headline figures - Card component variant without Sparkline

### DIFF
--- a/backstop_data/bitmaps_reference/ds-vr-test__components_card_example-card-set-with-headline-figures_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_card_example-card-set-with-headline-figures_0_document_0_desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88c89290dfdd9963fcacf1053320833e828e20affd2e0c1a5f0fad41ca81f456
+size 42793

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_card_example-card-set-with-headline-figures_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_card_example-card-set-with-headline-figures_0_document_1_tablet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:017b557a4dcd1b53d84fe26e40ed763a9d49baab975c782af9b1b6ed479be8b3
+size 41808

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_card_example-card-set-with-headline-figures_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_card_example-card-set-with-headline-figures_0_document_2_mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb8cc29fbe36a0e400a1dcdf73ef2ce1cc978b021d3c296f9fd0af9dd67fabcc
+size 39009

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -2,6 +2,11 @@
     margin: 0 0 2rem;
     width: 100%;
 
+    &--headline {
+        background-color: var(--ons-color-banner-bg);
+        padding: 2rem;
+    }
+
     &__link {
         display: flex;
         flex-direction: column;

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -2,7 +2,7 @@
     margin: 0 0 2rem;
     width: 100%;
 
-    &--headline {
+    &--feature {
         background-color: var(--ons-color-banner-bg);
         padding: 2rem;
     }

--- a/src/components/card/_macro-options.md
+++ b/src/components/card/_macro-options.md
@@ -1,8 +1,9 @@
-| Name  | Type                      | Required | Description                                                                                                                                           |
-| ----- | ------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| title | `Object<Title>`           | true     | An object containing title attributes for [the card’s title](#title).                                                                                 |
-| image | `Object<Image>` or `true` | false    | An object containing path attributes for [the card’s image](#image). If value is `true` will show placeholder with root as `placeholderURL` base path |
-| body  | `Object<Body>`            | true     | An object containing body attributes for [the card’s body](#body).                                                                                    |
+| Name    | Type                      | Required | Description                                                                                                                                           |
+| ------- | ------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| title   | `Object<Title>`           | true     | An object containing title attributes for [the card’s title](#title).                                                                                 |
+| image   | `Object<Image>` or `true` | false    | An object containing path attributes for [the card’s image](#image). If value is `true` will show placeholder with root as `placeholderURL` base path |
+| body    | `Object<Body>`            | true     | An object containing body attributes for [the card’s body](#body).                                                                                    |
+| variant | string                    | false    | A single value to adjust the component using available variants: “headline”                                                                           |
 
 ## Image
 
@@ -18,6 +19,7 @@
 | Name         | Type   | Required | Description                                                                   |
 | ------------ | ------ | -------- | ----------------------------------------------------------------------------- |
 | text         | string | true     | The text for the card title                                                   |
+| subtitle     | string | false    | The text for the card subtitle                                                |
 | headingLevel | int    | false    | Number used to determine the heading level of the card title. Defaults to `2` |
 | classes      | string | false    | Font size classes for the card title. Defaults to `ons-u-fs-m`                |
 | url          | string | true     | The URL for the title link `href` attribute                                   |
@@ -27,6 +29,7 @@
 
 | Name      | Type                                                        | Required | Description                                                                               |
 | --------- | ----------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------- |
+| figure    | string                                                      | false    | Headline figure for the card element                                                      |
 | text      | string                                                      | true     | The excerpt text for the card element                                                     |
 | id        | string                                                      | true     | The HTML `id` for the card text excerpt. Used for the card’s `aria-describedBy` attribute |
 | itemsList | `Array<ListItem>` [_(ref)_](/foundations/typography/#lists) | false    | A list of links for child items of the card                                               |

--- a/src/components/card/_macro-options.md
+++ b/src/components/card/_macro-options.md
@@ -3,7 +3,7 @@
 | title   | `Object<Title>`           | true     | An object containing title attributes for [the card’s title](#title).                                                                                 |
 | image   | `Object<Image>` or `true` | false    | An object containing path attributes for [the card’s image](#image). If value is `true` will show placeholder with root as `placeholderURL` base path |
 | body    | `Object<Body>`            | true     | An object containing body attributes for [the card’s body](#body).                                                                                    |
-| variant | string                    | false    | A single value to adjust the component using available variants: “headline”                                                                           |
+| variant | string                    | false    | A single value to adjust the component using available variants: “feature”                                                                            |
 
 ## Image
 

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -4,7 +4,7 @@
     {% set closingHeadingTag = "</h" + headingLevel + ">" %}
     {% set placeholderSrcset = (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/small/placeholder-card.png 1x, " + (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/large/placeholder-card.png 2x" %}
 
-    <div class="ons-card{% if params.variant == "feature" %}ons-card--feature ons-u-flex-grow{% endif %}">
+    <div class="ons-card {% if params.variant == "feature" %}ons-card--feature ons-u-flex-grow{% endif %}">
         <a href="{{ params.title.url }}" class="ons-card__link {% if params.title.subtitle %}ons-u-mb-xs{% endif %}">
             {%- if params.image -%}
                 {% if params.image.smallSrc %}

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -4,7 +4,7 @@
     {% set closingHeadingTag = "</h" + headingLevel + ">" %}
     {% set placeholderSrcset = (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/small/placeholder-card.png 1x, " + (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/large/placeholder-card.png 2x" %}
 
-    <div class="ons-card {% if params.variant == "headline" %}ons-card--headline ons-u-flex-grow{% endif %}">
+    <div class="ons-card {% if params.variant == "feature" %}ons-card--feature ons-u-flex-grow{% endif %}">
         <a href="{{ params.title.url }}" class="ons-card__link {% if params.title.subtitle %}ons-u-mb-xs{% endif %}">
             {%- if params.image -%}
                 {% if params.image.smallSrc %}
@@ -35,13 +35,11 @@
         </a>
 
         {% if params.title.subtitle %}
-            <p class="ons-u-fs-s">{{ params.title.subtitle }}</p>
+            <p class="ons-card__subtitle ons-u-fs-s">{{ params.title.subtitle }}</p>
         {% endif %}
 
-        {% if params.variant == "headline" %}
-            {% if params.body.figure %}
-                <p class="ons-card__figure ons-u-fs-3xl ons-u-fw-b ons-u-mb-no">{{ params.body.figure }}</p>
-            {% endif %}
+        {% if params.body.figure %}
+            <p class="ons-card__figure ons-u-fs-3xl ons-u-fw-b ons-u-mb-no">{{ params.body.figure }}</p>
         {% endif %}
 
         <p id="{{ params.body.id }}">{{ params.body.text }}</p>

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -4,7 +4,7 @@
     {% set closingHeadingTag = "</h" + headingLevel + ">" %}
     {% set placeholderSrcset = (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/small/placeholder-card.png 1x, " + (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/large/placeholder-card.png 2x" %}
 
-    <div class="ons-card {% if params.variant == "feature" %}ons-card--feature ons-u-flex-grow{% endif %}">
+    <div class="ons-card{% if params.variant == "feature" %}ons-card--feature ons-u-flex-grow{% endif %}">
         <a href="{{ params.title.url }}" class="ons-card__link {% if params.title.subtitle %}ons-u-mb-xs{% endif %}">
             {%- if params.image -%}
                 {% if params.image.smallSrc %}

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -4,7 +4,7 @@
     {% set closingHeadingTag = "</h" + headingLevel + ">" %}
     {% set placeholderSrcset = (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/small/placeholder-card.png 1x, " + (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/large/placeholder-card.png 2x" %}
 
-    <div class="ons-card{% if params.variant == "headline" %}ons-card--headline ons-u-flex-grow{% endif %}">
+    <div class="ons-card {% if params.variant == "headline" %}ons-card--headline ons-u-flex-grow{% endif %}">
         <a href="{{ params.title.url }}" class="ons-card__link {% if params.title.subtitle %}ons-u-mb-xs{% endif %}">
             {%- if params.image -%}
                 {% if params.image.smallSrc %}

--- a/src/components/card/_macro.njk
+++ b/src/components/card/_macro.njk
@@ -4,8 +4,8 @@
     {% set closingHeadingTag = "</h" + headingLevel + ">" %}
     {% set placeholderSrcset = (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/small/placeholder-card.png 1x, " + (params.image.placeholderUrl if params.image.placeholderUrl else "") + "/img/large/placeholder-card.png 2x" %}
 
-    <div class="ons-card">
-        <a href="{{ params.title.url }}" class="ons-card__link">
+    <div class="ons-card{% if params.variant == "headline" %}ons-card--headline ons-u-flex-grow{% endif %}">
+        <a href="{{ params.title.url }}" class="ons-card__link {% if params.title.subtitle %}ons-u-mb-xs{% endif %}">
             {%- if params.image -%}
                 {% if params.image.smallSrc %}
                     <img
@@ -33,6 +33,16 @@
             class="ons-card__title {{ params.title.classes | default('ons-u-fs-m') }}" id="{{ params.title.id }}"> {{ params.title.text }}
             {{ closingHeadingTag | safe }}
         </a>
+
+        {% if params.title.subtitle %}
+            <p class="ons-u-fs-s">{{ params.title.subtitle }}</p>
+        {% endif %}
+
+        {% if params.variant == "headline" %}
+            {% if params.body.figure %}
+                <p class="ons-card__figure ons-u-fs-3xl ons-u-fw-b ons-u-mb-no">{{ params.body.figure }}</p>
+            {% endif %}
+        {% endif %}
 
         <p id="{{ params.body.id }}">{{ params.body.text }}</p>
 

--- a/src/components/card/_macro.spec.js
+++ b/src/components/card/_macro.spec.js
@@ -36,6 +36,20 @@ const EXAMPLE_CARD_WITH_PLACEHOLDER_IMAGE_WITH_PATH = {
     },
 };
 
+const EXAMPLE_CARD_FEATURE_VARIANT = {
+    variant: 'feature',
+    title: {
+        text: 'Feature card title',
+        url: 'http://example.com',
+        subtitle: 'Optional subtitle',
+    },
+    body: {
+        figure: '123,456',
+        text: 'Example feature card text',
+        id: 'example-feature-text-id',
+    },
+};
+
 describe('macro: card', () => {
     describe('mode: without image', () => {
         it('passes jest-axe checks', async () => {
@@ -265,6 +279,50 @@ describe('macro: card', () => {
 
                 expect($('.ons-card__image').attr('alt')).toBe('');
             });
+        });
+    });
+
+    describe('variant: feature', () => {
+        it('renders the `feature` variant with correct class', () => {
+            const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_FEATURE_VARIANT));
+            expect($('.ons-card').hasClass('ons-card--feature')).toBe(true);
+        });
+
+        it('has the provided `title` text', () => {
+            const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_FEATURE_VARIANT));
+
+            expect($('.ons-card__title').text().trim()).toBe('Feature card title');
+        });
+
+        it('has the provided `subitle` text', () => {
+            const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_FEATURE_VARIANT));
+
+            expect($('.ons-card__subtitle').text().trim()).toBe('Optional subtitle');
+        });
+
+        it('outputs a hyperlink with the provided `url`', () => {
+            const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_FEATURE_VARIANT));
+
+            expect($('.ons-card__link').attr('href')).toBe('http://example.com');
+        });
+
+        it('has the provided `figure`', () => {
+            const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_FEATURE_VARIANT));
+
+            expect($('.ons-card__figure').text().trim()).toBe('123,456');
+        });
+
+        it('has the provided `text` accessible via the `textId` identifier', () => {
+            const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_FEATURE_VARIANT));
+
+            expect($('#example-feature-text-id').text().trim()).toBe('Example feature card text');
+        });
+
+        it('passes jest-axe checks', async () => {
+            const $ = cheerio.load(renderComponent('card', EXAMPLE_CARD_FEATURE_VARIANT));
+
+            const results = await axe($.html());
+            expect(results).toHaveNoViolations();
         });
     });
 });

--- a/src/components/card/example-card-set-with-headline-figures.njk
+++ b/src/components/card/example-card-set-with-headline-figures.njk
@@ -1,0 +1,62 @@
+{% from "components/card/_macro.njk" import onsCard %}
+
+<div class="ons-container">
+    <div class="ons-grid ons-grid-flex ons-grid-flex--vertical-top">
+        <div class="ons-grid__col ons-grid__col--flex-col ons-grid__col--stretch ons-u-flex-grow ons-col-4@m">
+            {{
+                onsCard({
+                    "variant": 'headline',
+                    "title": {
+                        "id": 'card-set-1',
+                        "text": 'Deaths registered annually',
+                        "url": '#0',
+                        "subtitle": 'England and Wales'
+                    },
+                    "body":{
+                        "id": 'text1',
+                        "figure": '581,363',
+                        "text": 'In 2023, up 0.7% from 2022'
+                    }
+                })
+            }}
+        </div>
+
+        <div class="ons-grid__col ons-grid__col--flex-col ons-grid__col--stretch ons-u-flex-grow ons-col-4@m">
+            {{
+                onsCard({
+                    "variant": 'headline',
+                    "title": {
+                        "id": 'card-set-2',
+                        "text": 'Alcohol-specific deaths',
+                        "url": '#0',
+                        "subtitle": 'UK'
+                    },
+                    "body":{
+                        "id": 'text2',
+                        "figure": '10,473',
+                        "text": 'In 2023, the highest number on record'
+                    }
+                })
+            }}
+        </div>
+
+        <div class="ons-grid__col ons-grid__col--flex-col ons-grid__col--stretch ons-u-flex-grow ons-col-4@m">
+            {{
+                onsCard({
+                    "variant": 'headline',
+                    "title": {
+                        "id": 'card-set-3',
+                        "text": 'Suicides registered',
+                        "subtitle": 'England and Wales',
+                        "url": '#0'
+                    },
+                    "body":{
+                        "id": 'text3',
+                        "figure": '6069',
+                        "text": 'In 2023, up 7.6% from 2022'
+                    }
+                })
+            }}
+        </div>
+    </div>
+</div>

--- a/src/components/card/example-card-set-with-headline-figures.njk
+++ b/src/components/card/example-card-set-with-headline-figures.njk
@@ -5,7 +5,7 @@
         <div class="ons-grid__col ons-grid__col--flex-col ons-grid__col--stretch ons-u-flex-grow ons-col-4@m">
             {{
                 onsCard({
-                    "variant": 'headline',
+                    "variant": 'feature',
                     "title": {
                         "id": 'card-set-1',
                         "text": 'Deaths registered annually',
@@ -24,7 +24,7 @@
         <div class="ons-grid__col ons-grid__col--flex-col ons-grid__col--stretch ons-u-flex-grow ons-col-4@m">
             {{
                 onsCard({
-                    "variant": 'headline',
+                    "variant": 'feature',
                     "title": {
                         "id": 'card-set-2',
                         "text": 'Alcohol-specific deaths',
@@ -43,7 +43,7 @@
         <div class="ons-grid__col ons-grid__col--flex-col ons-grid__col--stretch ons-u-flex-grow ons-col-4@m">
             {{
                 onsCard({
-                    "variant": 'headline',
+                    "variant": 'feature',
                     "title": {
                         "id": 'card-set-3',
                         "text": 'Suicides registered',

--- a/src/foundations/page-template/example-base-page-template-block-areas.njk
+++ b/src/foundations/page-template/example-base-page-template-block-areas.njk
@@ -126,7 +126,7 @@
         </div>
 
         <div class="ons-grid ons-grid-flex ons-grid-flex--column@2xs@m">
-            <div class="ons-grid__col ons-grid__col--flex ons-u-flex-grow">
+            <div class="ons-grid__col ons-u-flex-grow">
                 <div class="ons-ds-block">
                     <div class="ons-ds-block__label">block: main</div>
                     <h1>Page content</h1>

--- a/src/scss/utilities/_grid.scss
+++ b/src/scss/utilities/_grid.scss
@@ -126,13 +126,22 @@
             padding-left: $grid-gutters * 2;
         }
 
+        &--flex {
+            display: flex;
+        }
+
+        &--flex-col {
+            display: flex;
+            flex-direction: column;
+        }
+
+        &--stretch {
+            align-self: stretch;
+        }
+
         .ons-grid-flex & {
             width: auto;
         }
-    }
-
-    &_col--flex {
-        display: flex;
     }
 }
 


### PR DESCRIPTION
### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/ONSDESYS-166

Adds a card variant for headline figures. 

- New 'feature' variant to allow user to choose grey background & adjusted flex card layout
- New 'subtitle' field in the title object
- New 'figure' field in the body object
- Updates the grid modifier classes to add some extra flexbox styling options.
- Removed an unused modifier class

### How to review this PR

- Checkout branch
- Preview new card variant - example card set with headline figures
- See that the cards match the latest designs (without Sparklines)

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
