### PR TITLE
Update the role for the cookie banner landmark region to avoid a clash with other banner landmark regions on the page.

### DIFF
--- a/src/components/cookies-banner/_macro.njk
+++ b/src/components/cookies-banner/_macro.njk
@@ -42,7 +42,7 @@
     {% set preferencesText = beforeLinkPreferencesUrl + ' <a href="' + settingsLinkUrl + '">' + afterLinkPreferencesUrl %}
 
     <section
-        role="banner"
+        role="region"
         class="ons-cookies-banner"
         aria-label="{{ params.ariaLabel | default(ariaLabel) }}"
         {% if params.cookieDomainPolicy %}data-ons-cookie-domain-policy="{{ params.cookieDomainPolicy }}"{% endif %}

--- a/src/components/cookies-banner/_macro.njk
+++ b/src/components/cookies-banner/_macro.njk
@@ -42,7 +42,6 @@
     {% set preferencesText = beforeLinkPreferencesUrl + ' <a href="' + settingsLinkUrl + '">' + afterLinkPreferencesUrl %}
 
     <section
-        role="region"
         class="ons-cookies-banner"
         aria-label="{{ params.ariaLabel | default(ariaLabel) }}"
         {% if params.cookieDomainPolicy %}data-ons-cookie-domain-policy="{{ params.cookieDomainPolicy }}"{% endif %}


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Relates to https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-829 and the previous PR https://github.com/ONSdigital/design-system/pull/3840.

When pulling the latest release into the CMS, I found a bug - Axe reports that “Document should not have more than one ‘banner’ landmark”. This is because the `<header>` element also has an implicit 'banner' role. This PR addresses that issue by removing the explicit role - as `<section>` implicitly has the role of 'region'.

### How to review this PR

It is hard to test this in the DS alone, but I have tested in my local build of the CMS, using the most recent DS build templates, where Axe reports the issue. If I edit the markup in the inspector to remove the role attribute from the cookie banner `section` element, the issue is no longer reported.

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
