### PR TITLE
[Fix] Decorative SVG icons being announced by screenreaders

### DIFF
--- a/src/components/icon/_macro.njk
+++ b/src/components/icon/_macro.njk
@@ -31,6 +31,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-arrow-next"
+            aria-hidden="true"
         >
             <path
                 d="m10 .2-.9.9c-.1.1-.1.4 0 .5l4 4H.6c-.2 0-.4.2-.4.4v1.2c0 .2.2.4.4.4h12.5l-3.9 3.7c-.2.2-.2.4 0 .6l.8.9c.2.2.4.2.6 0L16.8 7c.2-.2.2-.4 0-.6L10.7.3c-.3-.2-.5-.2-.7-.1z"
@@ -45,6 +46,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-arrow-previous"
+            aria-hidden="true"
         >
             <path
                 d="M6.4.2.3 6.4c-.2.2-.2.4 0 .6l6.2 5.8c.2.2.4.1.6 0l.8-.9c.2-.2.1-.4 0-.6l-4-3.7h12.5c.2 0 .4-.2.4-.4V6c0-.2-.2-.4-.4-.4H3.8l4-4c.2-.1.2-.4.1-.5L7 .2c-.1-.1-.4-.1-.6 0z"
@@ -59,6 +61,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-arrow-up"
+            aria-hidden="true"
         >
             <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
         </svg>
@@ -71,6 +74,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-check"
+            aria-hidden="true"
         >
             <path
                 d="M14.35,3.9l-.71-.71a.5.5,0,0,0-.71,0h0L5.79,10.34,3.07,7.61a.51.51,0,0,0-.71,0l-.71.71a.51.51,0,0,0,0,.71l3.78,3.78a.5.5,0,0,0,.71,0h0L14.35,4.6A.5.5,0,0,0,14.35,3.9Z"
@@ -86,6 +90,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-chevron"
+            aria-hidden="true"
         >
             <path
                 d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
@@ -101,6 +106,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-download"
+            aria-hidden="true"
         >
             <path
                 d="M5.6 9a.48.48 0 0 0 .7 0l3-3.2a.48.48 0 0 0 0-.7C9.3 5 9.2 5 9 5H7.5V.5A.47.47 0 0 0 7 0H5a.47.47 0 0 0-.5.5V5H3a.47.47 0 0 0-.5.5.37.37 0 0 0 .1.3Z"
@@ -118,6 +124,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-exit"
+            aria-hidden="true"
         >
             <path
                 d="M13.85,7.65l-2.5-2.5a.5.5,0,0,0-.71,0,.48.48,0,0,0-.15.36V7h-3a.5.5,0,0,0-.5.5v1a.5.5,0,0,0,.5.5h3v1.5A.49.49,0,0,0,11,11a.48.48,0,0,0,.34-.14l2.51-2.5a.49.49,0,0,0,0-.68Z"
@@ -156,6 +163,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-lock"
+            aria-hidden="true"
         >
             <path
                 d="M12.25,6h-.72V4.49a3.5,3.5,0,0,0-7,0V6H3.75A.77.77,0,0,0,3,6.75v6.5a.77.77,0,0,0,.75.75h8.5a.77.77,0,0,0,.75-.75V6.75A.77.77,0,0,0,12.25,6ZM5.54,4.49a2.5,2.5,0,1,1,5,0V6h-5ZM9,11.66a.3.3,0,0,1-.26.34H7.29A.29.29,0,0,1,7,11.69v0l.39-1.82a1,1,0,1,1,1.4-.18.77.77,0,0,1-.18.18Z"
@@ -171,6 +179,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-person"
+            aria-hidden="true"
         >
             <path d="M7,9H9a5,5,0,0,1,5,5H2A5,5,0,0,1,7,9Z" transform="translate(-2 -2)" />
             <circle cx="6" cy="3" r="3" />
@@ -184,6 +193,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-print"
+            aria-hidden="true"
         >
             <path
                 d="M17 4H3C1.3 4 0 5.2 0 6.8v5.5h4V16h12v-3.7h4V6.8C20 5.2 18.7 4 17 4zm-3 10H6V9h8v5zm3-6a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm-1-8H4v3h12V0z"
@@ -198,6 +208,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-quote"
+            aria-hidden="true"
         >
             <path d="M13.44.77h-3l-2 4v6h6v-6h-3l2-4zm-8 0h-3l-2 4v6h6v-6h-3l2-4z" transform="translate(-0.44 -0.77)" />
         </svg>
@@ -225,6 +236,7 @@
             fill="currentColor"
             role="img"
             title="ons-icon-sort-sprite"
+            aria-hidden="true"
         >
             <path class="ons-topTriangle" d="M6 0l6 7.2H0L6 0zm0 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z" />
             <path class="ons-bottomTriangle" d="M6 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z" />
@@ -302,6 +314,7 @@
             fill="currentcolor"
             role="img"
             title="ons-icon-loader"
+            aria-hidden="true"
         >
             <rect x="0" y="0" width="100" height="100" fill="none"></rect>
             <rect x="46.5" y="40" width="7" height="20" rx="5" ry="5" transform="rotate(0 50 50) translate(0 -30)">


### PR DESCRIPTION

<!-- ignore-task-list-start -->

### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/ONSDESYS-467
Related issue: https://github.com/ONSdigital/design-system/issues/3583

This PR addresses the issue of decorative SVG icons being announced by screenreaders by adding an aria-hidden to all SVGs which are for presentation purposes only and should be ignored by assistive tech.

### How to review this PR

Testing with a screenreader e.g. Voiceover:

- Review components which include decorative SVGs and validate that they are not announced (or inspect element and see the icons have `aria-hidden="true"` assigned), e.g.:
  - header menu toggle button
  - breadcrumbs (in grey hero variant)
  - details panel show/hide button
  - accordion

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
