### PR TITLE
Revert "Update viewport meta tag and add safe area insets"

### DIFF
--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -4,7 +4,7 @@ exports[`base page template matches the basic variant header snapshot 1`] = `
 "<!DOCTYPE html><html lang="en"><head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>ONS Design System</title>
         <link rel="stylesheet" href="/css/main.css">
         <link rel="stylesheet" media="print" href="/css/print.css">
@@ -927,7 +927,7 @@ exports[`base page template matches the body block override snapshot 1`] = `
 "<!DOCTYPE html><html lang="en"><head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Social survey</title>
         <link rel="stylesheet" href="/css/main.css">
         <link rel="stylesheet" media="print" href="/css/print.css">
@@ -1009,7 +1009,7 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
 "<!DOCTYPE html><html lang="en"><head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Social survey</title>
         <link rel="stylesheet" href="/css/main.css">
         <link rel="stylesheet" media="print" href="/css/print.css">
@@ -1250,7 +1250,7 @@ exports[`base page template matches the footer block override snapshot 1`] = `
 "<!DOCTYPE html><html lang="en"><head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Social survey</title>
         <link rel="stylesheet" href="/css/main.css">
         <link rel="stylesheet" media="print" href="/css/print.css">
@@ -1497,7 +1497,7 @@ exports[`base page template matches the full configuration snapshot 1`] = `
 "<!DOCTYPE html><html lang="en"><head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Social survey</title>
         <link rel="stylesheet" href="/some-path/css/main.css">
         <link rel="stylesheet" media="print" href="/some-path/css/print.css">
@@ -2853,7 +2853,7 @@ exports[`base page template matches the meta block override snapshot 1`] = `
 "<!DOCTYPE html><html lang="en"><head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Social survey</title>
         <link rel="stylesheet" href="/css/main.css">
         <link rel="stylesheet" media="print" href="/css/print.css">
@@ -3100,7 +3100,7 @@ exports[`base page template matches the social block override snapshot 1`] = `
 "<!DOCTYPE html><html lang="en"><head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Social survey</title>
         <link rel="stylesheet" href="/css/main.css">
         <link rel="stylesheet" media="print" href="/css/print.css">

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -367,16 +367,6 @@
             width: 100vw;
             transform: translateX(-50%);
             border-top: 0;
-            padding-left: env(safe-area-inset-left);
-            padding-right: env(safe-area-inset-right);
-
-            // iOS Edge can render 100vw breakout panels under the Dynamic Island in landscape.
-            // Keep panels in normal flow on touch landscape viewports so body safe-area insets apply.
-            @media (orientation: landscape) and (hover: none) and (pointer: coarse) {
-                left: 0;
-                width: 100%;
-                transform: none;
-            }
         }
     }
 

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -62,7 +62,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>{{ pageTitle }}</title>
         <link rel="stylesheet" href="{{ assetsUrl }}/css/main.css" />
         <link rel="stylesheet" media="print" href="{{ assetsUrl }}/css/print.css" />


### PR DESCRIPTION
What is the context of this PR?

This reverts a previous commit which added viewport-fit=cover which tells mobile browsers that the page wants to use the entire physical screen. [ONSDESYS-873](https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-873)

<!-- ignore-task-list-start -->

### What is the context of this PR?

Reverted the header and template changes.

### How to review this PR

Using an iPhone with Chrome and Safari, page content should be consistent.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue


[ONSDESYS-873]: https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ