### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -1,6 +1,9 @@
 name: Run visual regression tests
 on: [push]
 
+permissions:
+    contents: read
+
 env:
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     RUNNING_IN_CI: true


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/design-system/security/code-scanning/9](https://github.com/ONSdigital/design-system/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any repository-modifying actions, the `contents: read` permission is sufficient. This limits the `GITHUB_TOKEN` to read-only access to the repository contents, ensuring the workflow operates with minimal privileges.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
