### PR TITLE
Add postMainContent block to Layout

### DIFF
--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -48,6 +48,7 @@ exports[`base page template matches the basic variant header snapshot 1`] = `
         
 
         
+        
     </head>
     <body>
         <!-- prettier-ignore-start -->
@@ -997,6 +998,7 @@ exports[`base page template matches the body block override snapshot 1`] = `
         
 
         
+        
     </head>
     <body>
         <!-- prettier-ignore-start -->
@@ -1080,6 +1082,7 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
 
         
 
+        
         
     </head>
     <body>
@@ -1355,6 +1358,7 @@ exports[`base page template matches the footer block override snapshot 1`] = `
             <link rel="manifest" href="/favicons/manifest.json">
         
 
+        
         
     </head>
     <body>
@@ -3007,6 +3011,7 @@ exports[`base page template matches the meta block override snapshot 1`] = `
         
 
         
+        
     </head>
     <body>
         <!-- prettier-ignore-start -->
@@ -3265,6 +3270,7 @@ exports[`base page template matches the social block override snapshot 1`] = `
             <link rel="manifest" href="/favicons/manifest.json">
         
 
+        
         
     </head>
     <body>

--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -898,6 +898,7 @@ exports[`base page template matches the basic variant header snapshot 1`] = `
                                     <div class="ons-grid__col ons-col-12@m">
                                         <div class="ons-page__main">
                                             
+                                            
                                         </div>
                                     </div>
                                 </div>
@@ -1256,6 +1257,7 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
                                     <div class="ons-grid__col ons-col-12@m">
                                         <div class="ons-page__main">
                                             
+                                            
                                         </div>
                                     </div>
                                 </div>
@@ -1529,6 +1531,7 @@ exports[`base page template matches the footer block override snapshot 1`] = `
                                 <div class="ons-grid">
                                     <div class="ons-grid__col ons-col-12@m">
                                         <div class="ons-page__main">
+                                            
                                             
                                         </div>
                                     </div>
@@ -2404,6 +2407,7 @@ exports[`base page template matches the full configuration snapshot 1`] = `
                                     <div class="ons-grid__col ons-col-12@m">
                                         <div class="ons-page__main">
                                             
+                                            
                                         </div>
                                     </div>
                                 </div>
@@ -3179,6 +3183,7 @@ exports[`base page template matches the meta block override snapshot 1`] = `
                                     <div class="ons-grid__col ons-col-12@m">
                                         <div class="ons-page__main">
                                             
+                                            
                                         </div>
                                     </div>
                                 </div>
@@ -3436,6 +3441,7 @@ exports[`base page template matches the social block override snapshot 1`] = `
                                 <div class="ons-grid">
                                     <div class="ons-grid__col ons-col-12@m">
                                         <div class="ons-page__main">
+                                            
                                             
                                         </div>
                                     </div>

--- a/__snapshots__/layout/_template.spec.js.snap
+++ b/__snapshots__/layout/_template.spec.js.snap
@@ -48,7 +48,6 @@ exports[`base page template matches the basic variant header snapshot 1`] = `
         
 
         
-        
     </head>
     <body>
         <!-- prettier-ignore-start -->
@@ -998,7 +997,6 @@ exports[`base page template matches the body block override snapshot 1`] = `
         
 
         
-        
     </head>
     <body>
         <!-- prettier-ignore-start -->
@@ -1082,7 +1080,6 @@ exports[`base page template matches the favicons block override snapshot 1`] = `
 
         
 
-        
         
     </head>
     <body>
@@ -1358,7 +1355,6 @@ exports[`base page template matches the footer block override snapshot 1`] = `
             <link rel="manifest" href="/favicons/manifest.json">
         
 
-        
         
     </head>
     <body>
@@ -3011,7 +3007,6 @@ exports[`base page template matches the meta block override snapshot 1`] = `
         
 
         
-        
     </head>
     <body>
         <!-- prettier-ignore-start -->
@@ -3270,7 +3265,6 @@ exports[`base page template matches the social block override snapshot 1`] = `
             <link rel="manifest" href="/favicons/manifest.json">
         
 
-        
         
     </head>
     <body>

--- a/backstop_data/bitmaps_reference/ds-vr-test__foundations_page-template_example-base-page-template-block-areas_0_document_0_desktop.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__foundations_page-template_example-base-page-template-block-areas_0_document_0_desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:000310ae935852590a87607a17a6e98ea6b595f09199a06ff9185174098732e8
-size 243486
+oid sha256:5b40ea4bdacff9fc63e614d8e3f5d4630e235a1dbf4ad2caff7e8c147b1f2159
+size 253056

--- a/backstop_data/bitmaps_reference/ds-vr-test__foundations_page-template_example-base-page-template-block-areas_0_document_1_tablet.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__foundations_page-template_example-base-page-template-block-areas_0_document_1_tablet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de0e7386d6fe8b2e3d2eab206065334ca6aba27d39ea3cda428e21eb6751f12f
-size 180652
+oid sha256:f795243c97157751fc503fe376484cdc3eac37ff524838a1923e8594a0b3ec85
+size 188660

--- a/backstop_data/bitmaps_reference/ds-vr-test__foundations_page-template_example-base-page-template-block-areas_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__foundations_page-template_example-base-page-template-block-areas_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04d02a60b4673115769a1b8bd762262cef6fed33050b7f4a91b5b69d407d4c6b
-size 149331
+oid sha256:686c2b63d0db9a234855e35471f305893fdba7f0289192dbec1941d81630fec0
+size 154734

--- a/migration_guides/73.x.x-to-74.0.0-migration-guide.md
+++ b/migration_guides/73.x.x-to-74.0.0-migration-guide.md
@@ -20,7 +20,7 @@ See [**Improve landmark semantics in Layout component**](https://github.com/ONSd
 
 -   The `main` block has been renamed to `mainContent`.
 
--   New `breadcrumbs`, `preBreadcrumbs`, `hero`, `postHero` and `postMain` blocks.
+-   New `breadcrumbs`, `preBreadcrumbs`, `hero`, `postHero` and `postMainContent` blocks.
 
 -   Instructions have been added for any blocks that are rendered outside of an existing landmark to explain that they must use a landmark level element.
 

--- a/migration_guides/73.x.x-to-74.0.0-migration-guide.md
+++ b/migration_guides/73.x.x-to-74.0.0-migration-guide.md
@@ -20,7 +20,7 @@ See [**Improve landmark semantics in Layout component**](https://github.com/ONSd
 
 -   The `main` block has been renamed to `mainContent`.
 
--   New `breadcrumbs`, `preBreadcrumbs`, `hero` and `postHero` blocks.
+-   New `breadcrumbs`, `preBreadcrumbs`, `hero`, `postHero` and `postMain` blocks.
 
 -   Instructions have been added for any blocks that are rendered outside of an existing landmark to explain that they must use a landmark level element.
 

--- a/src/foundations/page-template/example-base-page-template-block-areas.njk
+++ b/src/foundations/page-template/example-base-page-template-block-areas.njk
@@ -153,6 +153,9 @@
                     <div class="ons-ds-block__label">block: mainContent</div>
                     <h1>Page content</h1>
                 </div>
+                <div class="ons-ds-block">
+                    <div class="ons-ds-block__label">block: postMainContent</div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -67,10 +67,10 @@
         <link rel="stylesheet" href="{{ assetsUrl }}/css/main.css" />
         <link rel="stylesheet" media="print" href="{{ assetsUrl }}/css/print.css" />
 
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin>
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin>
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin>
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin>
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin />
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin />
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin />
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin />
 
         <meta name="theme-color" content="{{ themeColor }}" />
         {% block meta %}
@@ -132,7 +132,8 @@
             <link rel="manifest" href="{{ assetsUrl }}/favicons/manifest.json" />
         {% endblock %}
 
-        {% block head %}{% endblock %}
+        {% block head %}
+        {% endblock %}
     </head>
     <body {% if pageConfig.bodyClasses %}class="{{ pageConfig.bodyClasses }}"{% endif %}>
         <!-- prettier-ignore-start -->
@@ -223,6 +224,7 @@
                                     <div class="ons-grid__col ons-col-{{ pageColNumber }}@m{{ pageColClasses }}">
                                         <div class="ons-page__main{{ mainColClasses }}">
                                             {% block mainContent %}{% endblock %}
+                                            {% block postMainContent %}{% endblock %}
                                         </div>
                                     </div>
                                 </div>

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -67,10 +67,10 @@
         <link rel="stylesheet" href="{{ assetsUrl }}/css/main.css" />
         <link rel="stylesheet" media="print" href="{{ assetsUrl }}/css/print.css" />
 
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin />
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin />
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin />
-        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin />
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff2" as="font" type="font/woff2" crossorigin>
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-regular.woff" as="font" type="font/woff" crossorigin>
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff2" as="font" type="font/woff2" crossorigin>
+        <link rel="preload" href="{{ assetsUrl }}/fonts/opensans-bold.woff" as="font" type="font/woff" crossorigin>
 
         <meta name="theme-color" content="{{ themeColor }}" />
         {% block meta %}

--- a/src/layout/_template.njk
+++ b/src/layout/_template.njk
@@ -132,8 +132,7 @@
             <link rel="manifest" href="{{ assetsUrl }}/favicons/manifest.json" />
         {% endblock %}
 
-        {% block head %}
-        {% endblock %}
+        {% block head %}{% endblock %}
     </head>
     <body {% if pageConfig.bodyClasses %}class="{{ pageConfig.bodyClasses }}"{% endif %}>
         <!-- prettier-ignore-start -->

--- a/src/layout/_template.spec.js
+++ b/src/layout/_template.spec.js
@@ -377,6 +377,7 @@ const ALL_SLOTS_EXAMPLE = `
 {% block hero %}<div data-slot="hero"></div>{% endblock %}
 {% block postHero %}<div data-slot="postHero"></div>{% endblock %}
 {% block mainContent %}<div data-slot="mainContent"></div>{% endblock %}
+{% block postMainContent %}<div data-slot="postMainContent"></div>{% endblock %}
 {% block preFooter %}<div data-slot="preFooter"></div>{% endblock %}
 {% block footer %}<footer data-slot="footer"></footer>{% endblock %}
 {% block bodyEnd %}<div data-slot="bodyEnd"></div>{% endblock %}
@@ -690,6 +691,7 @@ describe('base page template', () => {
             'hero',
             'postHero',
             'mainContent',
+            'postMainContent',
             'preFooter',
             'footer',
             'bodyEnd',
@@ -723,5 +725,12 @@ describe('base page template', () => {
         expect(heroIndex).toBeLessThan(postHeroIndex);
         expect(postHeroIndex).toBeLessThan(containerIndex);
         expect($('#main-content .ons-page__main [data-slot="mainContent"]').length).toBe(1);
+
+        const mainColChildren = $('#main-content .ons-page__main').children().toArray();
+        const mainContentIndex = mainColChildren.findIndex((child) => $(child).is('[data-slot="mainContent"]'));
+        const postMainContentIndex = mainColChildren.findIndex((child) => $(child).is('[data-slot="postMainContent"]'));
+
+        expect(postMainContentIndex).toBeGreaterThan(-1);
+        expect(mainContentIndex).toBeLessThan(postMainContentIndex);
     });
 });


### PR DESCRIPTION
<!-- ignore-task-list-start -->

See [Link to Jira issue](https://officefornationalstatistics.atlassian.net/browse/CMS-1338)

- When working on the CMS PR I found another place where it would be beneficial to have a block to override - at the moment we have to include the backToTop link on every page, and it would be easier to use a block in the base template. So I have added a new block after the `mainContent` called `postMainContent`.
- Updated the 'template block areas' example and relevant VR tests
- Updated the base template snapshot
- Updated the migration instructions

### How to review

Check code changes and updated example template, and ensure CI checks pass.

<!-- ignore-task-list-end -->

### Checklist

- [x] I have linked the Issue
- [x] I have selected the Assignee
- [x] I have selected the most helpful Label
- [x] I have suggested an excellent Title for our release notes
