### PR TITLE
Potential fix for code scanning alert no. 34: Incomplete string escaping or encoding

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -259,7 +259,7 @@ export default class Tabs {
     }
 
     getPanel(tab) {
-        const panelSelector = this.getHref(tab).replace(/\./g, '\\.');
+        const panelSelector = Tabs.escapeForCSSSelector(this.getHref(tab));
         const panel = this.component.querySelector(panelSelector);
         return panel;
     }
@@ -298,5 +298,13 @@ export default class Tabs {
         const href = tab.getAttribute('href');
         const hash = href.slice(href.indexOf('#'), href.length);
         return hash;
+    }
+    /**
+     * Escapes special characters in a string for use in a CSS selector.
+     * @param {string} str - The input string to escape.
+     * @returns {string} - The escaped string.
+     */
+    static escapeForCSSSelector(str) {
+        return str.replace(/([ #.:[\]{}()<>?+*~=|^$!\\])/g, '\\$1');
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/design-system/security/code-scanning/34](https://github.com/ONSdigital/design-system/security/code-scanning/34)

To fix the issue, we need to ensure that the input string returned by `this.getHref(tab)` is properly escaped for use in the `querySelector` method. A robust solution involves using a well-tested sanitization library, which is the recommended approach. If we do not want to introduce a new dependency, we can create a utility function to escape all special characters in the string for use in a CSS selector. This includes escaping backslashes (`\`) in addition to periods (`.`) and other special characters.

The fix involves:
1. Creating a utility method named `escapeForCSSSelector` that escapes all special characters in a string for use in a CSS selector.
2. Replacing the current `replace` call on line 262 with a call to the new utility method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
