### PR TITLE
Fix readme badges and add new test badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ONS Design System
 
 [![GitHub release](https://img.shields.io/github/release/ONSdigital/design-system.svg)](https://github.com/ONSdigital/design-system/releases)
-[![Tests](https://github.com/ONSdigital/design-system/actions/workflows/tests.yml/badge.svg)](https://github.com/ONSdigital/design-system/actions/workflows/tests.yml)
+[![Macro and script tests](https://github.com/ONSdigital/design-system/actions/workflows/macro-and-script-tests.yml/badge.svg)](https://github.com/ONSdigital/design-system/actions/workflows/macro-and-script-tests.yml)
+[![Visual regression tests](https://github.com/ONSdigital/design-system/actions/workflows/visual-regression-tests.yml/badge.svg)](https://github.com/ONSdigital/design-system/actions/workflows/visual-regression-tests.yml)
+[![Lighthouse tests](https://github.com/ONSdigital/design-system/actions/workflows/lighthouse-ci.yml/badge.svg)](https://github.com/ONSdigital/design-system/actions/workflows/lighthouse-ci.yml)
 [![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/ONSdigital/design-system.svg)](https://github.com/ONSdigital/design-system/pulls)
 [![Github last commit](https://img.shields.io/github/last-commit/ONSdigital/design-system.svg)](https://github.com/ONSdigital/design-system/commits)
 [![Github contributors](https://img.shields.io/github/contributors/ONSdigital/design-system.svg)](https://github.com/ONSdigital/design-system/graphs/contributors)

--- a/src/components/radios/_macro-options.md
+++ b/src/components/radios/_macro-options.md
@@ -12,7 +12,7 @@
 | legendIsQuestionTitle | boolean                              | false                           | Creates an `h1` inside the legend. Use when the radios are [the only fieldset on the page](/components/fieldset#legend-as-pagequestion-title) |
 | value                 | string                               | false                           | Set to “true” to preset the checked radio. This can also be achieved by setting the `checked` parameter on the `Radio` item to “true”.        |
 | error                 | `Error` [_(ref)_](/components/error) | false                           | Configuration for validation errors                                                                                                           |
-| or                    | string                               | false                           | Text for the “Or” seperator label                                                                                                             |
+| or                    | string                               | false                           | Text for the “Or” separator label                                                                                                             |
 | clearRadios           | object`<ClearRadios>`                | false                           | Settings for for the [clear selection button](#clearradios)                                                                                   |
 
 ## Radio


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Fixes:

Updates the readme badges to point to the correct tests so that the results can be reported correctly. Our test files have changed names and this badge still points at the old name.

Also fixes a typo in one of the param tables.

### How to review this PR

Check the readme in GitHub on this branch (https://github.com/ONSdigital/design-system/tree/fix-readme-badges) and see that all tests results are now being reported correctly

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [ ] I have selected the correct Assignee
-   [ ] I have linked the correct Issue
