### PR TITLE
Pin action-gh-release to 2.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Zip templates
               run: zip -r templates.zip templates/*
             - name: Release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v2.2.2
               with:
                   files: templates.zip
               env:


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes: [ONSDESYS-533](https://jira.ons.gov.uk/browse/ONSDESYS-533)

At the moment our release Github workflow that adds the templates zip file to our releases is failing because of an issue in the latest version (2.3.0) of `softprops/action-gh-release`

The logs of the run are here http://github.com/ONSdigital/design-system/actions/runs/15557182123/job/43801416960

Other people are having similar issues and have raised issues on their Github:
https://github.com/softprops/action-gh-release/issues/628
https://github.com/softprops/action-gh-release/issues/627

To fix this for now, this PR pins `softprops/action-gh-release` to the version before (2.2.2)

### How to review this PR

- Fork this repository and do a release, see that the workflow fails
- Merge this change into your forked repo, do a release and see that the workflow passes and templates.zip is added to the release.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
