### PR TITLE
Address results disappear in AddressInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,5 @@ npm publish --access public
 -   [SonarLint](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode)
 -   [Sass](https://marketplace.visualstudio.com/items?itemName=Syler.sass-indented)
 -   [Stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
+
+<!-- Add and remove -->

--- a/README.md
+++ b/README.md
@@ -231,5 +231,3 @@ npm publish --access public
 -   [SonarLint](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode)
 -   [Sass](https://marketplace.visualstudio.com/items?itemName=Syler.sass-indented)
 -   [Stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
-
-<!-- Add and remove -->

--- a/src/components/address-input/autosuggest.address.spec.js
+++ b/src/components/address-input/autosuggest.address.spec.js
@@ -411,6 +411,29 @@ describe('script: address-input', () => {
                     });
                 });
             });
+
+            describe('when a grouped suggestion is selected with the mouse', () => {
+                beforeEach(async () => {
+                    const options = await page.$$('.ons-autosuggest__option');
+                    await options[0].click();
+                    await setTimeout(400);
+                });
+
+                it('makes expected bucket request', async () => {
+                    expect(
+                        await apiFaker.getRequestCount(
+                            '/addresses/eq/bucket?postcode=CF14%202AA&streetname=Penlline%20Road&townname=Whitchurch&groupfullpostcodes=combo',
+                        ),
+                    ).toBe(1);
+                });
+
+                it('keeps nested suggestion entries after blur timeout', async () => {
+                    const suggestions = await page.$$eval('.ons-autosuggest__option', (nodes) =>
+                        nodes.map((node) => node.textContent.trim()),
+                    );
+                    expect(suggestions).toEqual(['197 College Road, Whitchurch, Cardiff, CF14 2AB']);
+                });
+            });
         });
 
         describe('when there is an error retrieving the address', () => {

--- a/src/components/autosuggest/autosuggest.ui.js
+++ b/src/components/autosuggest/autosuggest.ui.js
@@ -201,6 +201,9 @@ export default class AutosuggestUI {
     }
 
     handleFocus() {
+        clearTimeout(this.blurTimeout);
+        this.blurring = false;
+
         if (this.allowMultiple === 'true' && this.allSelections.length && this.input.value.slice(-1) !== ' ' && this.input.value !== '') {
             this.input.value = `${this.input.value}, `;
         }
@@ -513,6 +516,7 @@ export default class AutosuggestUI {
 
     selectResult(index) {
         if (this.results.length) {
+            clearTimeout(this.blurTimeout);
             this.settingResult = true;
             const result = this.results[index || this.highlightedResultIndex || 0];
             const resultItem = result.item ?? result;

--- a/src/components/autosuggest/autosuggest.ui.js
+++ b/src/components/autosuggest/autosuggest.ui.js
@@ -201,7 +201,6 @@ export default class AutosuggestUI {
     }
 
     handleFocus() {
-        clearTimeout(this.blurTimeout);
         this.blurring = false;
 
         if (this.allowMultiple === 'true' && this.allSelections.length && this.input.value.slice(-1) !== ' ' && this.input.value !== '') {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

See https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-981?atlOrigin=eyJpIjoiNWU1NDc3NDQ4ODA4NDA1YmIwNTI1NTRmZDlkOTM0MDQiLCJwIjoiaiJ9

Briefly describe what you have changed and why.

- Address input not clickable with mouse when user partially inputs a postcode, user could scroll to the addresses in a list, but on selection the address would clear and default to the search term not the individual address list.
- Replicated this on the **aims-diy** repo on the /typeahead page. 
- If you click on the Gate Reach address (29 addresses) you are presented with a list - when you click on gate reach with a mouse, the address list flashes for a moment but then clears (see video below).  However, you can still reach the address selection with keyboard directionals without any issues.

<img width="1277" height="767" alt="ex26ga-lookup" src="https://github.com/user-attachments/assets/1f271132-d3e7-4a4a-8205-a646678856bf" />

Result when clicking with mouse - defaults back to the parent search term:

<img width="581" height="347" alt="default-back-to-search" src="https://github.com/user-attachments/assets/5e8ae929-2ac0-43ee-96ea-0058cacd392a" />

**Fix:**
-  `autosuggest.ui.js` -  Cancel the blur timer in `selectResult` so a mouse click on a grouped postcode result keeps nested suggestions; reset `this.blurring = false` in `handleFocus` so that flag does not stay stuck after a cancelled blur.
- `autosuggest.address.spec.js` - Add mouse-click coverage for grouped suggestions (bucket request + nested options still present after 400ms / past the blur timeout), using the design-system’s faked address API.

### How to review

- Rebuild `main.js` and override `cdn.ons.gov.uk/sdc/design-system/73.1.1/scripts/main.js` while running the aims-diy UI (http://localhost:5001), since design-system does not hit a live postcode API.

**Video Evidence Before and After:**

**BEFORE:-** (address list flashes for a second and then dissappears)

https://github.com/user-attachments/assets/764388bb-d312-49d1-8a25-ec6a741b5ffb

**AFTER:-**

https://github.com/user-attachments/assets/89079262-5f9e-47f2-b3e8-f4561efccc33

<!-- ignore-task-list-end -->

### Checklist

- [X] I have linked the Issue
- [X] I have selected the Assignee
- [X] I have selected the most helpful Label
- [X] I have suggested an excellent Title for our release notes
