### PR TITLE
update symbol height, width and radius for bar/colum with confidence…

### DIFF
--- a/src/components/chart/_chart.scss
+++ b/src/components/chart/_chart.scss
@@ -91,15 +91,14 @@
 
         &-item {
             &--uncertainty {
-                width: 12px;
-                height: 12px;
+                width: 14px;
+                height: 14px;
                 background-color: rgb(32 96 149 / 65%);
             }
 
             &--estimate {
                 width: 20px;
                 height: 3px;
-                border-radius: 2px;
                 background-color: #003c57;
             }
         }

--- a/src/components/chart/common-chart-options.js
+++ b/src/components/chart/common-chart-options.js
@@ -196,6 +196,12 @@ class CommonChartOptions {
                     label?.attr({
                         x: 30, // Adjust label position to account for longer line
                     });
+                } else if (seriesType === 'columnrange') {
+                    symbol.attr({
+                        width: 14,
+                        height: 14,
+                        y: 8,
+                    });
                 } else {
                     if (!symbol) return;
                     // Set the symbol size for bar / column series


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes [CCB-29](https://jira.ons.gov.uk/browse/CCB-29)

This PR addresses minor visual inconsistencies in the legend items for bar and column chart with confidence levels

1. Square symbol legend: Updated the legend symbol size from 12px to the correct 14px for both bar and column charts
2. Line symbol symbol: Adjusted legend with line symbol to have square ends instead of the default rounded ends


### How to review this PR

Confirm the following:
- The square legend symbol for bar and column with confidence levels now has 14×14 size.
- The line symbol in the legend for the column with confidence level  displays with square line ends, not rounded.
- Check that the VR tests updates this change

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [ ] I have selected the correct Assignee
-   [ ] I have linked the correct Issue
