### PR TITLE
Content inside Button should wrap

### DIFF
--- a/backstop_data/bitmaps_reference/ds-vr-test__patterns_question_example-question-anatomy_0_document_2_mobile.png
+++ b/backstop_data/bitmaps_reference/ds-vr-test__patterns_question_example-question-anatomy_0_document_2_mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c480a5bed225c9aff9dcbe713f02c56f08f5cd31eb2d3b02913b0a0593b6a4cb
-size 199099
+oid sha256:37f81a9cd89b6762364c31a64852ec7e5557db14b67f319c534c8974122be7a6
+size 198468

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -89,6 +89,10 @@ $button-shadow-size: 3px;
             height: 18px;
             width: 18px;
             flex: 0 0 auto; // prevent the icon from shrinking when text wraps
+
+            ~ .ons-btn__text {
+                text-align: left;
+            }
         }
     }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -89,10 +89,6 @@ $button-shadow-size: 3px;
             height: 18px;
             width: 18px;
             flex: 0 0 auto; // prevent the icon from shrinking when text wraps
-
-            ~ .ons-btn__text {
-                text-align: left;
-            }
         }
     }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -827,6 +827,12 @@ $button-shadow-size: 3px;
             }
         }
     }
+
+    &[type='submit'] {
+        .ons-pl-question-anatomy__component & {
+            white-space: nowrap; // targeting buttons of type submit within the question anatomy component to prevent wrapping of the button text
+        }
+    }
 }
 
 .ons-search__btn {

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -84,7 +84,6 @@ $button-shadow-size: 3px;
         // Required for Google Tag Manager
         pointer-events: none;
         position: relative;
-        text-align: left;
         .ons-icon {
             fill: var(--ons-color-text-inverse);
             height: 18px;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -827,12 +827,6 @@ $button-shadow-size: 3px;
             }
         }
     }
-
-    &[type='submit'] {
-        .ons-pl-question-anatomy__component & {
-            white-space: nowrap; // targeting buttons of type submit within the question anatomy component to prevent wrapping of the button text
-        }
-    }
 }
 
 .ons-search__btn {

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -16,7 +16,7 @@ $button-shadow-size: 3px;
     text-decoration: none;
     text-rendering: optimizelegibility;
     vertical-align: top;
-    white-space: nowrap;
+    white-space: normal;
 
     &--search {
         .ons-icon {
@@ -84,10 +84,12 @@ $button-shadow-size: 3px;
         // Required for Google Tag Manager
         pointer-events: none;
         position: relative;
+        text-align: left;
         .ons-icon {
             fill: var(--ons-color-text-inverse);
             height: 18px;
             width: 18px;
+            flex: 0 0 auto; // prevent the icon from shrinking when text wraps
         }
     }
 

--- a/src/patterns/question/example-question-anatomy.njk
+++ b/src/patterns/question/example-question-anatomy.njk
@@ -11,6 +11,7 @@ noTabs: true
     .ons-pl-question-anatomy {
         border-collapse: collapse;
         border-spacing: 0;
+        margin: -1.5rem;
         max-width: 57.445rem;
     }
 
@@ -19,7 +20,7 @@ noTabs: true
     }
 
     .ons-pl-question-anatomy .ons-pl-question-anatomy__component {
-        padding: 1rem 1.5rem 0 0;
+        padding: 1rem 1.5rem;
         vertical-align: top;
     }
 

--- a/src/patterns/question/example-question-anatomy.njk
+++ b/src/patterns/question/example-question-anatomy.njk
@@ -11,7 +11,6 @@ noTabs: true
     .ons-pl-question-anatomy {
         border-collapse: collapse;
         border-spacing: 0;
-        margin: -1.5rem;
         max-width: 57.445rem;
     }
 
@@ -20,7 +19,7 @@ noTabs: true
     }
 
     .ons-pl-question-anatomy .ons-pl-question-anatomy__component {
-        padding: 1rem 1.5rem;
+        padding: 1rem 1.5rem 0 0;
         vertical-align: top;
     }
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->

See [[Link to Jira issue](https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-964)]

Briefly describe what you have changed and why.

- It was observed that buttons with long text labels were overflowing their containers and were not wrapping - this was apparent in side columns in the Wagtail CMS and also in the design system itself.

- <img width="664" height="207" alt="image-20260617-144817" src="https://github.com/user-attachments/assets/70f33541-4ec1-4465-b781-a04dcd17e64c" />

- <img width="755" height="171" alt="Screenshot 2026-09-03 at 09 27 38" src="https://github.com/user-attachments/assets/6b5b5cf9-1fac-4a7f-a1f6-eb82b502274f" />

**GDS Design system:**

- Investigated the upstream Frontend Button component [Button](https://design-system.service.gov.uk/components/button/)  to understand whether `white-space: nowrap` is an established GDS convention.  The current Button component does not apply `white-space: nowrap` to `.govuk-button`, allowing button text to wrap naturally where required.

- This is also true of the Start button [Start now button – Button](https://design-system.service.gov.uk/components/button/start/), which includes an SVG icon alongside button text. Rather than preventing the button content from wrapping, the component uses `flexbox` and applies `lex-shrink: 0` specifically to the icon. This allows the icon to retain its intended size and positioning without forcing the entire button label onto a single line.

**ONS Design System:**

- Git history shows that white-space: nowrap was explicitly introduced to the ONS Button component in `commit 369008d` (4 June 2024), as part of PR #3190, “Update .editorconfig and improve and run our linting and formatting process”.  [Update `.editorconfig` and improve and run our linting and formatting process by rmccar · Pull Request #3190 · ONSdigital/design-system](https://github.com/ONSdigital/design-system/pull/3190) 

- While the declaration was deliberately added in that commit, we have been unable to identify any accompanying rationale or discussion establishing non-wrapping button labels as a design requirement. The PR was primarily concerned with linting, formatting and code standardisation, with no documented discussion around button text wrapping, icons, responsive behaviour or accessibility.

- Agreed with team that this is likely a bug introduced by a dev and therefore we can fix without signoff from UCD

**Backstop Visual regression Fix** 
- There was only 1 Visual Regression edge case during testing - the “Save and Continue” button wraps on small devices (which is what we now want it to do), but only when used inside a `ons-pl-question-anatomy__row` Question Anatomy component.
- the wrapping of the button changed the expected pixel formation of the Question anatomy component as due to the button being allowed to wrap, it meant the entire component was no longer being forced to cause an horizontal overflow on the page. 
- See **"files changed"** tab to view the updated backstop image - the corrected behaviour  also means that  the question anatomy content now sits within the viewport, evident by the white margin on the right hand side of the screen.

<img width="45%" height="auto" alt="ds-vr-test__patterns_question_example-question-anatomy_0_document_2_mobile" src="https://github.com/user-attachments/assets/c06f2cc4-2844-4fed-aaf4-3765c6aebfa5" />

<img width="45%" height="auto" alt="failed_diff_ds-vr-test__patterns_question_example-question-anatomy_0_document_2_mobile" src="https://github.com/user-attachments/assets/e04a9d48-ad48-4687-aa90-824f28a5ca80" />

**After images:**

<img width="902" height="337" alt="Screenshot 2026-09-03 151213" src="https://github.com/user-attachments/assets/6028138e-b6b1-4a76-b9d8-d1a469ae04f5" />

### How to review

Describe the steps to review and test these changes.

<!-- ignore-task-list-end -->

### Checklist

- [X] I have linked the Issue
- [X] I have selected the Assignee
- [X] I have selected the most helpful Label
- [X] I have suggested an excellent Title for our release notes
