### PR TITLE
Fix merged table rendering in Python env

### DIFF
--- a/src/components/table/_macro.njk
+++ b/src/components/table/_macro.njk
@@ -19,7 +19,7 @@
                 {% endif %}
             >
                 {% if params.caption %}
-                    <caption class="ons-table__caption{{ " ons-u-vh" if params.hideCaption }}">
+                    <caption class="ons-table__caption{{ ' ons-u-vh' if params.hideCaption }}">
                         {{ params.caption }}
                     </caption>
                 {% endif %}

--- a/src/components/table/_macro.njk
+++ b/src/components/table/_macro.njk
@@ -2,22 +2,6 @@
     {% from "components/button/_macro.njk" import onsButton %}
     {% from "components/icon/_macro.njk" import onsIcon %}
     {% set variants = params.variants if params.variants %}
-    {% set hasRowSpan = false %}
-    {% for row in params.thList %}
-        {% for th in row.ths %}
-            {% if th.rowspan %}
-                {% set hasRowSpan = true %}
-            {% endif %}
-        {% endfor %}
-    {% endfor %}
-
-    {% for row in params.trs %}
-        {% for td in row.tds %}
-            {% if td.rowspan %}
-                {% set hasRowSpan = true %}
-            {% endif %}
-        {% endfor %}
-    {% endfor %}
 
     <div class="ons-table-scrollable ons-table-scrollable--on">
         <div
@@ -28,7 +12,7 @@
         >
             <table
                 {% if params.id %}id="{{ params.id }}"{% endif %}
-                class="ons-table{{ ' ' + params.tableClasses if params.tableClasses else '' }}{% if hasRowSpan %}{{ ' ' }}ons-table--has-rowspan{% endif %}{% if variants %}{% if variants is not string %}{% for variant in variants %}{{ ' ' }}ons-table--{{ variant }}{% endfor %}{% else %}{{ ' ' }}ons-table--{{ variants }}{% endif %}{% endif %}"
+                class="ons-table{{ ' ' + params.tableClasses if params.tableClasses else '' }}{% for row in params.thList %}{% for th in row.ths %}{% if th.rowspan %}{{ ' ' }}ons-table--has-rowspan{% endif %}{% endfor %}{% endfor %}{% for row in params.trs %}{% for td in row.tds %}{% if td.rowspan %}{{ ' ' }}ons-table--has-rowspan{% endif %}{% endfor %}{% endfor %}{% if variants %}{% if variants is not string %}{% for variant in variants %}{{ ' ' }}ons-table--{{ variant }}{% endfor %}{% else %}{{ ' ' }}ons-table--{{ variants }}{% endif %}{% endif %}"
                 {% if params.sortBy and 'sortable' in variants %}
                     data-aria-sort="{{ params.sortBy }}" data-aria-asc="{{ params.ariaAsc }}" data-aria-desc="{{ params.ariaDesc }}"
                 {% endif %}

--- a/src/components/table/_macro.njk
+++ b/src/components/table/_macro.njk
@@ -10,6 +10,7 @@
             role="region"
             aria-label="{{ params.caption }}. {{ params.ariaLabel | default('Scrollable table') }}"
         >
+            {# Uses multiple loops to set the rowspan class so that it can work in both nunjucks and jinja2 environments due to the scoping rules of each language #}
             <table
                 {% if params.id %}id="{{ params.id }}"{% endif %}
                 class="ons-table{{ ' ' + params.tableClasses if params.tableClasses else '' }}{% for row in params.thList %}{% for th in row.ths %}{% if th.rowspan %}{{ ' ' }}ons-table--has-rowspan{% endif %}{% endfor %}{% endfor %}{% for row in params.trs %}{% for td in row.tds %}{% if td.rowspan %}{{ ' ' }}ons-table--has-rowspan{% endif %}{% endfor %}{% endfor %}{% if variants %}{% if variants is not string %}{% for variant in variants %}{{ ' ' }}ons-table--{{ variant }}{% endfor %}{% else %}{{ ' ' }}ons-table--{{ variants }}{% endif %}{% endif %}"

--- a/src/components/table/_macro.njk
+++ b/src/components/table/_macro.njk
@@ -28,7 +28,7 @@
                     {% if params.thList %}
                         {% set thGroups = params.thList %}
                     {% else %}
-                        {% set thGroups = [ { ths: params.ths } ] %}
+                        {% set thGroups = [ { "ths": params.ths } ] %}
                     {% endif %}
                     {% for headerCols in thGroups %}
                         <tr class="ons-table__row">


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

This PR fixes some bugs in the table macro related to some logic in that macro that doesnt work correctly in a python/jinja2 environment.
The first change is to the way the `ons-table--has-rowspan` is added to the `<table>` element. In jinja2 any variable set inside a for loop are only accessible in that for loop so the changes to the `hasRowSpan` var were inaccessible from outside of the loop so it was always false when it came to adding the class. This had to be refactored to add the class inside the loop instead of setting the var. This fixed the spacing and border issues.
The second change fixes the way keys are accessed and set within object in a jinja2 env. Without the quotes around `ths` this was being set as undefined and therefore in the loop `{% for th in headerCols.ths %}` this key was inaccessible so the titles were never being set.

### How to review this PR

- spin up the [design-system-python-flask-demo](https://github.com/ONSdigital/design-system-python-flask-demo) repo and see that the column titles are missing, the spacing is off on the second column and the bottom border does not span the width of the table in the `example-table-merge-cells` example
- manually copy the table macro from this branch into the [design-system-python-flask-demo](https://github.com/ONSdigital/design-system-python-flask-demo) repo
- remove the `load-design-system-templates` step from the run command in the make file
- spin up that repo again and see that these issues are resolved
- do the same steps in the DS repo to make sure nothing is broken or there aren't any unintended changes there

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
