### PR TITLE
Improve release categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,30 +1,30 @@
 changelog:
     categories:
-        - title: ⚠️ Breaking changes
+        - title: ⚠️ Breaking
           labels:
               - Breaking changes
-        - title: New features
+        - title: New
           labels:
               - Component
               - Pattern
-        - title: Accessibility improvements
-          labels:
-              - Accessibility
         - title: Enhancements
           labels:
               - Enhancement
-              - CI/CD
-              - Tech improvements
         - title: Fixes
           labels:
               - Bug
+        - title: Accessibility
+          labels:
+              - Accessibility
         - title: Documentation
           labels:
               - Documentation
               - Example
-        - title: Dependency updates
+        - title: Build & tooling
           labels:
               - Dependencies
-        - title: Other changes
+              - CI/CD
+              - Tech improvements
+        - title: Other
           labels:
               - '*'


### PR DESCRIPTION
<!-- ignore-task-list-start -->

### What is the context of this PR?

Improve the release categories in Github releases. Order, group and name them to make them more readable.

### How to review this PR

Ensure I haven't removed any ticket labels. 

### Checklist

This needs to be completed by the person raising the PR.

<!-- ignore-task-list-end -->

-   [x] I have selected the correct Assignee
-   [x] I have linked the correct Issue
