### PR TITLE
Fix/onsdesys 413/textarea character limit calculated incorrectly

### DIFF
--- a/src/components/char-check-limit/_macro.njk
+++ b/src/components/char-check-limit/_macro.njk
@@ -3,13 +3,16 @@
         {% set content = caller() %}
         <span class="ons-js-char-check-input">{{ content | safe }}</span>
     {% endif %}
+    {% set limitSingular = params.charCountOverLimitSingular | default("You have exceeded the character limit by {x} character") %}
+    {% set limitPlural = params.charCountOverLimitPlural | default("You have exceeded the character limit by {x} characters") %}
+
     <span
         id="{{ params.id }}"
         class="ons-input__limit ons-u-fs-s--b ons-u-d-no ons-u-mt-2xs"
         data-charcount-singular="{{ params.charCountSingular }}"
         data-charcount-plural="{{ params.charCountPlural }}"
-        data-charcount-limit-singular="{{ params.charCountOverLimitSingular }}"
-        data-charcount-limit-plural="{{ params.charCountOverLimitPlural }}"
+        data-charcount-limit-singular="{{ limitSingular }}"
+        data-charcount-limit-plural="{{ limitPlural }}"
     >
     </span>
 {% endmacro %}

--- a/src/components/char-check-limit/_macro.spec.js
+++ b/src/components/char-check-limit/_macro.spec.js
@@ -26,10 +26,44 @@ describe('FOR: Macro: CharCheckLimit', () => {
             test('THEN: has the data attribute which defines charCountSingular', () => {
                 expect($('.ons-input__limit').attr('data-charcount-singular')).toBe('You have {x} character remaining');
             });
-            test('THEN: has the data attribute which defines charCountOverLimitSingular', () => {
+            test('THEN: has the default data-charcount-limit-singular attribute', () => {
+                expect($('.ons-input__limit').attr('data-charcount-limit-singular')).toBe(
+                    'You have exceeded the character limit by {x} character',
+                );
+            });
+            test('THEN: has the default data-charcount-limit-plural attribute', () => {
+                expect($('.ons-input__limit').attr('data-charcount-limit-plural')).toBe(
+                    'You have exceeded the character limit by {x} characters',
+                );
+            });
+        });
+    });
+
+    describe('GIVEN: Params: charCountOverLimitSingular', () => {
+        describe('WHEN: charCountOverLimitSingular is provided', () => {
+            const $ = cheerio.load(
+                renderComponent('char-check-limit', {
+                    ...EXAMPLE_CHAR_CHECK_LIMIT,
+                    charCountOverLimitSingular: '{x} character too many',
+                }),
+            );
+
+            test('THEN: has the provided data-charcount-limit-singular attribute', () => {
                 expect($('.ons-input__limit').attr('data-charcount-limit-singular')).toBe('{x} character too many');
             });
-            test('THEN: has the data attribute which defines charCountOverLimitPlural', () => {
+        });
+    });
+
+    describe('GIVEN: Params: charCountOverLimitPlural', () => {
+        describe('WHEN: charCountOverLimitPlural is provided', () => {
+            const $ = cheerio.load(
+                renderComponent('char-check-limit', {
+                    ...EXAMPLE_CHAR_CHECK_LIMIT,
+                    charCountOverLimitPlural: '{x} characters too many',
+                }),
+            );
+
+            test('THEN: has the provided data-charcount-limit-plural attribute', () => {
                 expect($('.ons-input__limit').attr('data-charcount-limit-plural')).toBe('{x} characters too many');
             });
         });

--- a/src/components/char-check-limit/_test-examples.js
+++ b/src/components/char-check-limit/_test-examples.js
@@ -2,6 +2,4 @@ export const EXAMPLE_CHAR_CHECK_LIMIT = {
     id: 'example-char-check-limit',
     charCountSingular: 'You have {x} character remaining',
     charCountPlural: 'You have {x} characters remaining',
-    charCountOverLimitSingular: '{x} character too many',
-    charCountOverLimitPlural: '{x} characters too many',
 };

--- a/src/components/char-check-limit/character-limit.js
+++ b/src/components/char-check-limit/character-limit.js
@@ -20,8 +20,7 @@ export default class CharLimit {
 
     updateLimitReadout(event, firstRun) {
         const value = this.input.value;
-        const lineBreaks = (value.match(/\n/g) || []).length;
-        const remaining = this.maxLength - (value.length + lineBreaks);
+        const remaining = this.maxLength - this.getCharLength(value);
         const message = remaining === 1 ? this.singularMessage : this.pluralMessage;
         // Prevent aria live announcement when component initialises
         if (!firstRun && event.inputType) {
@@ -52,5 +51,10 @@ export default class CharLimit {
                 event_label: `Limit of ${this.maxLength} reached/exceeded`,
             });
         }
+    }
+
+    getCharLength(text) {
+        const lineBreaks = (text.match(/\n/g) || []).length;
+        return text.length + lineBreaks;
     }
 }

--- a/src/components/char-check-limit/character-limit.js
+++ b/src/components/char-check-limit/character-limit.js
@@ -20,7 +20,8 @@ export default class CharLimit {
 
     updateLimitReadout(event, firstRun) {
         const value = this.input.value;
-        const remaining = this.maxLength - value.length;
+        const lineBreaks = (value.match(/\n/g) || []).length;
+        const remaining = this.maxLength - (value.length + lineBreaks);
         const message = remaining === 1 ? this.singularMessage : this.pluralMessage;
         // Prevent aria live announcement when component initialises
         if (!firstRun && event.inputType) {

--- a/src/components/char-check-limit/character-limit.js
+++ b/src/components/char-check-limit/character-limit.js
@@ -24,7 +24,6 @@ export default class CharLimit {
         const message = remaining === 1 ? this.singularMessage : this.pluralMessage;
         // Prevent aria live announcement when component initialises
         if (!firstRun && event.inputType) {
-            this.limitElement.setAttribute('aria-live', 'polite');
             this.limitElement.setAttribute('aria-live', [remaining > 0 ? 'polite' : 'assertive']);
         } else {
             this.limitElement.removeAttribute('aria-live');

--- a/src/components/char-check-limit/character-limit.js
+++ b/src/components/char-check-limit/character-limit.js
@@ -7,7 +7,7 @@ const attrCharLimitRef = 'data-char-limit-ref';
 export default class CharLimit {
     constructor(input) {
         this.input = input;
-        this.maxLength = input.maxLength;
+        this.maxLength = this.input.getAttribute('data-maxlength');
         this.limitElement = document.getElementById(input.getAttribute(attrCharLimitRef));
         this.singularMessage = this.limitElement.getAttribute('data-charcount-singular');
         this.pluralMessage = this.limitElement.getAttribute('data-charcount-plural');

--- a/src/components/char-check-limit/character-limit.js
+++ b/src/components/char-check-limit/character-limit.js
@@ -11,6 +11,8 @@ export default class CharLimit {
         this.limitElement = document.getElementById(input.getAttribute(attrCharLimitRef));
         this.singularMessage = this.limitElement.getAttribute('data-charcount-singular');
         this.pluralMessage = this.limitElement.getAttribute('data-charcount-plural');
+        this.limitSingularMessage = this.limitElement.getAttribute('data-charcount-limit-singular');
+        this.limitPluralMessage = this.limitElement.getAttribute('data-charcount-limit-plural');
 
         this.updateLimitReadout(null, true);
         this.limitElement.classList.remove('ons-u-d-no');
@@ -21,7 +23,7 @@ export default class CharLimit {
     updateLimitReadout(event, firstRun) {
         const value = this.input.value;
         const remaining = this.maxLength - this.getCharLength(value);
-        const message = remaining === 1 ? this.singularMessage : this.pluralMessage;
+
         // Prevent aria live announcement when component initialises
         if (!firstRun && event.inputType) {
             this.limitElement.setAttribute('aria-live', [remaining > 0 ? 'polite' : 'assertive']);
@@ -29,7 +31,13 @@ export default class CharLimit {
             this.limitElement.removeAttribute('aria-live');
         }
 
-        this.limitElement.innerText = message.replace('{x}', remaining);
+        this.limitElement.innerText = this.getMessage(
+            remaining,
+            this.singularMessage,
+            this.pluralMessage,
+            this.limitSingularMessage,
+            this.limitPluralMessage,
+        );
 
         this.setLimitClass(remaining, this.input, inputClassLimitReached);
         this.setLimitClass(remaining, this.limitElement, remainingClassLimitReached);
@@ -55,5 +63,22 @@ export default class CharLimit {
     getCharLength(text) {
         const lineBreaks = (text.match(/\n/g) || []).length;
         return text.length + lineBreaks;
+    }
+
+    getMessage(remaining, singularMessage, pluralMessage, limitSingularMessage, limitPluralMessage) {
+        let message;
+
+        if (remaining === 1) {
+            message = singularMessage;
+        } else if (remaining === -1) {
+            message = limitSingularMessage;
+        } else if (remaining < -1) {
+            message = limitPluralMessage;
+        } else {
+            message = pluralMessage;
+        }
+
+        // Use Math.abs to always return a positive number
+        return message.replace('{x}', Math.abs(remaining));
     }
 }

--- a/src/components/checkboxes/_macro.spec.js
+++ b/src/components/checkboxes/_macro.spec.js
@@ -164,7 +164,7 @@ describe('macro: checkboxes', () => {
         it('renders the text area with expected parameters', () => {
             const $ = cheerio.load(renderComponent('checkboxes', EXAMPLE_CHECKBOX_ITEM_CHECKBOXES_WITH_TEXTAREA));
             expect($('.ons-input--textarea').attr('name')).toBe('other answer');
-            expect($('.ons-input--textarea').attr('maxlength')).toBe('300');
+            expect($('.ons-input--textarea').attr('data-maxlength')).toBe('300');
             expect($('.ons-input__limit').attr('data-charcount-singular')).toBe('You have {x} character remaining');
             expect($('.ons-input__limit').attr('data-charcount-plural')).toBe('You have {x} characters remaining');
         });

--- a/src/components/textarea/_macro-options.md
+++ b/src/components/textarea/_macro-options.md
@@ -21,12 +21,14 @@
 
 ## CharCheckLimit
 
-| Name              | Type    | Required | Description                                                                                                                                                                                        |
-| ----------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id                | string  | true     | The HTML `id` of the component                                                                                                                                                                     |
-| limit             | integer | true     | The maximum number of characters allowed in the input                                                                                                                                              |
-| charCountPlural   | string  | true     | The string displayed when multiple characters can be entered before the limit is reached. Set `{x}` in the string to be replaced with the number, for example “You have {x} characters remaining”. |
-| charCountSingular | string  | true     | The string displayed when one more character can be entered before the limit is reached. Set `{x}` in the string to be replaced with the number, for example “You have {x} character remaining”.   |
+| Name                       | Type    | Required | Description                                                                                                                                                                                                                                                                    |
+| -------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| id                         | string  | true     | The HTML `id` of the component                                                                                                                                                                                                                                                 |
+| limit                      | integer | true     | The maximum number of characters allowed in the input                                                                                                                                                                                                                          |
+| charCountPlural            | string  | true     | The string displayed when multiple characters can be entered before the limit is reached. Set `{x}` in the string to be replaced with the number, for example “You have {x} characters remaining”.                                                                             |
+| charCountSingular          | string  | true     | The string displayed when one more character can be entered before the limit is reached. Set `{x}` in the string to be replaced with the number, for example “You have {x} character remaining”.                                                                               |
+| charCountOverLimitPlural   | string  | false    | The string displayed when multiple characters have been entered after the limit is reached. Set `{x}` in the string to be replaced with the number, for example “You are {x} characters over the limit". Defaults to "You have exceeded the character limit by {x} characters" |
+| charCountOverLimitSingular | string  | false    | The string displayed when one more character has been entered after the limit is reached. Set `{x}` in the string to be replaced with the number, for example “You are {x} character over the limit". Defaults to "You have exceeded the character limit by {x} character"     |
 
 ## Label
 

--- a/src/components/textarea/_macro.njk
+++ b/src/components/textarea/_macro.njk
@@ -25,7 +25,7 @@
             {% endif %}
             rows="{{ params.rows | default(8) }}"
             {% if params.charCheckLimit and params.charCheckLimit.limit %}
-                maxlength="{{ params.charCheckLimit.limit }}" data-char-limit-ref="{{ params.id }}-lim"
+                data-maxlength="{{ params.charCheckLimit.limit }}" data-char-limit-ref="{{ params.id }}-lim"
                 aria-describedby="{{ params.id }}-lim"
             {% endif %}
             {% if params.attributes %}{% for attribute, value in (params.attributes.items() if params.attributes is mapping and params.attributes.items else params.attributes) %}{{ ' ' }}{{ attribute }}{% if value %}="{{ value }}"{% endif %}{% endfor %}{% endif %}

--- a/src/components/textarea/_macro.njk
+++ b/src/components/textarea/_macro.njk
@@ -39,7 +39,9 @@
                     "id": params.id ~ "-lim",
                     "limit": params.charCheckLimit.limit,
                     "charCountSingular": params.charCheckLimit.charCountSingular,
-                    "charCountPlural": params.charCheckLimit.charCountPlural
+                    "charCountPlural": params.charCheckLimit.charCountPlural,
+                    "charCountOverLimitSingular": params.charCheckLimit.charCountOverLimitSingular,
+                    "charCountOverLimitPlural": params.charCheckLimit.charCountOverLimitPlural
                 })
             %}
             {% endcall %}

--- a/src/components/textarea/_macro.spec.js
+++ b/src/components/textarea/_macro.spec.js
@@ -210,7 +210,7 @@ describe('macro: textarea', () => {
         it('has the provided maximum length', () => {
             const $ = cheerio.load(renderComponent('textarea', EXAMPLE_TEXTAREA_WITH_CHARACTER_LIMIT));
 
-            expect($('.ons-input--textarea').attr('maxlength')).toBe('200');
+            expect($('.ons-input--textarea').attr('data-maxlength')).toBe('200');
         });
 
         it('has data attribute which references the character limit component', () => {

--- a/src/components/textarea/_macro.spec.js
+++ b/src/components/textarea/_macro.spec.js
@@ -22,6 +22,8 @@ const EXAMPLE_TEXTAREA_WITH_CHARACTER_LIMIT = {
         limit: 200,
         charCountSingular: 'You have {x} character remaining',
         charCountPlural: 'You have {x} characters remaining',
+        charCountOverLimitSingular: 'You are {x} character over the limit',
+        charCountOverLimitPlural: 'You are {x} characters over the limit',
     },
 };
 
@@ -236,6 +238,8 @@ describe('macro: textarea', () => {
                 limit: 200,
                 charCountSingular: 'You have {x} character remaining',
                 charCountPlural: 'You have {x} characters remaining',
+                charCountOverLimitSingular: 'You are {x} character over the limit',
+                charCountOverLimitPlural: 'You are {x} characters over the limit',
             });
         });
     });

--- a/src/components/textarea/example-textarea-with-character-limit.njk
+++ b/src/components/textarea/example-textarea-with-character-limit.njk
@@ -12,7 +12,9 @@
         "charCheckLimit": {
             "limit": 200,
             "charCountSingular": "You have {x} character remaining",
-            "charCountPlural": "You have {x} characters remaining"
+            "charCountPlural": "You have {x} characters remaining",
+            "charCountOverLimitSingular": "You are {x} character over the limit",
+            "charCountOverLimitPlural": "You are {x} characters over the limit"
         }
     })
 }}

--- a/src/components/textarea/textarea.spec.js
+++ b/src/components/textarea/textarea.spec.js
@@ -37,7 +37,7 @@ describe('script: textarea', () => {
 
                 it('then the characters remaining readout reflect the number of characters remaining', async () => {
                     const readout = await page.$eval('#example-textarea-lim', (node) => node.textContent);
-                    expect(readout).toBe('You have 12 characters remaining');
+                    expect(readout).toBe('You have 11 characters remaining');
                 });
             });
 


### PR DESCRIPTION
### What is the context of this PR?

Ticket: [ONSDESYS-413](https://jira.ons.gov.uk/browse/ONSDESYS-413)

- Sets up default text for exceeding the character limit to prevent a breaking change.
- Move away from using `input.maxLength` to using `input.getAttribute('data-maxlength')` so the browser won't stop a user over typing.
- Update documentation to inform user of ability to override default texts for going over text limits.
- Updates tests to take into account that new lines now count as two characters, not just one.


### How to review this PR

- Check the textarea examples works without error.
- Check the textarea example with character limit updates the character count correctly for single and plural examples. This should accurately reflect when you have characters remaining and when you are over the limit.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
