### PR TITLE
Exclude ons-card__title from h2 font size override

### DIFF
--- a/src/scss/objects/_page.scss
+++ b/src/scss/objects/_page.scss
@@ -28,7 +28,7 @@
 }
 
 .ons-page__body {
-    h2:not(.ons-document-list__item-title, .ons-details__title) {
+    h2:not(.ons-document-list__item-title, .ons-details__title, .ons-card__title) {
         @extend .ons-u-fs-xl;
     }
     h3,


### PR DESCRIPTION
### What is the context of this PR?

After adding the card strip component to the service manual for [ONSDESYS-523](https://jira.ons.gov.uk/browse/ONSDESYS-523) the font-size required for the titles within the component were being overridden. This change excludes the card strip titles from the override.

**Before:**
![image](https://github.com/user-attachments/assets/9e2f8e7d-68fb-4bd2-87ec-b931f6c5370e)

**After**
![image](https://github.com/user-attachments/assets/e2432bb0-86e0-4586-8b3c-2e3c4febcfa3)


### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
