### PR TITLE
Revert changes to reduce extra logging "Remove Google analytics not connected" in tests

### DIFF
--- a/.github/workflows/macro-and-script-tests.yml
+++ b/.github/workflows/macro-and-script-tests.yml
@@ -21,4 +21,4 @@ jobs:
             - name: Clear jest cache
               run: yarn test:clear-cache
             - name: Run macro and script tests
-              run: yarn test | grep -v "Google analytics not connected"
+              run: yarn test


### PR DESCRIPTION
Reverts ONSdigital/design-system#3510

Ticket: [ONSDESYS-526](https://jira.ons.gov.uk/browse/ONSDESYS-526)

The change introduced in PR [3510](https://github.com/ONSdigital/design-system/pull/3510) unintentionally caused the pipeline to succeed even when tests fail.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
