### PR TITLE
Upgrade NPM publish script to use OIDC

### DIFF
--- a/.github/workflows/npm-bundle.yml
+++ b/.github/workflows/npm-bundle.yml
@@ -4,6 +4,7 @@ on:
         types: [published]
 
 permissions:
+    id-token: write
     contents: read
 
 env:
@@ -36,5 +37,3 @@ jobs:
             - run: npm version "$RELEASE_VERSION" --no-git-tag-version
             - run: yarn npm-bundle
             - run: npm publish --access public --tag "$NPM_DIST_TAG"
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-bundle.yml
+++ b/.github/workflows/npm-bundle.yml
@@ -32,7 +32,6 @@ jobs:
               uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
               with:
                   node-version-file: '.nvmrc'
-                  registry-url: https://registry.npmjs.org/
             - run: yarn install
             - run: npm version "$RELEASE_VERSION" --no-git-tag-version
             - run: yarn npm-bundle

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "author": {
         "name": "ONS Digital"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ONSdigital/design-system"
+    },
     "scripts": {
         "start": "gulp start",
         "watch": "gulp watch",


### PR DESCRIPTION
<!-- ignore-task-list-start -->

See https://officefornationalstatistics.atlassian.net/browse/ONSDESYS-1004

Upgrades the Github Action script that publishes releases to NPM to use the newer OIDC "trusted publisher" authentication.
  
### How to review

I have made a test prerelease from this branch. It now works.

<!-- ignore-task-list-end -->

### Checklist

- [x] I have linked the Issue
- [x] I have selected the Assignee
- [x] I have selected the most helpful Label
- [x] I have suggested an excellent Title for our release notes
