### PR TITLE
Remove lines between each shaded area

### DIFF
--- a/backstop_data/bitmaps_reference/ds-vr-test__components_chart_example-area-chart_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_chart_example-area-chart_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7c170d37b7ef0054d6e6c5216a1f28ab557516f21e19352f1e2a83248fc9eec
-size 81232
+oid sha256:51a49fe690382b388b90b4a4e2ce809876a93e90e2dcedf632e88a02babb636a
+size 77907

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_chart_example-area-chart_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_chart_example-area-chart_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33bb78c8c5399cc839666559e2be88d764f746df6f524ffb1edbeca0de1af509
-size 65329
+oid sha256:3595752a5644e197178e2cf2af7e59b94ff35b0035a5e6b692b1a19b492c81e1
+size 63510

--- a/backstop_data/bitmaps_reference/ds-vr-test__components_chart_example-area-chart_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__components_chart_example-area-chart_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db4b9901beaf74be7581962adc5ca783e4963a930786fdc23f38235b2cb36a4b
-size 59324
+oid sha256:eea3a4e98da37e6c9e1097214eb6fa76c085abbbdfd3c9f93bb3da57fcaa0c85
+size 58077

--- a/src/components/chart/area-chart.js
+++ b/src/components/chart/area-chart.js
@@ -12,6 +12,7 @@ class AreaChart {
                     // 'rectangle' counterintuitively gives a circle, because the legend icon has a border radius of half it's height by default
                     legendSymbol: 'rectangle',
                     stacking: 'normal',
+                    lineWidth: 0,
                 },
                 series: {
                     marker: {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

This PR addresses feedback on https://jira.ons.gov.uk/browse/CCB-21 about the lines between each area slightly extending, when they should be flush. Removing the lines altogether addresses the problem.

### How to review this PR

View the area chart on a local build, and ensure that there are no lines visible between each shaded area.

<details>
<summary>Click to expand</summary>

Before:

![line-chart-with-overhanging-lines](https://github.com/user-attachments/assets/e079db82-6371-44ec-9e62-ca2b6f53e024)


After:

![line-width-zero-no-overhang](https://github.com/user-attachments/assets/cbb8681a-b000-437e-a099-5241b1ff8f1f)

</details>

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
