### PR TITLE
[Fix] Add headingLevel to Details Panel

### DIFF
--- a/src/components/details-panel/_macro-options.md
+++ b/src/components/details-panel/_macro-options.md
@@ -1,8 +1,9 @@
-| Name         | Type                 | Required | Description                                             |
-| ------------ | -------------------- | -------- | ------------------------------------------------------- |
-| title        | string               | true     | Title for the details panel                             |
-| DetailsItems | array`<DetailsItem>` | true     | Settings for the array of [Details Items](#DetailsItem) |
-| open         | boolean              | false    | Forces the details panel to be open when the page loads |
+| Name         | Type                 | Required | Description                                                                                                                                     |
+| ------------ | -------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| title        | string               | true     | Title for the details panel                                                                                                                     |
+| headingLevel | int                  | false    | Number used to determine the heading level of the title text. Use to ensure the title has a correct semantic order on the page. Defaults to `2` |
+| DetailsItems | array`<DetailsItem>` | true     | Settings for the array of [Details Items](#DetailsItem)                                                                                         |
+| open         | boolean              | false    | Forces the details panel to be open when the page loads                                                                                         |
 
 ## DetailsItem
 

--- a/src/components/details-panel/_macro.njk
+++ b/src/components/details-panel/_macro.njk
@@ -4,7 +4,11 @@
             <div class="ons-container ons-details-panel__banner-contents">
                 <span class="ons-details-panel__info-icon ons-u-mr-2xs" aria-hidden="true">i</span>
                 <div class="ons-details-panel__banner-body">
-                    <h3 class="ons-details-panel__banner-title ons-u-mb-2xs">{{ params.title }}</h3>
+                    {% set titleTag = params.headingLevel | default(2) %}
+                    {% set openingTag = "<h" ~ titleTag %}
+                    {% set closingTag = "</h" ~ titleTag ~ ">" %}
+                    {{ openingTag | safe }}
+                    class="ons-details-panel__banner-title ons-u-fs-m ons-u-mb-2xs">{{ params.title }}{{ closingTag | safe }}
                     <div class="ons-details-panel__banner-detail ons-js-details-heading">
                         <span class="ons-details-panel__banner-detail-title ons-js-corrections-details-title ons-u-mr-3xs"
                             >Show detail</span

--- a/src/components/details-panel/_macro.spec.js
+++ b/src/components/details-panel/_macro.spec.js
@@ -15,6 +15,28 @@ describe('FOR: Macro: Details Panel', () => {
         });
     });
 
+    describe('GIVEN: Params: headingLevel', () => {
+        describe('WHEN: headingLevel is provided', () => {
+            const customParams = {
+                ...EXAMPLE_DETAILS_PANEL,
+                headingLevel: 3,
+            };
+            const $ = cheerio.load(renderComponent('details-panel', customParams));
+            test('THEN: banner title uses the correct heading level', () => {
+                const bannerTitle = $('.ons-details-panel__banner-title');
+                expect(bannerTitle.prop('tagName')).toBe('H3');
+            });
+        });
+
+        describe('WHEN: headingLevel is not provided', () => {
+            const $ = cheerio.load(renderComponent('details-panel', EXAMPLE_DETAILS_PANEL));
+            test('THEN: banner title uses default heading level (h2)', () => {
+                const bannerTitle = $('.ons-details-panel__banner-title');
+                expect(bannerTitle.prop('tagName')).toBe('H2');
+            });
+        });
+    });
+
     describe('GIVEN: Params: detailsItems', () => {
         describe('WHEN: detailsItems is provided', () => {
             const $ = cheerio.load(renderComponent('details-panel', EXAMPLE_DETAILS_PANEL));

--- a/src/components/details-panel/_test-examples.js
+++ b/src/components/details-panel/_test-examples.js
@@ -3,6 +3,7 @@ export const EXAMPLE_DETAILS_PANEL = {
     detailsItems: [
         {
             text: 'Correction',
+            headingLevel: 3,
             date: {
                 iso: '2025-01-22T16:30Z',
                 short: '22nd January 2025, 4:30PM',


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/ONSDESYS-466
Related issue: https://github.com/ONSdigital/design-system/issues/3582

Adds a custom heading level to the details panel component so we have more control over the semantic order of headings when the component is included on a page

### How to review this PR

- Preview Details Panel
- Update headingLevel param and see that the title updates as expected to the assigned heading
- Check that the styling for the title remains the same regardless of heading level assigned

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
