### PR TITLE
See if the font family is the issue with the inconsistent VR tests

### DIFF
--- a/src/components/chart/common-chart-options.js
+++ b/src/components/chart/common-chart-options.js
@@ -9,7 +9,7 @@ class CommonChartOptions {
             chart: {
                 backgroundColor: 'transparent',
                 style: {
-                    fontFamily: '"OpenSans", "Helvetica Neue", arial, sans-serif',
+                    fontFamily: '"Helvetica Neue", arial, sans-serif',
                     color: '#222222',
                 },
             },


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

From discussion we found that there was a difference in the chart height between opening in a new tab, and loading it afresh. Further experimentation showed that the difference disappeared when we no longer set the OpenSans font for all charts. This is just to see if it also eliminates differences in the VR tests.

### How to review this PR

Describe the steps required to test the changes (include screenshots if appropriate).

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [ ] I have selected the correct Assignee
-   [ ] I have linked the correct Issue
