### PR TITLE
Remove deprecated ariaLabelMsg param from message list

### DIFF
--- a/src/components/message-list/_macro-options.md
+++ b/src/components/message-list/_macro-options.md
@@ -6,7 +6,7 @@
 | fromLabel         | string           | true     | The visually hidden screen reader “From” prefix for each message metadata information                                        |
 | dateLabel         | string           | true     | The visually hidden screen reader “Sent” prefix for each message metadata information                                        |
 | hiddenReadLabel   | string           | true     | The visually hidden screen reader “Read the message” prefix for each visually hidden link to the message conversation thread |
-| bodyLabel         | string           | false    | The visually hidden screen reader "body" prefix for message body vvvvvv                                                      |
+| bodyLabel         | string           | false    | The visually hidden screen reader "body" prefix for message body                                                             |
 | messages          | `Array<Message>` | true     | Settings for each [message item](#message)                                                                                   |
 
 ## Message

--- a/src/components/message-list/_macro-options.md
+++ b/src/components/message-list/_macro-options.md
@@ -1,12 +1,12 @@
 | Name              | Type             | Required | Description                                                                                                                  |
 | ----------------- | ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| ariaLabel         | string           | false    | The `aria-label` attribute for the message list element. Defaults to “Message List”.                                         |
+| ariaLabel         | string           | false    | The `aria-label` attribute for the message list element. Defaults to “Message List”                                          |
 | unreadText        | string           | true     | Text label for each unread message suffix displayed in brackets, for example, “New”                                          |
-| ariaLabelMetaData | string           | false    | The `aria-label` attribute for each message metadata information. Defaults to “Message metadata”.                            |
+| ariaLabelMetaData | string           | false    | The `aria-label` attribute for each message metadata information. Defaults to “Message metadata”                             |
 | fromLabel         | string           | true     | The visually hidden screen reader “From” prefix for each message metadata information                                        |
 | dateLabel         | string           | true     | The visually hidden screen reader “Sent” prefix for each message metadata information                                        |
 | hiddenReadLabel   | string           | true     | The visually hidden screen reader “Read the message” prefix for each visually hidden link to the message conversation thread |
-| bodyLabel         | string           | false    | The visually hidden screen reader "body" prefix for message body                                                             |
+| bodyLabel         | string           | false    | The visually hidden screen reader "body" prefix for message body. Defaults to “Message text”                                 |
 | messages          | `Array<Message>` | true     | Settings for each [message item](#message)                                                                                   |
 
 ## Message

--- a/src/components/message-list/_macro-options.md
+++ b/src/components/message-list/_macro-options.md
@@ -3,11 +3,10 @@
 | ariaLabel         | string           | false    | The `aria-label` attribute for the message list element. Defaults to “Message List”.                                         |
 | unreadText        | string           | true     | Text label for each unread message suffix displayed in brackets, for example, “New”                                          |
 | ariaLabelMetaData | string           | false    | The `aria-label` attribute for each message metadata information. Defaults to “Message metadata”.                            |
-| ariaLabelMsg      | string           | false    | (DEPRECATED) The `aria-label` attribute for each message body preview. Defaults to “Message text”.                           |
 | fromLabel         | string           | true     | The visually hidden screen reader “From” prefix for each message metadata information                                        |
 | dateLabel         | string           | true     | The visually hidden screen reader “Sent” prefix for each message metadata information                                        |
 | hiddenReadLabel   | string           | true     | The visually hidden screen reader “Read the message” prefix for each visually hidden link to the message conversation thread |
-| bodyLabel         | string           | false    | (NEW) The visually hidden screen reader "body" prefix for message body                                                       |
+| bodyLabel         | string           | false    | The visually hidden screen reader "body" prefix for message body vvvvvv                                                      |
 | messages          | `Array<Message>` | true     | Settings for each [message item](#message)                                                                                   |
 
 ## Message

--- a/src/components/message-list/_macro.njk
+++ b/src/components/message-list/_macro.njk
@@ -6,7 +6,7 @@
                     <a href="{{ message.subject.url }}" class="ons-u-fs-r--b">{{ message.subject.text }}</a>
                     {% if message.unread %}<span class="ons-message-item__unread ons-u-fs-s">({{ params.unreadText }})</span>{% endif %}
                 </h3>
-                <dl class="ons-message-item__metadata" aria-label="{{ params.ariaLabelMetaData | default("Message metadata") }}">
+                <dl class="ons-message-item__metadata" aria-label="{{ params.ariaLabelMetaData | default('Message metadata') }}">
                     <dt class="ons-message-item__metadata-term ons-message-item__metadata-term--from ons-u-vh">{{ params.fromLabel }}:</dt>
                     <dd class="ons-message-item__metadata-value ons-message-item__metadata-value--from ons-u-fs-r--b">
                         {{ message.fromText }}
@@ -16,9 +16,7 @@
                         {{ message.dateText }}
                     </dd>
                     <dt class="ons-message-item__metadata-term ons-message-item__metadata-term--body ons-u-vh">
-                        {% if params.ariaLabelMsg and not params.bodyLabel %}
-                            {{ params.ariaLabelMsg | default("Message text") }}:
-                        {% else %}
+                        {% if params.bodyLabel %}
                             {{ params.bodyLabel | default("Message text") }}:
                         {% endif %}
                     </dt>

--- a/src/components/message-list/_macro.njk
+++ b/src/components/message-list/_macro.njk
@@ -16,9 +16,7 @@
                         {{ message.dateText }}
                     </dd>
                     <dt class="ons-message-item__metadata-term ons-message-item__metadata-term--body ons-u-vh">
-                        {% if params.bodyLabel %}
-                            {{ params.bodyLabel | default("Message text") }}:
-                        {% endif %}
+                        {{ params.bodyLabel | default("Message text") }}:
                     </dt>
                     <dd class="ons-message-item__metadata-value ons-message-item__metadata-value--body ons-u-fs-r ons-u-mt-s">
                         {{ message.body | safe }}

--- a/src/components/message-list/_macro.spec.js
+++ b/src/components/message-list/_macro.spec.js
@@ -42,7 +42,7 @@ const EXAMPLE_MESSAGE_LIST = {
     ariaLabelMetaData: 'Message information',
 };
 
-const EXAMPLE_MESSAGE_LIST_WIHTOUT_BODYLABEL_PARAM = {
+const EXAMPLE_MESSAGE_LIST_WITHOUT_BODYLABEL_PARAM = {
     unreadText: 'New',
     fromLabel: 'From',
     dateLabel: 'Date',
@@ -118,24 +118,14 @@ describe('macro: message-list', () => {
         expect($('.ons-message-item__link:first').text()).toContain('Read the message: ');
     });
 
-    it('has visually hidden label `bodyLabel` when only `bodyLabel` is provided`', () => {
+    it('has visually hidden label `bodyLabel` when `bodyLabel` is provided`', () => {
         const $ = cheerio.load(renderComponent('message-list', EXAMPLE_MESSAGE_LIST_MINIMAL));
 
         expect($('.ons-message-item__metadata-term--body:first').text().trim()).toBe('Body:');
     });
 
-    it('has visually hidden label `bodyLabel` when both `bodyLabel` is provided`', () => {
-        const $ = cheerio.load(
-            renderComponent('message-list', {
-                ...EXAMPLE_MESSAGE_LIST_MINIMAL,
-            }),
-        );
-
-        expect($('.ons-message-item__metadata-term--body:first').text().trim()).toBe('Body:');
-    });
-
     it('has the default text for visually hidden label `bodyLabel` when `bodyLabel` is not provided', () => {
-        const $ = cheerio.load(renderComponent('message-list', EXAMPLE_MESSAGE_LIST_WIHTOUT_BODYLABEL_PARAM));
+        const $ = cheerio.load(renderComponent('message-list', EXAMPLE_MESSAGE_LIST_WITHOUT_BODYLABEL_PARAM));
 
         expect($('.ons-message-item__metadata-term--body:first').text().trim()).toBe('Message text:');
     });

--- a/src/components/message-list/_macro.spec.js
+++ b/src/components/message-list/_macro.spec.js
@@ -42,27 +42,6 @@ const EXAMPLE_MESSAGE_LIST = {
     ariaLabelMetaData: 'Message information',
 };
 
-const EXAMPLE_MESSAGE_LIST_WITH_DEPRECATED_ARIALABELMSG_PARAM = {
-    unreadText: 'New',
-    fromLabel: 'From',
-    dateLabel: 'Date',
-    hiddenReadLabel: 'Read the message',
-    ariaLabelMsg: 'Aria Label Msg Preview',
-    messages: [
-        {
-            id: 'message1',
-            unread: true,
-            subject: {
-                url: 'https://example.com/message/1',
-                text: 'Example message subject',
-            },
-            fromText: 'Example Sender 1',
-            dateText: 'Tue 4 Jul 2020 at 7:47',
-            body: 'An example message.',
-        },
-    ],
-};
-
 const EXAMPLE_MESSAGE_LIST_WIHTOUT_BODYLABEL_PARAM = {
     unreadText: 'New',
     fromLabel: 'From',
@@ -145,24 +124,17 @@ describe('macro: message-list', () => {
         expect($('.ons-message-item__metadata-term--body:first').text().trim()).toBe('Body:');
     });
 
-    it('has visually hidden label `bodyLabel` when both `bodyLabel` and `ariaLabelMsg` are provided`', () => {
+    it('has visually hidden label `bodyLabel` when both `bodyLabel` is provided`', () => {
         const $ = cheerio.load(
             renderComponent('message-list', {
                 ...EXAMPLE_MESSAGE_LIST_MINIMAL,
-                ariaLabelMsg: 'Aria Label Msg Preview',
             }),
         );
 
         expect($('.ons-message-item__metadata-term--body:first').text().trim()).toBe('Body:');
     });
 
-    it('has visually hidden deprecated label `ariaLabelMsg` when only `ariaLabelMsg` is provided', () => {
-        const $ = cheerio.load(renderComponent('message-list', EXAMPLE_MESSAGE_LIST_WITH_DEPRECATED_ARIALABELMSG_PARAM));
-
-        expect($('.ons-message-item__metadata-term--body:first').text().trim()).toBe('Aria Label Msg Preview:');
-    });
-
-    it('has the defualt text for visually hidden label `bodyLabel` when both `bodyLabel` and `ariaLabelMsg` are not provided', () => {
+    it('has the default text for visually hidden label `bodyLabel` when `bodyLabel` is not provided', () => {
         const $ = cheerio.load(renderComponent('message-list', EXAMPLE_MESSAGE_LIST_WIHTOUT_BODYLABEL_PARAM));
 
         expect($('.ons-message-item__metadata-term--body:first').text().trim()).toBe('Message text:');


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

_BREAKING CHANGE_

Fixes: [ONSDESYS-644](https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-644)

Removes the deprecated param `ariaLabelMsg` from the message list component ready for the major release (73.0.0).

**This will impact the message list component** 

**To mitigate the breaking changes:**
Replace any references to the `ariaLabelMsg` when using the message list component with `bodyLabel`.

Here is an example with the param replaced

```
{{
    onsMessageList({
        "ariaLabel": "Message list for ONS Business Surveys",
		"ariaLabelMsg": "Body",
        "unreadText": "New",
        "fromLabel": "From",
        "dateLabel": "Sent",
        "hiddenReadLabel": "Read the message",
        "ariaLabelMetaData": "Message information",
        "messages": [
            {
                "id": "message-list-example-1",
                "subject": {
                    "url": "#0",
                    "text": "BRES 2016 survey response query"
                },
                "unread": true,
                "fromText": "ONS Business Surveys Team",
                "dateText": "Tue 4 Jul 2020 at 7:47",
                "body": "Hi Jacky. Thanks for that information. Your figures have allowed us to create more accurate…"
            },
            {
                "id": "message-list-example-2",
                "subject":{
                    "url": "#0",
                    "text": "BRES 2015 Enquiry on data"
                },
                "fromText": "Jacky Turner",
                "dateText": "Mon 1 Oct 2019 at 9:52",
                "body": "Hi Jacky, Thank you for returning the Business Register and Employment Survey (BRES) 2016…"
            }
        ]
    })
}}
```


### How to review this PR

- Compare this branch to main using both params and make sure that the resulting html is the same of using either param
- Test with a screenreader to make sure what is read out is the same

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
