### PR TITLE
Fixes to aspect ratio and tick intervals

### DIFF
--- a/src/components/chart/chart.js
+++ b/src/components/chart/chart.js
@@ -62,14 +62,20 @@ class HighchartsBaseChart {
         this.yAxisTickIntervalDesktop = this.node.dataset.highchartsYAxisTickIntervalDesktop
             ? parseInt(this.node.dataset.highchartsYAxisTickIntervalDesktop)
             : undefined;
-        this.commonChartOptions = new CommonChartOptions(this.xAxisTickIntervalDesktop, this.yAxisTickIntervalDesktop);
+        this.commonChartOptions = new CommonChartOptions();
         this.estimateLineLabel = this.node.dataset.highchartsEstimateLineLabel;
         this.uncertainyRangeLabel = this.node.dataset.highchartsUncertaintyRangeLabel;
         this.customReferenceLineValue = this.node.dataset.highchartsCustomReferenceLineValue
             ? parseFloat(this.node.dataset.highchartsCustomReferenceLineValue)
             : undefined;
 
-        this.specificChartOptions = new SpecificChartOptions(this.theme, this.chartType, this.config);
+        this.specificChartOptions = new SpecificChartOptions(
+            this.theme,
+            this.chartType,
+            this.config,
+            this.xAxisTickIntervalDesktop,
+            this.yAxisTickIntervalDesktop,
+        );
         this.lineChart = new LineChart();
         this.barChart = new BarChart();
         this.columnChart = new ColumnChart();
@@ -259,25 +265,25 @@ class HighchartsBaseChart {
             const currentChart = event.target;
             if (this.chartType === 'line') {
                 this.lineChart.updateLastPointMarker(currentChart.series);
-                this.commonChartOptions.hideDataLabels(currentChart.series);
+                this.specificChartOptions.hideDataLabels(currentChart.series);
             }
             if (this.chartType === 'bar') {
                 this.barChart.updateBarChartHeight(this.config, currentChart, this.useStackedLayout);
                 if (!this.hideDataLabels) {
                     this.barChart.postLoadDataLabels(currentChart);
                 } else {
-                    this.commonChartOptions.hideDataLabels(currentChart.series);
+                    this.specificChartOptions.hideDataLabels(currentChart.series);
                 }
             }
             if (this.chartType === 'column') {
-                this.commonChartOptions.hideDataLabels(currentChart.series);
+                this.specificChartOptions.hideDataLabels(currentChart.series);
             }
             if (this.chartType === 'scatter') {
                 this.scatterChart.updateMarkers(currentChart);
             }
             if (this.chartType === 'columnrange') {
                 this.columnRangeChart.updateColumnRangeChartHeight(this.config, currentChart);
-                this.commonChartOptions.hideDataLabels(currentChart.series);
+                this.specificChartOptions.hideDataLabels(currentChart.series);
 
                 if (this.extraScatter > 0) {
                     const scatterSeries = currentChart.series.filter((series) => series.type === 'scatter');
@@ -290,7 +296,7 @@ class HighchartsBaseChart {
             if (this.extraLines > 0) {
                 currentChart.series.forEach((series) => {
                     if (series.type === 'line') {
-                        this.commonChartOptions.hideDataLabels([series]);
+                        this.specificChartOptions.hideDataLabels([series]);
                     }
                 });
             }

--- a/src/components/chart/common-chart-options.js
+++ b/src/components/chart/common-chart-options.js
@@ -2,7 +2,7 @@ import ChartConstants from './chart-constants';
 
 // Options that are common to all chart types - these are set once in the Highcharts.setOptions() method
 class CommonChartOptions {
-    constructor(xAxisTickInterval, yAxisTickInterval) {
+    constructor() {
         this.constants = ChartConstants.constants();
 
         this.options = {
@@ -85,7 +85,6 @@ class CommonChartOptions {
                 tickWidth: 1,
                 tickLength: 6,
                 tickColor: this.constants.gridLineColor,
-                tickInterval: yAxisTickInterval,
             },
             xAxis: {
                 labels: {
@@ -109,7 +108,6 @@ class CommonChartOptions {
                 tickWidth: 1,
                 tickLength: 6,
                 tickColor: this.constants.gridLineColor,
-                tickInterval: xAxisTickInterval,
             },
             plotOptions: {
                 series: {
@@ -134,16 +132,6 @@ class CommonChartOptions {
     }
 
     getOptions = () => this.options;
-
-    hideDataLabels = (series) => {
-        series.forEach((series) => {
-            series.update({
-                dataLabels: {
-                    enabled: false,
-                },
-            });
-        });
-    };
 }
 
 export default CommonChartOptions;

--- a/src/components/chart/specific-chart-options.js
+++ b/src/components/chart/specific-chart-options.js
@@ -2,7 +2,7 @@ import ChartConstants from './chart-constants';
 
 // Options that rely on the chart config but are not specific to the chart type
 class SpecificChartOptions {
-    constructor(theme, type, config) {
+    constructor(theme, type, config, xAxisTickInterval, yAxisTickInterval) {
         this.constants = ChartConstants.constants();
         this.theme = theme;
         this.config = config;
@@ -12,6 +12,12 @@ class SpecificChartOptions {
             chart: {
                 type: type,
                 marginTop: this.config.legend.enabled ? (type === 'boxplot' ? 50 : undefined) : 50,
+            },
+            yAxis: {
+                tickInterval: yAxisTickInterval,
+            },
+            xAxis: {
+                tickInterval: xAxisTickInterval,
             },
         };
     }
@@ -30,6 +36,16 @@ class SpecificChartOptions {
                 tickInterval: yAxisTickInterval,
             },
         };
+    };
+
+    hideDataLabels = (series) => {
+        series.forEach((series) => {
+            series.update({
+                dataLabels: {
+                    enabled: false,
+                },
+            });
+        });
     };
 
     disableLegendForSingleSeries = (config) => {

--- a/src/components/chart/specific-chart-options.js
+++ b/src/components/chart/specific-chart-options.js
@@ -42,18 +42,25 @@ class SpecificChartOptions {
     };
 
     adjustChartHeight = (currentChart, percentageHeightDesktop, percentageHeightMobile) => {
-        // get height and width of the plot area
-        const plotHeight = currentChart.plotHeight;
+        // get current width of the plot area
         const plotWidth = currentChart.plotWidth;
-        // calculate the new plot height based on the percentage height
-        // default to the current height
-        let newPlotHeight = plotHeight;
+        let newPlotHeight = undefined;
+        let totalHeight = 400; // Highcharts default height - needed if one of the percentage heights is undefined
+
+        // Calculate the new plot height based on the percentage height
         if (plotWidth > 400) {
-            newPlotHeight = Math.round(plotWidth * (percentageHeightDesktop / 100));
+            if (percentageHeightDesktop !== undefined) {
+                newPlotHeight = Math.round(plotWidth * (percentageHeightDesktop / 100));
+            }
         } else {
-            newPlotHeight = Math.round(plotWidth * (percentageHeightMobile / 100));
+            if (percentageHeightMobile !== undefined) {
+                newPlotHeight = Math.round(plotWidth * (percentageHeightMobile / 100));
+            }
         }
-        const totalHeight = currentChart.plotTop + newPlotHeight + currentChart.marginBottom;
+        // update the total height if we have a new plot height
+        if (newPlotHeight !== undefined) {
+            totalHeight = currentChart.plotTop + newPlotHeight + currentChart.marginBottom;
+        }
 
         // set the new size of the chart
         if (totalHeight !== currentChart.chartHeight) {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

see https://jira.ons.gov.uk/browse/CCB-143

This responds to two issues raised by @nimasmi  testing the charts in the CMS

- There was one more case where we were calling functionality from `common-chart-options.js` when it should have been in `specific-chart-options.js`, which was the tick interval settings - which meant that if there was more than one chart on a page, these were being set incorrectly for the second chart
- I have moved the `hideDataLabels` function as well as a precaution, although there is nothing chart specific in this function definition
- There was a bug with the chart aspect ratio when only one value out of `percentageHeightDesktop` and `percentageHeightMobile` was set, which should now be addressed.

### How to review this PR

On a local build, try changing the `percentageHeightDesktop` and percentageHeightMobile` values in a test chart so there is only one, and ensure that resizing up and down from desktop to mobile works as expected - and that the default height of 400px is used for the chart in the case where no value is set.

Try adding more than one chart to a new example file, and ensure that if you set the tick intervals for the first chart, it doesn't then set them for the second chart.

Check that `hideDataLabels` still functions as expected.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
