### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-bundle.yml
+++ b/.github/workflows/npm-bundle.yml
@@ -3,6 +3,10 @@ on:
     release:
         types: [published]
 
+permissions:
+    contents: read
+    packages: write
+
 env:
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/design-system/security/code-scanning/7](https://github.com/ONSdigital/design-system/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the `contents: read` permission is sufficient for most steps, while `packages: write` is required for publishing to npm.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
