### PR TITLE
[Fix] Accessibility - Meaningful labels

### DIFF
--- a/src/components/hero/_macro.spec.js
+++ b/src/components/hero/_macro.spec.js
@@ -109,7 +109,7 @@ describe('macro: hero', () => {
         const $ = cheerio.load(renderComponent('hero', { ...EXAMPLE_HERO, variants: 'grey', officialStatisticsBadge: true }));
 
         expect($('.ons-hero__badge').length).toBe(1);
-        expect($('.ons-hero__badge svg title').text().trim()).toBe('Offical Statistics Badge');
+        expect($('.ons-hero__badge svg title').text().trim()).toBe('Official Statistics Badge');
     });
 
     it('outputs the statistics badge as a link when officialStatisticsBadgeUrl is provided', () => {

--- a/src/components/icon/_macro.njk
+++ b/src/components/icon/_macro.njk
@@ -701,7 +701,7 @@
             class="ons-icon--logo{{ iconClasses }}"
         >
             <title id="{{ params.altTextId | default ('official-statistics-alt') }}">
-                {{ params.altText | default ('Offical Statistics Badge') }}
+                {{ params.altText | default ('Official Statistics Badge') }}
             </title>
             <path
                 d="M12.4999 92.59C7.18988 92.59 2.87988 88.27 2.87988 82.97C2.87988 77.67 7.19988 73.35 12.4999 73.35H64.4999C69.8099 73.35 74.1199 77.67 74.1199 82.97C74.1199 88.27 69.7999 92.59 64.4999 92.59H12.4999Z"

--- a/src/components/language-selector/_macro-options.md
+++ b/src/components/language-selector/_macro-options.md
@@ -8,6 +8,7 @@
 | ---------- | ------- | -------- | --------------------------------------------------------------------------------------------------- |
 | url        | string  | true     | URL to change the application language                                                              |
 | isoCode    | string  | true     | The ISO language code for the language                                                              |
+| ariaLabel  | string  | false    | Alternative meaningful label for screenreaders                                                      |
 | text       | string  | true     | The name of the language to display                                                                 |
 | abbrText   | string  | false    | Abbreviated version of the language text can be provided. This will be displayed on small viewports |
 | current    | boolean | true     | The current selected language                                                                       |

--- a/src/components/language-selector/_macro-options.md
+++ b/src/components/language-selector/_macro-options.md
@@ -8,7 +8,6 @@
 | ---------- | ------- | -------- | --------------------------------------------------------------------------------------------------- |
 | url        | string  | true     | URL to change the application language                                                              |
 | isoCode    | string  | true     | The ISO language code for the language                                                              |
-| ariaLabel  | string  | false    | Alternative meaningful label for screenreaders                                                      |
 | text       | string  | true     | The name of the language to display                                                                 |
 | abbrText   | string  | false    | Abbreviated version of the language text can be provided. This will be displayed on small viewports |
 | current    | boolean | true     | The current selected language                                                                       |

--- a/src/components/language-selector/_macro.njk
+++ b/src/components/language-selector/_macro.njk
@@ -9,12 +9,15 @@
                     href="{{ language.url }}"
                     lang="{{ language.isoCode }}"
                     {% if language.attributes %}{% for attribute, value in (language.attributes) %}{{ ' ' }}{{ attribute }}="{{ value }}"{% endfor %}{% endif %}
-                    >{% if language.abbrText %}
+                >
+                    {# Visually hidden helper text for screenreaders #}
+                    <span class="ons-u-vh">Change language to{{ ' ' }}</span>
+                    {% if language.abbrText %}
                         <span class="ons-u-d-no@s">{{ language.abbrText }}</span><span class="ons-u-d-no@2xs@s">{{- language.text -}}</span>
                     {% else %}
                         {{- language.text -}}
-                    {% endif %}</a
-                >
+                    {% endif %}
+                </a>
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Ticket: https://jira.ons.gov.uk/browse/ONSDESYS-486
Related issue: https://github.com/ONSdigital/design-system/issues/3591

1. After investigating the duplicate alt text on the ONS logo, it turns out this is a quirk of Voiceover (particularly when tested in Chrome rather than Safari) where it ignores `display: none` on the parent container of an `<svg>`, especially where the parent is also an `<a>` tag. However this works as expected when testing in Safari, where the hidden svg is correctly ignored. As this is an edge case and not a straightforward fix (we'd need to use JS to handle this) I'm going to leave this one for now as it's a minor issue & more of a nice to have. 
2. Updates language switcher label to add SR-only text for additional context to the link
3. Fixes typo in Official Stats Badge logo so it is announced correctly

### How to review this PR

- Check language switcher either testing with a screenreader or inspect the element and see we have some visually hidden text to provide additional context to the link. Make sure this does not show visually on the page.
- Check the typo is resolved and the alt text is announced correctly.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
