### PR TITLE
Header search label is not shown in Welsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,5 @@ npm publish --access public
 -   [SonarLint](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode)
 -   [Sass](https://marketplace.visualstudio.com/items?itemName=Syler.sass-indented)
 -   [Stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
+
+<!-- Add and remove -->

--- a/README.md
+++ b/README.md
@@ -231,5 +231,3 @@ npm publish --access public
 -   [SonarLint](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode)
 -   [Sass](https://marketplace.visualstudio.com/items?itemName=Syler.sass-indented)
 -   [Stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint)
-
-<!-- Add and remove -->

--- a/src/components/header/_macro.njk
+++ b/src/components/header/_macro.njk
@@ -368,7 +368,7 @@
                                 "name": params.search.form.inputName | default('q'),
                                 "width": 'full',
                                 "label": {
-                                    "text": (params.search.form.inputLabel if params.search.form else params.searchLinks.searchNavigationInputLabel) | default('Chwilio’r SYG' if params.lang == 'cy' else 'Search the ONS'),
+                                    "text": (params.search.form.inputLabel if params.search.form else params.searchLinks.searchNavigationInputLabel) | default('Chwilio’r SYG' if currentLanguageIsoCode == 'cy' else 'Search the ONS'),
                                     "id": "header-search-input-label"
                                 },
                                 "searchButton": {

--- a/src/components/header/_macro.spec.js
+++ b/src/components/header/_macro.spec.js
@@ -84,32 +84,6 @@ describe('FOR: Macro: Header', () => {
             expect(results).toHaveNoViolations();
             expect($('.ons-header-nav-search__heading').length).toBe(0);
         });
-
-        test('THEN: renders Welsh default search input label when current language is Cymraeg', () => {
-            const params = {
-                ...EXAMPLE_HEADER_BASIC,
-                variants: 'basic',
-                search: { form: { action: '/search' } },
-                language: {
-                    languages: [
-                        {
-                            url: '#0',
-                            isoCode: 'cy',
-                            text: 'Cymraeg',
-                            current: true,
-                        },
-                        {
-                            url: '#0',
-                            isoCode: 'en',
-                            text: 'English',
-                            current: false,
-                        },
-                    ],
-                },
-            };
-            const $ = cheerio.load(renderComponent('header', params));
-            expect($('#header-search-input-label').text().trim()).toBe('Chwilio’r SYG');
-        });
     });
 
     describe('Snapshot: search heading', () => {

--- a/src/components/header/_macro.spec.js
+++ b/src/components/header/_macro.spec.js
@@ -84,6 +84,32 @@ describe('FOR: Macro: Header', () => {
             expect(results).toHaveNoViolations();
             expect($('.ons-header-nav-search__heading').length).toBe(0);
         });
+
+        test('THEN: renders Welsh default search input label when current language is Cymraeg', () => {
+            const params = {
+                ...EXAMPLE_HEADER_BASIC,
+                variants: 'basic',
+                search: { form: { action: '/search' } },
+                language: {
+                    languages: [
+                        {
+                            url: '#0',
+                            isoCode: 'cy',
+                            text: 'Cymraeg',
+                            current: true,
+                        },
+                        {
+                            url: '#0',
+                            isoCode: 'en',
+                            text: 'English',
+                            current: false,
+                        },
+                    ],
+                },
+            };
+            const $ = cheerio.load(renderComponent('header', params));
+            expect($('#header-search-input-label').text().trim()).toBe('Chwilio’r SYG');
+        });
     });
 
     describe('Snapshot: search heading', () => {

--- a/src/components/header/_macro.spec.js
+++ b/src/components/header/_macro.spec.js
@@ -84,32 +84,6 @@ describe('FOR: Macro: Header', () => {
             expect(results).toHaveNoViolations();
             expect($('.ons-header-nav-search__heading').length).toBe(0);
         });
-
-        test('THEN: renders Welsh default search input label when current language is Cymraeg', () => {
-            const params = {
-                ...EXAMPLE_HEADER_BASIC,
-                variants: 'basic',
-                search: { form: { action: '/search' } },
-                language: {
-                    languages: [
-                        {
-                            url: '#0',
-                            isoCode: 'cy',
-                            text: 'Cymraeg',
-                            current: true,
-                        },
-                        {
-                            url: '#0',
-                            isoCode: 'en',
-                            text: 'English',
-                            current: false,
-                        },
-                    ],
-                },
-            };
-            const $ = cheerio.load(renderComponent('header', params));
-            expect($('#header-search-input-label').text().trim()).toBe('Chwilio’r SYG');
-        });
     });
 
     describe('Snapshot: search heading', () => {
@@ -1128,6 +1102,27 @@ describe('FOR: Macro: Header', () => {
             );
             test('THEN: renders search input with default label', () => {
                 expect($('#header-search-input-label').text().trim()).toBe('Search the ONS');
+            });
+        });
+        describe('WHEN: inputLabel is not provided and Welsh is the current language', () => {
+            const $ = cheerio.load(
+                renderComponent('header', {
+                    ...EXAMPLE_HEADER_SEARCH,
+                    variants: 'basic',
+                    language: {
+                        languages: [
+                            { url: '#0', isoCode: 'en', text: 'English', current: false },
+                            { url: '#0', isoCode: 'cy', text: 'Cymraeg', current: true },
+                        ],
+                    },
+                    search: {
+                        ...EXAMPLE_HEADER_SEARCH.search,
+                        form: { ...EXAMPLE_HEADER_SEARCH.search.form, inputLabel: undefined },
+                    },
+                }),
+            );
+            test('THEN: renders search input with Welsh default label', () => {
+                expect($('#header-search-input-label').text().trim()).toBe('Chwilio’r SYG');
             });
         });
         describe('WHEN: buttonText is provided', () => {


### PR DESCRIPTION
<!-- ignore-task-list-start -->

See [[ONSDESYS-938]](https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-938)

<img width="1059" height="429" alt="Screenshot 2026-08-13 at 13 53 07" src="https://github.com/user-attachments/assets/ddf85b74-7bd3-4975-a098-78fbf74d4469" />

Briefly describe what you have changed and why.

### How to review

Describe the steps to review and test these changes.

- Updated `src/components/header/_macro.njk` so the default search input label uses `currentLanguageIsoCode == 'cy'` instead of `params.lang == 'cy'`.
- Added regression test:  WHEN: inputLabel is not provided and Welsh is the current language → asserts #header-search-input-label is Chwilio’r SYG.


- The Welsh default was wired to `params.lang`, but the header does not receive `params.lang` from the page template.
- Language is passed via `params.language.languages`, and the header already derives `currentLanguageIsoCode` from the entry with current: true (also used for logos / browser banner).
- Using that same source means Welsh pages without an explicit `inputLabel` correctly fall back to Chwilio’r SYG; English still falls back to Search the ONS.
- Explicit overrides (`params.search.form.inputLabel / searchLinks.searchNavigationInputLabel`) are unchanged and still take precedence.
- The new unit test locks in the failing scenario (Welsh current + no inputLabel) so the bug can’t return unnoticed.

**For testing purposes** - In the absence of a live in browser toggle switch, I've removed the explicit `search.form.inputLabel` (which overrides languages) and manually changed current language to `true` or `false` for `en` or `cy` use cases, showing that the languages switch to the correct translation.

https://github.com/user-attachments/assets/16a6b77d-2912-4583-b5b4-fb2d5c04ca18

<!-- ignore-task-list-end -->

### Checklist

- [X] I have linked the Issue
- [X] I have selected the Assignee
- [X] I have selected the most helpful Label
- [X] I have suggested an excellent Title for our release notes


[ONSDESYS-938]: https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ