### PR TITLE
[Fix] TOC Accessibility updates

### DIFF
--- a/src/components/table-of-contents/_macro-options.md
+++ b/src/components/table-of-contents/_macro-options.md
@@ -28,4 +28,5 @@
 | Name      | Type               | Required | Description                               |
 | --------- | ------------------ | -------- | ----------------------------------------- |
 | title     | string             | true     | Text for the related links title          |
+| ariaLabel | string             | false    | Optional aria label for screenreaders     |
 | itemsList | array`<itemsList>` | false    | An array of [list item links](#itemslist) |

--- a/src/components/table-of-contents/_macro.njk
+++ b/src/components/table-of-contents/_macro.njk
@@ -3,7 +3,7 @@
     {% from "components/skip-to-content/_macro.njk" import onsSkipToContent %}
     {% from "components/button/_macro.njk" import onsButton %}
 
-    <aside class="ons-table-of-contents-container" role="complementary">
+    <aside class="ons-table-of-contents-container">
         {% if params.skipLink %}
             {{
                 onsSkipToContent({

--- a/src/components/table-of-contents/_macro.spec.js
+++ b/src/components/table-of-contents/_macro.spec.js
@@ -69,6 +69,7 @@ const EXAMPLE_TABLE_OF_CONTENTS_RELATED_LINKS_BUTTON = {
     ],
     relatedLinks: {
         title: 'Related publications',
+        ariaLabel: 'Related publications',
         itemsList: [
             {
                 url: '#0',
@@ -207,6 +208,12 @@ describe('macro: table-of-contents', () => {
             const $ = cheerio.load(renderComponent('table-of-contents', EXAMPLE_TABLE_OF_CONTENTS_RELATED_LINKS_BUTTON));
 
             expect($('.ons-table-of-contents__related-links h2').text().trim()).toBe('Related publications');
+        });
+
+        it('renders related links section with correct aria-label', () => {
+            const $ = cheerio.load(renderComponent('table-of-contents', EXAMPLE_TABLE_OF_CONTENTS_RELATED_LINKS_BUTTON));
+
+            expect($('.ons-table-of-contents__related-links').attr('aria-label')).toBe('Related publications');
         });
 
         it('outputs `lists` component for related links with expected parameters', () => {


### PR DESCRIPTION

<!-- ignore-task-list-start -->

### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/ONSDESYS-482
Related issue: https://github.com/ONSdigital/design-system/issues/3587

- Removes `role="complementary"` as this is no longer needed (redundant when using `<aside>`)
- Adds ariaLabel param to the relatedLinks block of TOC component - this was already part of the macro, it just hadn't been added as an option

### How to review this PR

- Preview TOC component (with related links) and set a custom ariaLabel to test it works as expected
- Make sure tests are running successfully

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
