### PR TITLE
Remove documentIndex variable in document-list

### DIFF
--- a/src/components/document-list/_macro.njk
+++ b/src/components/document-list/_macro.njk
@@ -2,7 +2,6 @@
     {% set titleTag = params.headingLevel | default(2) %}
     {% set openingTag = "<h" ~ titleTag %}
     {% set closingTag = "</h" ~ titleTag ~ ">" %}
-    {% set documentIndex = 0 %}
     <ul
         {% if params.id %}id="{{ params.id }}"{% endif %}class="ons-document-list{{ ' ' + params.classes if params.classes else '' }}"
         {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ ' ' }}{{ attribute }}="{{ value }}"{% endfor %}{% endif %}


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?
 `documentIndex` was created in this [PR](https://github.com/ONSdigital/design-system/pull/3567) to create ID for each document. But it was not used subsequently as we took a different approach to resolve the bug. Removing this line  -
  `{% set documentIndex = 0 %}` which I forgot to remove 

### How to review this PR

Check `documentIndex` is not used anywhere in `document-list` macro

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
