### PR TITLE
Fix font preload resource type

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,5 @@ Describe the steps to review and test these changes.
 
 - [ ] I have linked the Issue
 - [ ] I have selected the Assignee
+- [ ] I have selected the most helpful Label
 - [ ] I have suggested an excellent Title for our release notes

--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -10,9 +10,9 @@ exports[`base page template matches the basic variant header snapshot 1`] = `
         <link rel="stylesheet" media="print" href="/css/print.css">
 
         <link rel="preload" href="/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin="">
         <link rel="preload" href="/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin="">
 
         <meta name="theme-color" content="#206095">
         
@@ -946,9 +946,9 @@ exports[`base page template matches the body block override snapshot 1`] = `
         <link rel="stylesheet" media="print" href="/css/print.css">
 
         <link rel="preload" href="/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin="">
         <link rel="preload" href="/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin="">
 
         <meta name="theme-color" content="#206095">
         
@@ -1039,9 +1039,9 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
         <link rel="stylesheet" media="print" href="/css/print.css">
 
         <link rel="preload" href="/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin="">
         <link rel="preload" href="/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin="">
 
         <meta name="theme-color" content="#206095">
         
@@ -1293,9 +1293,9 @@ exports[`base page template matches the footer block override snapshot 1`] = `
         <link rel="stylesheet" media="print" href="/css/print.css">
 
         <link rel="preload" href="/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin="">
         <link rel="preload" href="/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin="">
 
         <meta name="theme-color" content="#206095">
         
@@ -1553,9 +1553,9 @@ exports[`base page template matches the full configuration snapshot 1`] = `
         <link rel="stylesheet" media="print" href="/some-path/css/print.css">
 
         <link rel="preload" href="/some-path/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/some-path/fonts/opensans-regular.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/some-path/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin="">
         <link rel="preload" href="/some-path/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/some-path/fonts/opensans-bold.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/some-path/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin="">
 
         <meta name="theme-color" content="#206095">
         
@@ -2922,9 +2922,9 @@ exports[`base page template matches the meta block override snapshot 1`] = `
         <link rel="stylesheet" media="print" href="/css/print.css">
 
         <link rel="preload" href="/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin="">
         <link rel="preload" href="/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin="">
 
         <meta name="theme-color" content="#206095">
         
@@ -3182,9 +3182,9 @@ exports[`base page template matches the social block override snapshot 1`] = `
         <link rel="stylesheet" media="print" href="/css/print.css">
 
         <link rel="preload" href="/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin="">
         <link rel="preload" href="/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin="">
-        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff2" crossorigin="">
+        <link rel="preload" href="/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin="">
 
         <meta name="theme-color" content="#206095">
         

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -68,9 +68,9 @@
         <link rel="stylesheet" media="print" href="{{ assetsUrl }}/css/print.css" />
 
         <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin>
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff" as="font" type="font/woff2" crossorigin>
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin>
         <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin>
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff" as="font" type="font/woff2" crossorigin>
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin>
 
         <meta name="theme-color" content="{{ themeColor }}" />
         {% block meta %}


### PR DESCRIPTION
<!-- ignore-task-list-start -->

Fixes the font preload resource type. 

### How to review

Load this release into a client app and check the warning is gone.

<!-- ignore-task-list-end -->

### Checklist

- [x] I have selected the Assignee
- [x] I have suggested an excellent Title for our release notes
