### PR TITLE
Pass header.search to Header in Layout

### DIFF
--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -189,7 +189,8 @@
                                 "titleLogo": pageConfig.header.titleLogo,
                                 "mastheadLogoAltText": pageConfig.header.mastheadLogoAltText,
                                 "menuLinks": pageConfig.header.menuLinks,
-                                "searchLinks": pageConfig.header.searchLinks
+                                "searchLinks": pageConfig.header.searchLinks,
+                                "search": pageConfig.header.search
                             })
                         }}
                     {% endblock %}

--- a/src/layout/_template.spec.js
+++ b/src/layout/_template.spec.js
@@ -546,6 +546,29 @@ const HEADER_BASIC_EXAMPLE = `
 {% block main %}{% endblock %}
 `;
 
+const HEADER_SEARCH_EXAMPLE = `
+{% set pageConfig = {
+    "title": "Social survey",
+    "header": {
+        "variants": "basic",
+        "search": {
+            "id": "search-links",
+            "links": {
+                "heading": "Popular searches",
+                "itemsList": [
+                    {
+                        "url": "#1",
+                        "text": "Cost of living"
+                    }
+                ]
+            }
+        }
+    }
+} %}
+
+{% block main %}{% endblock %}
+`;
+
 describe('base page template', () => {
     it('passes jest-axe checks', async () => {
         const $ = cheerio.load(renderBaseTemplate(FULL_EXAMPLE));
@@ -571,5 +594,13 @@ describe('base page template', () => {
         const $ = cheerio.load(renderBaseTemplate(params));
 
         expect($.html()).toMatchSnapshot();
+    });
+
+    it('renders header search correctly from pageConfig.header.search', () => {
+        const $ = cheerio.load(renderBaseTemplate(HEADER_SEARCH_EXAMPLE));
+
+        expect($.html()).toContain('id="search-links"');
+        expect($.html()).toContain('Popular searches');
+        expect($.html()).toContain('Cost of living');
     });
 });


### PR DESCRIPTION
<!-- ignore-task-list-start -->

Bug: `header.searchLinks` is now deprecated, but its replacement `header.search` is not passed to Header in the Layout component.

### How to review

Ensure no regressions.

<!-- ignore-task-list-end -->

### Checklist

- [x] I have linked the Issue
- [x] I have selected the Assignee
- [x] I have suggested an excellent Title for our release notes
