### PR TITLE
Lint only changed CSS files on precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         ],
         "*.scss": [
             "prettier --write",
-            "yarn run stylelint-fix"
+            "stylelint --fix"
         ],
         "*.{yml,yaml,njk,html}": [
             "prettier --write"


### PR DESCRIPTION
<!-- ignore-task-list-start -->

Solves our recent pre-commit failures.

- The repo has long been configured to run stylelint across all SCSS when any .scss file is committed.
- For a period, stylelint findings were effectively tolerated because .stylelintrc.yml set defaultSeverity: warning.
- In May, that defaultSeverity was removed in commit 02bcf2c8, so stylelint findings became blocking again.
- In June, the stylelint toolchain was upgraded, which introduced or tightened rules around deprecated CSS and nesting patterns.
- CI does not run stylelint, so the remaining SCSS backlog was not being surfaced in pull requests.

Result: we only now discover old repo-wide SCSS issues locally, at commit time, when we happen to stage a SCSS file.

We cannot expect to lint all files in the repo in a precommit if there are existing rule violations. So let's just lint the changed files for now. 

All the rule violations will need fixing at the same time as re-enabling repo-wide enforcement. 

### How to review

Check that you can now commit a change to an SCSS file.

<!-- ignore-task-list-end -->

### Checklist

- [x] I have selected the Assignee
- [x] I have selected the most helpful Label
- [x] I have suggested an excellent Title for our release notes
