### PR TITLE
Grey hero variant - fix/update statistics logo (#285)

### DIFF
--- a/backstop_data/bitmaps_reference/ds-vr-test__components_hero_example-hero-grey_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_hero_example-hero-grey_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d8eee068019896519f05ca007ee8199caefcaff8a5a8fbbedb8f36328db19a2
-size 84029
+oid sha256:6a037332d9e283f770f3b63a7b6e656f55c4f80c0aae6bbd21b0ade278fdfbc0
+size 82571

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_hero_example-hero-grey_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_hero_example-hero-grey_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:768c98cd4952d5b85aac7aa34f2a156b85b6b27ff6defd30b1a3d45cbdeb0499
-size 80783
+oid sha256:02a2c1d93f6374b1c983e29108e04e506d26eae260456c10670454c518fc098f
+size 79313

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_hero_example-hero-grey_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_hero_example-hero-grey_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ed7ef68e2553edcfa1ba44ad75969f48197e31944dd690c5f5c0837f23dd6d7
-size 75586
+oid sha256:faad4f9d6610cf9f0f3061f9bfe6082cf87fe81bdddfeb1989226e8d083c4976
+size 74290

--- a/src/components/hero/_hero.scss
+++ b/src/components/hero/_hero.scss
@@ -70,12 +70,9 @@
             }
         }
     }
-    &__badge {
-        @include mq(l) {
-            position: absolute;
-            right: 0;
-            top: 85px;
-        }
+
+    &__badge-link {
+        display: block;
     }
 
     &--topic {
@@ -95,7 +92,11 @@
     }
 
     &__content {
-        height: 100%;
+        @include mq(l) {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+        }
     }
 
     &__pre-title {

--- a/src/components/hero/_macro-options.md
+++ b/src/components/hero/_macro-options.md
@@ -1,18 +1,20 @@
-| Name                    | Type                                                      | Required | Description                                                                                                                        |
-| ----------------------- | --------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| variants                | array or string                                           | false    | An array of values or single value (string) to adjust the component using available variant, “dark, navy-blue, grey and pale-blue” |
-| wide                    | boolean                                                   | false    | Set to “true” when using the `wide` page layout container                                                                          |
-| title                   | string                                                    | true     | Text for the hero title                                                                                                            |
-| subtitle                | string                                                    | false    | Text for the hero subtitle                                                                                                         |
-| text                    | string                                                    | false    | Text to follow the hero title and subtitle                                                                                         |
-| button                  | `Object<Button>`                                          | false    | Settings for the hero [call to action button](#button)                                                                             |
-| html                    | string                                                    | false    | Allows arbitrary HTML for additional content to be added to the component                                                          |
-| detailsColumns          | integer                                                   | false    | Number of grid columns for the hero to span on screens larger than the medium breakpoint, defaults to 8                            |
-| descriptionList         | `DescriptionList` [_(ref)_](/components/description-list) | false    | Settings to set the DescriptionList component within the HTML `<hero>` element                                                     |
-| officialStatisticsBadge | boolean                                                   | false    | Set to “true” display the official statistics badge (only available for the "grey" hero variant)                                   |
-| topic                   | string                                                    | false    | Topic for the hero                                                                                                                 |
-| breadcrumbs             | `Breadcrumbs` [_(ref)_](/components/breadcrumbs)          | false    | Settings to set the Breadcrumbs component within the HTML `<hero>` element                                                         |
-| censusLogo              | boolean                                                   | false    | Set to “true” display the census 2021 logo (only available for the "grey" hero variant)                                            |
+| Name                       | Type                                                      | Required | Description                                                                                                                        |
+| -------------------------- | --------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| variants                   | array or string                                           | false    | An array of values or single value (string) to adjust the component using available variant, “dark, navy-blue, grey and pale-blue” |
+| wide                       | boolean                                                   | false    | Set to “true” when using the `wide` page layout container                                                                          |
+| title                      | string                                                    | true     | Text for the hero title                                                                                                            |
+| subtitle                   | string                                                    | false    | Text for the hero subtitle                                                                                                         |
+| text                       | string                                                    | false    | Text to follow the hero title and subtitle                                                                                         |
+| button                     | `Object<Button>`                                          | false    | Settings for the hero [call to action button](#button)                                                                             |
+| html                       | string                                                    | false    | Allows arbitrary HTML for additional content to be added to the component                                                          |
+| detailsColumns             | integer                                                   | false    | Number of grid columns for the hero to span on screens larger than the medium breakpoint, defaults to 8                            |
+| descriptionList            | `DescriptionList` [_(ref)_](/components/description-list) | false    | Settings to set the DescriptionList component within the HTML `<hero>` element                                                     |
+| officialStatisticsBadge    | string                                                    | false    | URL for the Statistics Badge                                                                                                       |
+| officialStatisticsBadgeUrl | boolean                                                   | false    | Set to “true” display the official statistics badge (only available for the "grey" hero variant)                                   |
+
+| topic | string | false | Topic for the hero |
+| breadcrumbs | `Breadcrumbs` [_(ref)_](/components/breadcrumbs) | false | Settings to set the Breadcrumbs component within the HTML `<hero>` element |
+| censusLogo | boolean | false | Set to “true” display the census 2021 logo (only available for the "grey" hero variant) |
 
 ## Button
 

--- a/src/components/hero/_macro-options.md
+++ b/src/components/hero/_macro-options.md
@@ -9,8 +9,8 @@
 | html                       | string                                                    | false    | Allows arbitrary HTML for additional content to be added to the component                                                          |
 | detailsColumns             | integer                                                   | false    | Number of grid columns for the hero to span on screens larger than the medium breakpoint, defaults to 8                            |
 | descriptionList            | `DescriptionList` [_(ref)_](/components/description-list) | false    | Settings to set the DescriptionList component within the HTML `<hero>` element                                                     |
-| officialStatisticsBadge    | string                                                    | false    | URL for the Statistics Badge                                                                                                       |
-| officialStatisticsBadgeUrl | boolean                                                   | false    | Set to “true” display the official statistics badge (only available for the "grey" hero variant)                                   |
+| officialStatisticsBadge    | boolean                                                   | false    | Set to “true” display the official statistics badge (only available for the "grey" hero variant)                                   |
+| officialStatisticsBadgeUrl | string                                                    | false    | URL for the Statistics Badge                                                                                                       |
 
 | topic | string | false | Topic for the hero |
 | breadcrumbs | `Breadcrumbs` [_(ref)_](/components/breadcrumbs) | false | Settings to set the Breadcrumbs component within the HTML `<hero>` element |

--- a/src/components/hero/_macro.njk
+++ b/src/components/hero/_macro.njk
@@ -54,18 +54,26 @@
 
                     {% if params.variants == "grey" and params.officialStatisticsBadge == true %}
                         <div class="ons-hero__badge ons-u-mb-s">
-                            <a
-                                href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="ons-hero__badge-link"
-                            >
+                            {% if params.officialStatisticsBadgeUrl %}
+                                <a
+                                    href="{{ params.officialStatisticsBadgeUrl }}"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="ons-hero__badge-link"
+                                >
+                                    {{-
+                                        onsIcon({
+                                            "iconType": 'official-statistics'
+                                        })
+                                    -}}
+                                </a>
+                            {% else %}
                                 {{-
                                     onsIcon({
                                         "iconType": 'official-statistics'
                                     })
                                 -}}
-                            </a>
+                            {% endif %}
                         </div>
                     {% endif %}
                 </div>

--- a/src/components/hero/_macro.njk
+++ b/src/components/hero/_macro.njk
@@ -37,36 +37,47 @@
                 {% if params.topic %}
                     <h2 class="ons-hero--topic">{{ params.topic | safe }}</h2>
                 {% endif %}
-                <div class="ons-hero__title-container">
-                    <header>
-                        <h1 class="ons-hero__title ons-u-fs-3xl">{{ params.title }}</h1>
-                        {% if params.subtitle %}
-                            <h2 class="ons-hero__subtitle ons-u-fs-r--b">{{ params.subtitle }}</h2>
+
+                <div class="ons-hero__content">
+                    <div class="ons-hero__title-container">
+                        <header>
+                            <h1 class="ons-hero__title ons-u-fs-3xl">{{ params.title }}</h1>
+                            {% if params.subtitle %}
+                                <h2 class="ons-hero__subtitle ons-u-fs-r--b">{{ params.subtitle }}</h2>
+                            {% endif %}
+                        </header>
+
+                        {% if params.text %}
+                            <p class="ons-hero__text">{{ params.text | safe }}</p>
                         {% endif %}
-                    </header>
-                    {% if params.text %}
-                        <p class="ons-hero__text">{{ params.text | safe }}</p>
+                    </div>
+
+                    {% if params.variants == "grey" and params.officialStatisticsBadge == true %}
+                        <div class="ons-hero__badge ons-u-mb-s">
+                            <a
+                                href="https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="ons-hero__badge-link"
+                            >
+                                {{-
+                                    onsIcon({
+                                        "iconType": 'official-statistics'
+                                    })
+                                -}}
+                            </a>
+                        </div>
                     {% endif %}
                 </div>
-                {% if params.variants == "grey" %}
-                    {% if params.officialStatisticsBadge == true %}
-                        <div class="ons-hero__badge ons-u-mb-s">
-                            {{-
-                                onsIcon({
-                                    "iconType": 'official-statistics'
-                                })
-                            -}}
-                        </div>
-                    {% endif %}
-                    {% if params.censusLogo == true %}
-                        <div class="ons-hero__census-logo">
-                            {{-
-                                onsIcon({
-                                    "iconType": 'census-logo'
-                                })
-                            -}}
-                        </div>
-                    {% endif %}
+
+                {% if params.variants == "grey" and params.censusLogo == true %}
+                    <div class="ons-hero__census-logo">
+                        {{-
+                            onsIcon({
+                                "iconType": 'census-logo'
+                            })
+                        -}}
+                    </div>
                 {% endif %}
 
                 {% if params.button %}

--- a/src/components/hero/example-hero-grey.njk
+++ b/src/components/hero/example-hero-grey.njk
@@ -8,6 +8,7 @@
         "variants": 'grey',
         "detailsColumns": '12',
         "officialStatisticsBadge": true,
+        "officialStatisticsBadgeUrl": 'https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/',
         "topic": 'Statistical article',
         "title": 'Retail sales rise amid summer discounts and sporting events, according to a first estimate',
         "text": 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id mattis ligula, nec sollicitudin arcu. Donec non tristique tellus. Donec eget malesuada lorem.',

--- a/src/components/icon/_macro.njk
+++ b/src/components/icon/_macro.njk
@@ -701,9 +701,9 @@
     {%- elif params.iconType == "official-statistics" -%}
         <svg
             xmlns="http://www.w3.org/2000/svg"
-            width="77"
-            height="93"
-            viewBox="0 0 77 93"
+            width="75"
+            height="90"
+            viewBox="-5 0 90 90"
             fill="none"
             title="ons-official-statistics-badge"
             focusable="false"


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Related issue: https://github.com/ONSdigital/design-system/issues/3485
DS ticket: https://jira.ons.gov.uk/browse/ONSDESYS-285

Fixes the size & layout issues with the statistics logo, and also adds an optional statistics badge URL option to the hero component.

### How to review this PR

- Review http://localhost:3001/components/hero/example-hero-grey.html locally
- Refer to screenshots from issue/ticket and see that the updated version resolves the layout issues
- Update the component options to check that the layout re-flows correctly when the statistics badge is not present
- Check that the statistics badge now has an optional link (and the example links to https://uksa.statisticsauthority.gov.uk/about-the-authority/uk-statistical-system/types-of-official-statistics/)

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
